### PR TITLE
fix(core): reload LLM HTTP client when timeout changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,6 @@ llm:
   top_p: 1
 
   # LLM request timeout in milliseconds.
-  # Restart Koe after changing this value.
   timeout_ms: 8000
 
   # Max tokens in LLM response. 1024 is plenty for voice input correction.

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -650,7 +650,7 @@ llm:
   model: "gpt-5.4-nano"
   temperature: 0
   top_p: 1
-  timeout_ms: 8000        # requires app restart to fully apply
+  timeout_ms: 8000
   max_output_tokens: 1024
   max_token_parameter: "max_completion_tokens"  # use "max_tokens" for older model endpoints
   dictionary_max_candidates: 0             # 0 = send all entries to LLM

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -42,6 +42,10 @@ struct Core {
 
 static CORE: Mutex<Option<Core>> = Mutex::new(None);
 
+fn llm_http_client_needs_reload(current: &Config, next: &Config) -> bool {
+    current.llm.timeout_ms != next.llm.timeout_ms
+}
+
 // ─── FFI Entry Points ───────────────────────────────────────────────
 
 /// Initialize the core. Must be called once before any other function.
@@ -159,19 +163,22 @@ pub extern "C" fn sp_core_reload_config() -> i32 {
 
     let mut global = CORE.lock().unwrap();
     if let Some(ref mut core) = *global {
-        let llm_http_client = match build_http_client(cfg.llm.timeout_ms) {
-            Ok(client) => client,
-            Err(e) => {
-                log::error!("reload HTTP client failed: {e}");
-                return -1;
-            }
-        };
+        if llm_http_client_needs_reload(&core.config, &cfg) {
+            let llm_http_client = match build_http_client(cfg.llm.timeout_ms) {
+                Ok(client) => client,
+                Err(e) => {
+                    log::error!("reload HTTP client failed: {e}");
+                    return -1;
+                }
+            };
+            core.llm_http_client = llm_http_client;
+            log::info!("LLM HTTP client reloaded after timeout_ms change");
+        }
         core.config = cfg;
         core.dictionary = dictionary;
         core.system_prompt = system_prompt;
         core.user_prompt_template = user_prompt_template;
-        core.llm_http_client = llm_http_client;
-        log::info!("config, dictionary, prompts, and HTTP client reloaded");
+        log::info!("config, dictionary, prompts, and HTTP client reloaded as needed");
     }
 
     0
@@ -207,6 +214,17 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
         }
         core.system_prompt = prompt::load_system_prompt(&config::resolve_system_prompt_path(&new_cfg));
         core.user_prompt_template = prompt::load_user_prompt_template(&config::resolve_user_prompt_path(&new_cfg));
+        if llm_http_client_needs_reload(&core.config, &new_cfg) {
+            match build_http_client(new_cfg.llm.timeout_ms) {
+                Ok(client) => {
+                    core.llm_http_client = client;
+                    log::info!("LLM HTTP client reloaded at session start after timeout_ms change");
+                }
+                Err(e) => {
+                    log::warn!("failed to reload LLM HTTP client at session start: {e}");
+                }
+            }
+        }
         core.config = new_cfg;
     }
 


### PR DESCRIPTION
## Summary

This fixes a config reload inconsistency introduced by the shared LLM HTTP client.

Koe already reloads config automatically, but `llm.timeout_ms` only took effect after app restart because the cached `reqwest::Client` was not rebuilt on hot reload. This change makes the client rebuild only when `llm.timeout_ms` actually changes.

## Changes

- rebuild the shared LLM HTTP client in `sp_core_reload_config()` only when `llm.timeout_ms` changes
- apply the same timeout-change check in the session-start hot reload path
- remove outdated comments that said changing `timeout_ms` requires restart

## Verification

- `cargo test -p koe-core -- --nocapture`
- `make build`

## Notes

- this keeps the optimization from reusing a shared HTTP client
- other config changes continue to hot-reload without forcing unnecessary client rebuilds