### PR TITLE
fix(asr): prevent use-after-free in MLX callback on cancel

### DIFF
--- a/Packages/KoeMLX/Sources/KoeMLX/MLXAsrManager.swift
+++ b/Packages/KoeMLX/Sources/KoeMLX/MLXAsrManager.swift
@@ -22,6 +22,7 @@ class MLXAsrManager {
     private var eventTask: Task<Void, Never>?
     private var callback: MLXEventCallback?
     private var callbackCtx: UnsafeMutableRawPointer?
+    private let callbackLock = NSLock()
 
     /// Load a Qwen3-ASR model from a local directory (blocking).
     func loadModel(path: String) -> Bool {
@@ -111,6 +112,14 @@ class MLXAsrManager {
 
     /// Cancel the session immediately.
     func cancel() {
+        // Clear callback context under lock FIRST so any in-flight or
+        // subsequent invokeCallback sees nil and never touches the pointer.
+        // Rust's close() reclaims the pointer only after this returns.
+        callbackLock.lock()
+        callback = nil
+        callbackCtx = nil
+        callbackLock.unlock()
+
         session?.cancel()
         eventTask?.cancel()
         eventTask = nil
@@ -126,6 +135,8 @@ class MLXAsrManager {
     // MARK: - Private
 
     private func invokeCallback(eventType: Int32, text: String) {
+        callbackLock.lock()
+        defer { callbackLock.unlock() }
         guard let cb = callback, let ctx = callbackCtx else { return }
         text.withCString { cstr in
             cb(ctx, eventType, cstr)

--- a/koe-asr/src/mlx.rs
+++ b/koe-asr/src/mlx.rs
@@ -175,6 +175,9 @@ impl crate::provider::AsrProvider for MlxProvider {
     }
 
     async fn close(&mut self) -> Result<()> {
+        // SAFETY: koe_mlx_cancel() synchronously clears the callback context on
+        // the Swift side (under a lock), ensuring no further calls through the
+        // callback pointer after this returns.  Safe to reclaim the sender afterward.
         unsafe {
             koe_mlx_cancel();
         }


### PR DESCRIPTION
## Problem

When Rust calls `close()` on the MLX provider, it invokes `koe_mlx_cancel()` then immediately frees the leaked `Box<Sender>` via `reclaim_sender()`. However, Swift's `Task.cancel()` is cooperative — the `eventTask` may still be running and can invoke the C callback with the already-freed context pointer, leading to a use-after-free crash.

## Solution

Add an `NSLock` to `MLXAsrManager`:
- `cancel()` clears `callback`/`callbackCtx` under the lock **before** cancelling the task
- `invokeCallback()` holds the lock for the entire C callback invocation

This guarantees the context pointer is never dereferenced after Rust reclaims it. A safety-invariant comment is added to the Rust side.

## Files changed
- `Packages/KoeMLX/Sources/KoeMLX/MLXAsrManager.swift`
- `koe-asr/src/mlx.rs` (comment only)

## Test plan
- [x] `make build` passes
- [ ] Hold-to-talk and tap-to-toggle work normally
- [ ] Rapid cancel during recording does not crash