### PR TITLE
fix(llm): tighten warmup readiness and drain handling

### DIFF
--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -678,9 +678,7 @@ async fn run_session(
     }
 
     // --- LLM Correction ---
-    let llm_enabled = llm_config.enabled
-        && !llm_config.base_url.is_empty()
-        && !llm_config.api_key.is_empty();
+    let llm_enabled = llm_is_ready(&llm_config);
 
     let final_text = if llm_enabled {
         {

--- a/koe-core/src/llm/openai_compatible.rs
+++ b/koe-core/src/llm/openai_compatible.rs
@@ -68,12 +68,17 @@ impl OpenAiCompatibleProvider {
             })?;
 
         let status = response.status();
-        let _ = response.bytes().await;
-        if !status.is_success() {
-            log::debug!("LLM warmup completed with HTTP {status}");
+        match response.bytes().await {
+            Ok(_) => {
+                if !status.is_success() {
+                    log::debug!("LLM warmup completed with HTTP {status}");
+                }
+                Ok(())
+            }
+            Err(e) => Err(KoeError::LlmFailed(format!(
+                "warmup read response body: {e}"
+            ))),
         }
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
This follow-up fixes review comments on the merged LLM warmup change in #25.

Specifically:
- Treat warmup response-body drain failures as actual warmup failures instead of silently returning success
- Reuse the same LLM readiness predicate for both warmup and the real correction path, so the two behaviors stay aligned

Validation:
- `cargo build -q -p koe-core`
- `cargo test -q -p koe-core`