### PR TITLE
feat: add left and right Control key support for hotkeys

### DIFF
--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -250,6 +250,8 @@ static NSString *normalizedHotkeyValue(NSString *value) {
             @"right_option",
             @"left_command",
             @"right_command",
+            @"left_control",
+            @"right_control",
         ]];
     });
     return [validValues containsObject:value] ? value : @"fn";
@@ -261,6 +263,8 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     if ([normalizedTrigger isEqualToString:@"left_option"]) return @"right_option";
     if ([normalizedTrigger isEqualToString:@"right_option"]) return @"left_command";
     if ([normalizedTrigger isEqualToString:@"left_command"]) return @"right_command";
+    if ([normalizedTrigger isEqualToString:@"right_command"]) return @"left_control";
+    if ([normalizedTrigger isEqualToString:@"left_control"]) return @"right_control";
     return @"fn";
 }
 
@@ -615,12 +619,16 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
         @"Right Option (\u2325)",
         @"Left Command (\u2318)",
         @"Right Command (\u2318)",
+        @"Left Control (\u2303)",
+        @"Right Control (\u2303)",
     ]];
     [self.hotkeyPopup itemAtIndex:0].representedObject = @"fn";
     [self.hotkeyPopup itemAtIndex:1].representedObject = @"left_option";
     [self.hotkeyPopup itemAtIndex:2].representedObject = @"right_option";
     [self.hotkeyPopup itemAtIndex:3].representedObject = @"left_command";
     [self.hotkeyPopup itemAtIndex:4].representedObject = @"right_command";
+    [self.hotkeyPopup itemAtIndex:5].representedObject = @"left_control";
+    [self.hotkeyPopup itemAtIndex:6].representedObject = @"right_control";
     [pane addSubview:self.hotkeyPopup];
     y -= rowH + 16;
 
@@ -634,12 +642,16 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
         @"Right Option (\u2325)",
         @"Left Command (\u2318)",
         @"Right Command (\u2318)",
+        @"Left Control (\u2303)",
+        @"Right Control (\u2303)",
     ]];
     [self.cancelHotkeyPopup itemAtIndex:0].representedObject = @"fn";
     [self.cancelHotkeyPopup itemAtIndex:1].representedObject = @"left_option";
     [self.cancelHotkeyPopup itemAtIndex:2].representedObject = @"right_option";
     [self.cancelHotkeyPopup itemAtIndex:3].representedObject = @"left_command";
     [self.cancelHotkeyPopup itemAtIndex:4].representedObject = @"right_command";
+    [self.cancelHotkeyPopup itemAtIndex:5].representedObject = @"left_control";
+    [self.cancelHotkeyPopup itemAtIndex:6].representedObject = @"right_control";
     [pane addSubview:self.cancelHotkeyPopup];
     y -= rowH + 8;
 

--- a/KoeApp/Koe/StatusBar/SPStatusBarManager.m
+++ b/KoeApp/Koe/StatusBar/SPStatusBarManager.m
@@ -43,6 +43,12 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     if ([value isEqualToString:@"right_command"]) {
         return @"Right Command (⌘)";
     }
