### PR TITLE
perf(llm): warm up connection before correction

### DIFF
--- a/koe-core/Cargo.toml
+++ b/koe-core/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4"
 env_logger = "0.11"
 uuid = { version = "1", features = ["v4"] }
 tokio-util = { version = "0.7", features = ["rt"] }
+urlencoding = "2"
 
 [build-dependencies]
 cbindgen = "0.27"

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -15,7 +15,9 @@ use crate::ffi::{
     invoke_session_ready, invoke_session_warning, invoke_state_changed, SPCallbacks,
     SPFeedbackConfig, SPHotkeyConfig, SPSessionContext, SPSessionMode,
 };
-use crate::llm::openai_compatible::{build_http_client, OpenAiCompatibleProvider};
+use crate::llm::openai_compatible::{
+    build_http_client, OpenAiCompatibleProvider, LLM_HTTP_POOL_IDLE_TIMEOUT,
+};
 use crate::llm::{CorrectionRequest, LlmProvider};
 use crate::session::{Session, SessionState};
 use koe_asr::{AsrConfig, AsrEvent, AsrProvider, DoubaoWsProvider, QwenAsrProvider, TranscriptAggregator};
@@ -28,9 +30,22 @@ use reqwest::Client;
 use std::ffi::c_char;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 use tokio::time::{timeout, Duration};
+
+const LLM_WARMUP_SAFETY_MARGIN: Duration = Duration::from_secs(20);
+const LLM_WARMUP_TTL: Duration = match LLM_HTTP_POOL_IDLE_TIMEOUT.checked_sub(LLM_WARMUP_SAFETY_MARGIN) {
+    Some(duration) => duration,
+    None => Duration::from_secs(0),
+};
+
+#[derive(Default)]
+struct LlmWarmupState {
+    in_flight: bool,
+    last_touched: Option<Instant>,
+}
 
 /// Global core state
 struct Core {
@@ -43,6 +58,7 @@ struct Core {
     system_prompt: String,
     user_prompt_template: String,
     llm_http_client: Client,
+    llm_warmup_state: Arc<Mutex<LlmWarmupState>>,
 }
 
 static CORE: Mutex<Option<Core>> = Mutex::new(None);
@@ -117,6 +133,7 @@ pub extern "C" fn sp_core_create(config_path: *const c_char) -> i32 {
         system_prompt,
         user_prompt_template,
         llm_http_client,
+        llm_warmup_state: Arc::new(Mutex::new(LlmWarmupState::default())),
     };
 
     let mut global = CORE.lock().unwrap();
@@ -362,10 +379,19 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
     };
     let llm_config = cfg.llm.clone();
     let llm_http_client = core.llm_http_client.clone();
+    let llm_warmup_state = core.llm_warmup_state.clone();
     let dictionary = core.dictionary.clone();
     let dictionary_max_candidates = cfg.llm.dictionary_max_candidates;
     let system_prompt = core.system_prompt.clone();
     let user_prompt_template = core.user_prompt_template.clone();
