### PR TITLE
perf(llm): reuse HTTP client and enable HTTP/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ llm:
   top_p: 1
 
   # LLM request timeout in milliseconds.
+  # Restart Koe after changing this value.
   timeout_ms: 8000
 
   # Max tokens in LLM response. 1024 is plenty for voice input correction.

--- a/koe-core/Cargo.toml
+++ b/koe-core/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 [dependencies]
 koe-asr = { path = "../koe-asr" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -650,7 +650,7 @@ llm:
   model: "gpt-5.4-nano"
   temperature: 0
   top_p: 1
-  timeout_ms: 8000
+  timeout_ms: 8000        # requires app restart to fully apply
   max_output_tokens: 1024
   max_token_parameter: "max_completion_tokens"  # use "max_tokens" for older model endpoints
   dictionary_max_candidates: 0             # 0 = send all entries to LLM

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -14,10 +14,11 @@ use crate::ffi::{
     invoke_session_ready, invoke_session_warning, invoke_state_changed, SPCallbacks,
     SPFeedbackConfig, SPHotkeyConfig, SPSessionContext, SPSessionMode,
 };
-use crate::llm::openai_compatible::OpenAiCompatibleProvider;
+use crate::llm::openai_compatible::{build_http_client, OpenAiCompatibleProvider};
 use crate::llm::{CorrectionRequest, LlmProvider};
 use crate::session::{Session, SessionState};
 use koe_asr::{AsrConfig, AsrEvent, AsrProvider, DoubaoWsProvider, TranscriptAggregator};
+use reqwest::Client;
 
 use std::ffi::c_char;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -36,6 +37,7 @@ struct Core {
     dictionary: Vec<String>,
     system_prompt: String,
     user_prompt_template: String,
+    llm_http_client: Client,
 }
 
 static CORE: Mutex<Option<Core>> = Mutex::new(None);
@@ -88,6 +90,13 @@ pub extern "C" fn sp_core_create(config_path: *const c_char) -> i32 {
             return -1;
         }
     };
