### PR TITLE
feat(llm): add GPT-5 reasoning effort handling

### DIFF
--- a/koe-core/src/llm/openai_compatible.rs
+++ b/koe-core/src/llm/openai_compatible.rs
@@ -73,6 +73,9 @@ impl LlmProvider for OpenAiCompatibleProvider {
             LlmMaxTokenParameter::MaxCompletionTokens => "max_completion_tokens",
         };
         body[token_field_name] = json!(self.max_output_tokens);
+        if matches!(self.max_token_parameter, LlmMaxTokenParameter::MaxCompletionTokens) {
+            body["reasoning_effort"] = json!("none");
+        }
 
         log::debug!("LLM request to {url}");
 


### PR DESCRIPTION
## Summary

This PR adds basic `reasoning_effort` handling for OpenAI-compatible LLM requests used in Koe’s voice input correction flow.

Since this path is latency-sensitive, the GPT-5-style request path now explicitly uses the lowest reasoning setting.

## What Changed

- send `reasoning_effort: "none"` when using `max_completion_tokens`
- do not send `reasoning_effort` when using `max_tokens`

This keeps compatibility with older model-style endpoints while explicitly disabling reasoning on GPT-5-style endpoints.

## Validation

Tested with:

- `gpt-4o-mini`
- `gpt-5.4-nano`