+
+    start_llm_warmup_if_needed(
+        &core.runtime,
+        &session_id,
+        &llm_config,
+        llm_http_client.clone(),
+        llm_warmup_state.clone(),
+    );
 
     // Spawn the session task
     core.runtime.spawn(async move {
@@ -379,6 +405,7 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
             asr,
             llm_config,
             llm_http_client,
+            llm_warmup_state,
             dictionary,
             dictionary_max_candidates,
             system_prompt,
@@ -501,6 +528,7 @@ async fn run_session(
     mut asr: Box<dyn AsrProvider>,
     llm_config: config::LlmSection,
     llm_http_client: Client,
+    llm_warmup_state: Arc<Mutex<LlmWarmupState>>,
     dictionary: Vec<String>,
     dictionary_max_candidates: usize,
     system_prompt: String,
@@ -697,6 +725,7 @@ async fn run_session(
 
         match llm.correct(&request).await {
             Ok(corrected) => {
+                mark_llm_connection_touched(&llm_warmup_state);
                 log::info!("[{session_id}] LLM corrected: {} chars", corrected.len());
                 corrected
             }
@@ -776,6 +805,76 @@ async fn wait_for_final(
 fn cleanup_session(session_arc: &Arc<Mutex<Option<Session>>>) {
     let mut s = session_arc.lock().unwrap();
     *s = None;
+}
+
+fn llm_is_ready(cfg: &config::LlmSection) -> bool {
+    cfg.enabled && !cfg.base_url.is_empty() && !cfg.api_key.is_empty() && !cfg.model.is_empty()
+}
+
+fn start_llm_warmup_if_needed(
+    runtime: &Runtime,
+    session_id: &str,
+    llm_config: &config::LlmSection,
+    llm_http_client: Client,
+    llm_warmup_state: Arc<Mutex<LlmWarmupState>>,
+) {
+    if !llm_is_ready(llm_config) {
+        return;
+    }
+
+    {
+        let mut state = llm_warmup_state.lock().unwrap();
+        if state.in_flight {
+            log::debug!("[{session_id}] skipping LLM warmup; already in flight");
+            return;
+        }
+        if state
+            .last_touched
+            .is_some_and(|instant| instant.elapsed() < LLM_WARMUP_TTL)
+        {
+            log::debug!("[{session_id}] skipping LLM warmup; connection recently used");
+            return;
+        }
+        state.in_flight = true;
+    }
+
+    let warmup_session_id = session_id.to_string();
+    let warmup_cfg = llm_config.clone();
+    runtime.spawn(async move {
+        log::info!("[{warmup_session_id}] starting LLM warmup");
+        let llm = OpenAiCompatibleProvider::new(
+            llm_http_client,
+            warmup_cfg.base_url,
+            warmup_cfg.api_key,
+            warmup_cfg.model,
+            warmup_cfg.temperature,
+            warmup_cfg.top_p,
+            warmup_cfg.max_output_tokens,
+            warmup_cfg.max_token_parameter,
+        );
+
+        let warmup_ok = match llm.warmup().await {
+            Ok(()) => {
+                log::info!("[{warmup_session_id}] LLM warmup completed");
+                true
+            }
+            Err(err) => {
+                log::debug!("[{warmup_session_id}] LLM warmup failed: {err}");
+                false
+            }
+        };
+
+        let mut state = llm_warmup_state.lock().unwrap();
+        state.in_flight = false;
+        if warmup_ok {
+            state.last_touched = Some(Instant::now());
+        }
+    });
+}
+
+fn mark_llm_connection_touched(llm_warmup_state: &Arc<Mutex<LlmWarmupState>>) {
+    let mut state = llm_warmup_state.lock().unwrap();
+    state.last_touched = Some(Instant::now());
 }
 
 // ─── Model Manager FFI ─────────────────────────────────────────────

--- a/koe-core/src/llm/openai_compatible.rs
+++ b/koe-core/src/llm/openai_compatible.rs
@@ -4,6 +4,9 @@ use crate::llm::{CorrectionRequest, LlmProvider};
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::time::Duration;
+use urlencoding::encode;
+
+pub const LLM_HTTP_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// LLM provider compatible with the OpenAI chat completions API.
 pub struct OpenAiCompatibleProvider {
@@ -39,12 +42,45 @@ impl OpenAiCompatibleProvider {
             max_token_parameter,
         }
     }
+
+    pub async fn warmup(&self) -> Result<()> {
+        let model = encode(&self.model);
+        let url = format!(
+            "{}/models/{}",
+            self.base_url.trim_end_matches('/'),
+            model
+        );
+
+        log::debug!("LLM warmup request to {url}");
+
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    KoeError::LlmTimeout
+                } else {
+                    KoeError::LlmFailed(e.to_string())
+                }
+            })?;
+
+        let status = response.status();
+        let _ = response.bytes().await;
+        if !status.is_success() {
+            log::debug!("LLM warmup completed with HTTP {status}");
+        }
+
+        Ok(())
+    }
 }
 
 pub fn build_http_client(timeout_ms: u64) -> std::result::Result<Client, reqwest::Error> {
     Client::builder()
         .timeout(Duration::from_millis(timeout_ms))
-        .pool_idle_timeout(Duration::from_secs(90))
+        .pool_idle_timeout(LLM_HTTP_POOL_IDLE_TIMEOUT)
         .pool_max_idle_per_host(2)
         .tcp_keepalive(Some(Duration::from_secs(30)))
         .http2_keep_alive_interval(Duration::from_secs(30))


### PR DESCRIPTION
This PR reduces cold LLM latency by warming the existing HTTP connection as soon as a recording session starts, so network setup can overlap with user speech instead of waiting until ASR has already finished.

In the current Azure OpenAI-compatible environment, direct cold-vs-warm measurements on the LLM host show an expected cold-path improvement of about 300ms. Across 7 paired runs, cold requests reached first response bytes in about 368-415ms, while warm reused connections did so in about 92-102ms, for an observed savings range of roughly 274-323ms.

This benefit mainly applies to:
- the first correction after app launch
- the first correction after the pooled connection has expired due to idleness

It is not expected to materially improve back-to-back dictation sessions when the LLM connection is already warm.

### Implementation

- Start a best-effort LLM warmup from `sp_core_session_begin`
- Reuse the existing shared `reqwest::Client`
- Use `GET /models/{model}` as a lightweight same-origin warmup request
- URL-encode model IDs
- Skip warmup when:
  - LLM is disabled or not configured
  - another warmup is already in flight
  - the connection was used recently
- Never block the real correction request on warmup

The reuse window is tied to the real HTTP client settings:
- pool idle timeout: `90s`
- safety margin: `20s`
- warmup reuse window: `70s`

For the current Rust `reqwest` stack, a lightweight same-origin request is the most practical warmup mechanism; unlike browsers, there is no built-in higher-level preconnect primitive that safely warms the pooled connection we actually want to reuse.

### Alternative explored but not adopted

We also tested HTTP/3 as a separate optimization idea.

Result:
- OpenAI's public endpoint could use HTTP/3 on a compatible network path
- the current Azure OpenAI-compatible endpoint did not demonstrate a usable HTTP/3 path in our testing
- `reqwest` HTTP/3 is still unstable and does not provide the fallback behavior we want

Because of that, HTTP/3 is not part of this PR. This change only warms the existing stable HTTP/2/TLS path.

### Validation

Passed:
- `cargo build -q -p koe-core`
- `cargo test -q -p koe-core`