### PR TITLE
fix(wizard): match runtime LLM request in test button

### DIFF
--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1363,11 +1363,15 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     }
 
     NSString *tokenParam = self.maxTokenParamPopup.selectedItem.representedObject ?: @"max_completion_tokens";
-    NSDictionary *body = @{
+    NSMutableDictionary *body = [@{
         @"model": model,
         @"messages": @[@{@"role": @"user", @"content": @"Hi"}],
         tokenParam: @(10),
-    };
+    } mutableCopy];
+    // Match runtime behavior: send reasoning_effort when using max_completion_tokens
+    if ([tokenParam isEqualToString:@"max_completion_tokens"]) {
+        body[@"reasoning_effort"] = @"none";
+    }
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];


### PR DESCRIPTION
## Why

The runtime LLM request includes `reasoning_effort: "none"` when using
`max_completion_tokens`, but the Setup Wizard test button did not. Strict
endpoints could reject the runtime request while the test passed.

## What changed

Added `reasoning_effort: "none"` to the test request body when
`max_completion_tokens` is selected, matching openai_compatible.rs runtime
behavior.

## Test plan

- [x] `make` builds successfully
- [ ] Manual: select max_completion_tokens in wizard, click Test — verify
  request includes reasoning_effort field