### PR TITLE
perf(asr): cache MLX model across sessions to avoid repeated loads

### DIFF
--- a/Packages/KoeMLX/Sources/KoeMLX/MLXAsrManager.swift
+++ b/Packages/KoeMLX/Sources/KoeMLX/MLXAsrManager.swift
@@ -18,21 +18,31 @@ typealias MLXEventCallback = @convention(c) (
 /// Manages Qwen3-ASR model loading and streaming inference via MLX.
 class MLXAsrManager {
     private var model: Qwen3ASRModel?
+    private var loadedModelPath: String?
     private var session: StreamingInferenceSession?
     private var eventTask: Task<Void, Never>?
     private var callback: MLXEventCallback?
     private var callbackCtx: UnsafeMutableRawPointer?
 
     /// Load a Qwen3-ASR model from a local directory (blocking).
+    /// Skips loading if the same path is already loaded.
     func loadModel(path: String) -> Bool {
+        if model != nil && loadedModelPath == path {
+            NSLog("KoeMLX: model already loaded from %@, reusing", path)
+            return true
+        }
+
         let semaphore = DispatchSemaphore(value: 0)
         var success = false
         Task {
             do {
-                model = try await Self.loadModelFromLocal(path: path)
+                self.model = try await Self.loadModelFromLocal(path: path)
+                self.loadedModelPath = path
                 success = true
             } catch {
                 NSLog("KoeMLX: failed to load model at %@: %@", path, error.localizedDescription)
+                self.model = nil
+                self.loadedModelPath = nil
             }
             semaphore.signal()
         }
@@ -121,6 +131,7 @@ class MLXAsrManager {
     func unloadModel() {
         cancel()
         model = nil
+        loadedModelPath = nil
     }
 
     // MARK: - Private


### PR DESCRIPTION
## Problem

The MLX model is reloaded from disk on every session's `connect()` call. For Qwen3-ASR models (0.6B–1.7B parameters), this adds significant latency that dominates the "press and speak" interaction.

## Solution

Track the loaded model path in `MLXAsrManager`. When `loadModel` is called with the same path that's already loaded, return immediately. The cached path is cleared on `unloadModel`.

## Files changed
- `Packages/KoeMLX/Sources/KoeMLX/MLXAsrManager.swift`

## Test plan
- [x] `make build` passes
- [ ] First session loads model (log: "model loaded from ...")
- [ ] Subsequent sessions skip loading (log: "model already loaded ... reusing")
- [ ] Changing model path in config triggers a fresh load