+    if ([value isEqualToString:@"left_control"]) {
+        return @"Left Control (⌃)";
+    }
+    if ([value isEqualToString:@"right_control"]) {
+        return @"Right Control (⌃)";
+    }
     return @"Fn (Globe)";
 }
 

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -110,13 +110,13 @@ pub struct DictionarySection {
 #[derive(Debug, Deserialize, Clone)]
 pub struct HotkeySection {
     /// Trigger key for voice input.
-    /// Options: "fn", "left_option", "right_option", "left_command", "right_command"
+    /// Options: "fn", "left_option", "right_option", "left_command", "right_command", "left_control", "right_control"
     /// Default: "fn"
     #[serde(default = "default_trigger_key")]
     pub trigger_key: String,
 
     /// Cancel key for aborting the current voice input session.
-    /// Options: "fn", "left_option", "right_option", "left_command", "right_command"
+    /// Options: "fn", "left_option", "right_option", "left_command", "right_command", "left_control", "right_control"
     /// Default: "left_option"
     #[serde(default = "default_cancel_key")]
     pub cancel_key: String,
@@ -173,14 +173,14 @@ impl HotkeySection {
 
     fn normalize_trigger_key_name(value: &str) -> String {
         match value {
-            "left_option" | "right_option" | "left_command" | "right_command" | "fn" => value.into(),
+            "left_option" | "right_option" | "left_command" | "right_command" | "left_control" | "right_control" | "fn" => value.into(),
             _ => default_trigger_key(),
         }
     }
 
     fn normalize_cancel_key_name(value: &str) -> String {
         match value {
-            "left_option" | "right_option" | "left_command" | "right_command" | "fn" => value.into(),
+            "left_option" | "right_option" | "left_command" | "right_command" | "left_control" | "right_control" | "fn" => value.into(),
             _ => default_cancel_key(),
         }
     }
@@ -206,6 +206,16 @@ impl HotkeySection {
                 key_code: 54,       // kVK_RightCommand
                 alt_key_code: 0,
                 modifier_flag: 0x00000010,  // NX_DEVICERCMDKEYMASK
+            },
+            "left_control" => HotkeyParams {
+                key_code: 59,       // kVK_Control
+                alt_key_code: 0,
+                modifier_flag: 0x00000001,  // NX_DEVICELCTLKEYMASK
+            },
+            "right_control" => HotkeyParams {
+                key_code: 62,       // kVK_RightControl
+                alt_key_code: 0,
+                modifier_flag: 0x00002000,  // NX_DEVICERCTLKEYMASK
             },
             // "fn" or anything else defaults to Fn/Globe
             _ => HotkeyParams {
@@ -272,7 +282,9 @@ fn default_cancel_key_for_trigger(trigger_key: &str) -> &'static str {
         "left_option" => "right_option",
         "right_option" => "left_command",
         "left_command" => "right_command",
-        "right_command" => "fn",
+        "right_command" => "left_control",
+        "left_control" => "right_control",
+        "right_control" => "fn",
         _ => "left_option",
     }
 }
@@ -654,9 +666,9 @@ dictionary:
   path: "dictionary.txt"  # relative to ~/.koe/
 
 hotkey:
-  # 触发键：fn | left_option | right_option | left_command | right_command
+  # 触发键：fn | left_option | right_option | left_command | right_command | left_control | right_control
   trigger_key: "fn"
-  # 取消键：不能与触发键重复
+  # 取消键：fn | left_option | right_option | left_command | right_command | left_control | right_control（不能与触发键重复）
   cancel_key: "left_option"
 "#;
 
@@ -709,5 +721,21 @@ mod tests {
         assert!(output.contains("cancel_key: right_option"));
 
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn default_cancel_key_cycles_through_all_keys() {
+        assert_eq!(default_cancel_key_for_trigger("fn"), "left_option");
+        assert_eq!(default_cancel_key_for_trigger("left_option"), "right_option");
+        assert_eq!(default_cancel_key_for_trigger("right_option"), "left_command");
+        assert_eq!(default_cancel_key_for_trigger("left_command"), "right_command");
+        assert_eq!(default_cancel_key_for_trigger("right_command"), "left_control");
+        assert_eq!(default_cancel_key_for_trigger("left_control"), "right_control");
+        assert_eq!(default_cancel_key_for_trigger("right_control"), "fn");
+    }
+
+    #[test]
+    fn default_cancel_key_falls_back_for_unknown() {
+        assert_eq!(default_cancel_key_for_trigger("unknown"), "left_option");
     }
 }


### PR DESCRIPTION
## Summary
Add left and right Control key options for trigger/cancel hotkeys.

## Changes
- UI: Add \"Left Control (⌃)\" and \"Right Control (⌃)\" to hotkey dropdowns
- Config: Add keyCode mappings (left_control=59, right_control=62)
- Validation: Update normalizedHotkeyValue() and default_cancel_key_for_trigger()
- Status bar: Update displayNameForHotkeyValue() for menu display

## Tested
- [x] Left Control works as trigger key
- [x] Right Control works as cancel key
- [x] Config saves correctly
- [x] Menu bar displays correctly