+    let llm_http_client = match build_http_client(cfg.llm.timeout_ms) {
+        Ok(client) => client,
+        Err(e) => {
+            log::error!("failed to create LLM HTTP client: {e}");
+            return -1;
+        }
+    };
 
     let core = Core {
         runtime,
@@ -98,6 +107,7 @@ pub extern "C" fn sp_core_create(config_path: *const c_char) -> i32 {
         dictionary,
         system_prompt,
         user_prompt_template,
+        llm_http_client,
     };
 
     let mut global = CORE.lock().unwrap();
@@ -149,11 +159,19 @@ pub extern "C" fn sp_core_reload_config() -> i32 {
 
     let mut global = CORE.lock().unwrap();
     if let Some(ref mut core) = *global {
+        let llm_http_client = match build_http_client(cfg.llm.timeout_ms) {
+            Ok(client) => client,
+            Err(e) => {
+                log::error!("reload HTTP client failed: {e}");
+                return -1;
+            }
+        };
         core.config = cfg;
         core.dictionary = dictionary;
         core.system_prompt = system_prompt;
         core.user_prompt_template = user_prompt_template;
-        log::info!("config, dictionary, and prompts reloaded");
+        core.llm_http_client = llm_http_client;
+        log::info!("config, dictionary, prompts, and HTTP client reloaded");
     }
 
     0
@@ -229,6 +247,7 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
         hotwords: core.dictionary.clone(),
     };
     let llm_config = cfg.llm.clone();
+    let llm_http_client = core.llm_http_client.clone();
     let dictionary = core.dictionary.clone();
     let dictionary_max_candidates = cfg.llm.dictionary_max_candidates;
     let system_prompt = core.system_prompt.clone();
@@ -243,6 +262,7 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
             audio_rx,
             asr_config,
             llm_config,
+            llm_http_client,
             dictionary,
             dictionary_max_candidates,
             system_prompt,
@@ -362,6 +382,7 @@ async fn run_session(
     mut audio_rx: mpsc::Receiver<Vec<u8>>,
     asr_config: AsrConfig,
     llm_config: config::LlmSection,
+    llm_http_client: Client,
     dictionary: Vec<String>,
     dictionary_max_candidates: usize,
     system_prompt: String,
@@ -525,6 +546,7 @@ async fn run_session(
         invoke_state_changed("correcting");
 
         let llm = OpenAiCompatibleProvider::new(
+            llm_http_client,
             llm_config.base_url,
             llm_config.api_key,
             llm_config.model,
@@ -532,7 +554,6 @@ async fn run_session(
             llm_config.top_p,
             llm_config.max_output_tokens,
             llm_config.max_token_parameter,
-            llm_config.timeout_ms,
         );
 
         // Filter dictionary candidates for prompt

--- a/koe-core/src/llm/openai_compatible.rs
+++ b/koe-core/src/llm/openai_compatible.rs
@@ -19,6 +19,7 @@ pub struct OpenAiCompatibleProvider {
 
 impl OpenAiCompatibleProvider {
     pub fn new(
+        client: Client,
         base_url: String,
         api_key: String,
         model: String,
@@ -26,13 +27,7 @@ impl OpenAiCompatibleProvider {
         top_p: f64,
         max_output_tokens: u32,
         max_token_parameter: LlmMaxTokenParameter,
-        timeout_ms: u64,
     ) -> Self {
-        let client = Client::builder()
-            .timeout(Duration::from_millis(timeout_ms))
-            .build()
-            .expect("failed to create HTTP client");
-
         Self {
             client,
             base_url,
@@ -44,6 +39,18 @@ impl OpenAiCompatibleProvider {
             max_token_parameter,
         }
     }
+}
+
+pub fn build_http_client(timeout_ms: u64) -> std::result::Result<Client, reqwest::Error> {
+    Client::builder()
+        .timeout(Duration::from_millis(timeout_ms))
+        .pool_idle_timeout(Duration::from_secs(90))
+        .pool_max_idle_per_host(2)
+        .tcp_keepalive(Some(Duration::from_secs(30)))
+        .http2_keep_alive_interval(Duration::from_secs(30))
+        .http2_keep_alive_timeout(Duration::from_secs(30))
+        .http2_keep_alive_while_idle(true)
+        .build()
 }
 
 impl LlmProvider for OpenAiCompatibleProvider {


### PR DESCRIPTION
## Summary

This PR improves LLM correction latency by reusing a shared `reqwest::Client` across sessions and enabling HTTP/2 support in `koe-core`.

The main issue in the current implementation is that the OpenAI-compatible provider builds a new HTTP client for every voice session. That prevents connection pooling from being effective and adds unnecessary transport setup cost on a latency-sensitive path.

This change keeps the existing config hot-read behavior for request-level settings, but moves the HTTP client lifecycle to the core level:

- create one shared LLM HTTP client in `sp_core_create()`
- reuse it across sessions
- rebuild it on explicit config reload
- prefer HTTP/2 when the upstream supports it, while still allowing automatic fallback to HTTP/1.1

This is a `koe-core` change, but it was implemented and validated on top of the current `windows-support` branch.

## What Changed

- enabled the `http2` feature for `reqwest`
- moved HTTP client construction out of `OpenAiCompatibleProvider::new()`
- added a shared LLM HTTP client to the global `Core` state
- cloned the shared client into each session instead of rebuilding it
- rebuilt the client during `sp_core_reload_config()`
- documented that changing `llm.timeout_ms` requires restarting Koe to fully apply
- tuned the transport settings for the voice-input use case:
  - `pool_max_idle_per_host(2)`
  - `tcp_keepalive(30s)`
  - `http2_keep_alive_interval(30s)`
  - `http2_keep_alive_timeout(30s)`
  - `http2_keep_alive_while_idle(true)`

## Why This Approach

`reqwest::Client` is designed to be reused and already contains an internal connection pool. Reusing the same client lets Koe keep transport state warm across voice sessions instead of paying the setup cost every time.

I intentionally did not add per-field config diffing logic for client rebuilds. The simpler policy here is:

- request-level settings like `base_url`, `api_key`, `model`, `temperature`, `top_p`, and token settings still apply on the next session
- transport-level client settings are refreshed on explicit reload / restart

That keeps the implementation small and predictable.

## Benchmark Notes

I ran a real-endpoint benchmark against the current Azure Foundry OpenAI-compatible endpoint used by this setup.

Most relevant comparison:

- current-like path: `HTTP/1.1 + fresh client per request`
- optimized path: `HTTP/2 + reused client`

30-request result:

- current-like path
  - average: `1.390s`
  - P50: `1.319s`
  - P90: `1.780s`
  - P95: `1.789s`

- optimized path
  - average: `1.113s`
  - P50: `1.079s`
  - P90: `1.470s`
  - P95: `1.584s`

Observed improvement:

- average latency reduced by `0.277s`
- about `19.9%` faster overall in this benchmark
- tail latency also improved

I also verified that the endpoint negotiates `HTTP/2` when the client has HTTP/2 enabled. This is not a forced-HTTP/2 change: if an upstream only supports HTTP/1.1, the client can still fall back automatically.

## Validation

Verified locally with:

```powershell
cargo test -p koe-core
cargo build --manifest-path koe-core/Cargo.toml --release --target x86_64-pc-windows-msvc
cmake -B KoeWin/build-x64 -S KoeWin -G "Visual Studio 18 2026" -A x64
cmake --build KoeWin/build-x64 --config Release
```

Also validated end-to-end on both Windows and macOS after rebasing onto the latest upstream `main`.

## User-Facing Behavior

No workflow changes.

The only user-facing documentation change is that `llm.timeout_ms` now explicitly notes:

- restart Koe after changing this value

because the shared HTTP client is long-lived and timeout is applied when that client is built.
