### PR TITLE
Make the LLM max-token request field configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ llm:
   # Max tokens in LLM response. 1024 is plenty for voice input correction.
   max_output_tokens: 1024
 
+  # Token limit field sent to the OpenAI-compatible API.
+  # Use "max_completion_tokens" for GPT-5/reasoning-compatible endpoints.
+  max_token_parameter: "max_tokens"
+
   # How many dictionary entries to include in the LLM prompt.
   # 0 = send all entries (recommended for dictionaries under ~500 entries).
   # Set a limit if your dictionary is very large and you want to reduce prompt size.

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -59,12 +59,21 @@ pub struct LlmSection {
     pub timeout_ms: u64,
     #[serde(default = "default_max_output_tokens")]
     pub max_output_tokens: u32,
+    #[serde(default = "default_llm_max_token_parameter")]
+    pub max_token_parameter: LlmMaxTokenParameter,
     #[serde(default = "default_dictionary_max_candidates")]
     pub dictionary_max_candidates: usize,
     #[serde(default = "default_system_prompt_path")]
     pub system_prompt_path: String,
     #[serde(default = "default_user_prompt_path")]
     pub user_prompt_path: String,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmMaxTokenParameter {
+    MaxTokens,
+    MaxCompletionTokens,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -165,6 +174,9 @@ fn default_max_output_tokens() -> u32 {
 }
 fn default_dictionary_max_candidates() -> usize {
     0
+}
+fn default_llm_max_token_parameter() -> LlmMaxTokenParameter {
+    LlmMaxTokenParameter::MaxTokens
 }
 fn default_dictionary_path() -> String {
     "dictionary.txt".into()
@@ -357,7 +369,8 @@ llm:
   top_p: 1
   timeout_ms: 8000
   max_output_tokens: 1024
-  dictionary_max_candidates: 0    # 0 = send all entries to LLM
+  max_token_parameter: "max_tokens"        # use "max_completion_tokens" for GPT-5/reasoning-compatible endpoints
+  dictionary_max_candidates: 0             # 0 = send all entries to LLM
   system_prompt_path: "system_prompt.txt"  # relative to ~/.koe/
   user_prompt_path: "user_prompt.txt"      # relative to ~/.koe/
 

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -492,6 +492,7 @@ async fn run_session(
             llm_config.temperature,
             llm_config.top_p,
             llm_config.max_output_tokens,
+            llm_config.max_token_parameter,
             llm_config.timeout_ms,
         );
 

--- a/koe-core/src/llm/openai_compatible.rs
+++ b/koe-core/src/llm/openai_compatible.rs
@@ -1,3 +1,4 @@
+use crate::config::LlmMaxTokenParameter;
 use crate::errors::{KoeError, Result};
 use crate::llm::{CorrectionRequest, LlmProvider};
 use reqwest::Client;
@@ -13,6 +14,7 @@ pub struct OpenAiCompatibleProvider {
     temperature: f64,
     top_p: f64,
     max_output_tokens: u32,
+    max_token_parameter: LlmMaxTokenParameter,
 }
 
 impl OpenAiCompatibleProvider {
@@ -23,6 +25,7 @@ impl OpenAiCompatibleProvider {
         temperature: f64,
         top_p: f64,
         max_output_tokens: u32,
+        max_token_parameter: LlmMaxTokenParameter,
         timeout_ms: u64,
     ) -> Self {
         let client = Client::builder()
@@ -38,6 +41,7 @@ impl OpenAiCompatibleProvider {
             temperature,
             top_p,
             max_output_tokens,
+            max_token_parameter,
         }
     }
 }
@@ -49,11 +53,10 @@ impl LlmProvider for OpenAiCompatibleProvider {
             self.base_url.trim_end_matches('/')
         );
 
-        let body = json!({
+        let mut body = json!({
             "model": self.model,
             "temperature": self.temperature,
             "top_p": self.top_p,
-            "max_tokens": self.max_output_tokens,
             "messages": [
                 {
                     "role": "system",
@@ -65,6 +68,11 @@ impl LlmProvider for OpenAiCompatibleProvider {
                 }
             ]
         });
+        let token_field_name = match self.max_token_parameter {
+            LlmMaxTokenParameter::MaxTokens => "max_tokens",
+            LlmMaxTokenParameter::MaxCompletionTokens => "max_completion_tokens",
+        };
+        body[token_field_name] = json!(self.max_output_tokens);
 
         log::debug!("LLM request to {url}");
 


### PR DESCRIPTION
## Summary
This change makes the max-token request field configurable for the OpenAI-compatible LLM integration.

## Motivation
The known failure that prompted this change was observed with Azure AI Foundry, where requests fail when the max-token field does not match the target model's API expectations.

Azure's guidance for this issue indicates that some deployments require `max_completion_tokens` instead of `max_tokens`:
https://learn.microsoft.com/en-us/answers/questions/2139738/openai-badrequesterror-error-code-400-((error-((me

Making this field configurable keeps Koe compatible with endpoints that require a different parameter name, while preserving the current default behavior.

## Changes
- add a `max_token_parameter` config option under `llm`
- support `max_tokens` and `max_completion_tokens` when building chat completion requests
- keep the default value as `max_tokens` for backward compatibility with existing setups
- document the new option in the sample config and README

## Testing
- cargo check
