### PR TITLE
fix(mlx): add generation counter to prevent stale session operations

### DIFF
--- a/Packages/KoeMLX/Sources/KoeMLX/CBridge.swift
+++ b/Packages/KoeMLX/Sources/KoeMLX/CBridge.swift
@@ -18,7 +18,7 @@ public func koeMLXStartSession(
     _ delayPreset: UnsafePointer<CChar>?,
     _ callback: @convention(c) (UnsafeMutableRawPointer?, Int32, UnsafePointer<CChar>?) -> Void,
     _ ctx: UnsafeMutableRawPointer?
-) -> Int32 {
+) -> UInt64 {
     let lang = language.map { String(cString: $0) } ?? "auto"
     let preset = delayPreset.map { String(cString: $0) } ?? "realtime"
     return manager.startSession(
@@ -26,23 +26,23 @@ public func koeMLXStartSession(
         delayPreset: preset,
         callback: callback,
         context: ctx
-    ) ? 0 : -1
+    )
 }
 
 @_cdecl("koe_mlx_feed_audio")
-public func koeMLXFeedAudio(_ samples: UnsafePointer<Float>?, _ count: UInt32) {
+public func koeMLXFeedAudio(_ samples: UnsafePointer<Float>?, _ count: UInt32, _ generation: UInt64) {
     guard let samples = samples else { return }
-    manager.feedAudio(samples, count: Int(count))
+    manager.feedAudio(samples, count: Int(count), generation: generation)
 }
 
 @_cdecl("koe_mlx_stop")
-public func koeMLXStop() {
-    manager.stop()
+public func koeMLXStop(_ generation: UInt64) {
+    manager.stop(generation: generation)
 }
 
 @_cdecl("koe_mlx_cancel")
-public func koeMLXCancel() {
-    manager.cancel()
+public func koeMLXCancel(_ generation: UInt64) {
+    manager.cancel(generation: generation)
 }
 
 @_cdecl("koe_mlx_unload_model")

--- a/Packages/KoeMLX/Sources/KoeMLX/MLXAsrManager.swift
+++ b/Packages/KoeMLX/Sources/KoeMLX/MLXAsrManager.swift
@@ -24,6 +24,9 @@ class MLXAsrManager {
     private var callback: MLXEventCallback?
     private var callbackCtx: UnsafeMutableRawPointer?
     private let callbackLock = NSLock()
+    /// Monotonically increasing generation counter.  Each startSession bumps it;
+    /// feedAudio / stop / cancel only act when the caller's generation matches.
+    private var generation: UInt64 = 0
 
     /// Load a Qwen3-ASR model from a local directory (blocking).
     /// Skips loading if the same path is already loaded.
@@ -52,14 +55,24 @@ class MLXAsrManager {
     }
 
     /// Start a streaming recognition session.
+    /// Returns the session generation (>0) on success, or 0 on failure.
     func startSession(language: String,
                       delayPreset: String,
                       callback: MLXEventCallback,
-                      context: UnsafeMutableRawPointer?) -> Bool {
+                      context: UnsafeMutableRawPointer?) -> UInt64 {
         guard let model = self.model else {
             NSLog("KoeMLX: model not loaded")
-            return false
+            return 0
         }
+
+        // Cancel any in-flight session before overwriting singleton state
+        session?.cancel()
+        eventTask?.cancel()
+        eventTask = nil
+        session = nil
+
+        generation &+= 1
+        let thisGeneration = generation
 
         self.callback = callback
         self.callbackCtx = context
@@ -89,7 +102,7 @@ class MLXAsrManager {
 
         eventTask = Task { [weak self] in
             for await event in session.events {
-                guard let self = self else { break }
+                guard let self = self, self.generation == thisGeneration else { break }
                 switch event {
                 case .displayUpdate(let confirmed, let provisional):
                     self.invokeCallback(eventType: 0, text: confirmed + provisional)
@@ -103,25 +116,34 @@ class MLXAsrManager {
                     break
                 }
             }
-            self?.invokeCallback(eventType: 5, text: "")
+            if let self = self, self.generation == thisGeneration {
+                self.invokeCallback(eventType: 5, text: "")
+            }
         }
 
-        return true
+        return thisGeneration
     }
 
     /// Feed raw f32 PCM samples at 16kHz.
-    func feedAudio(_ samples: UnsafePointer<Float>, count: Int) {
+    /// Ignored if `gen` doesn't match the current session generation.
+    func feedAudio(_ samples: UnsafePointer<Float>, count: Int, generation gen: UInt64) {
+        guard gen == generation else { return }
         let buffer = Array(UnsafeBufferPointer(start: samples, count: count))
         session?.feedAudio(samples: buffer)
     }
 
     /// Gracefully stop the session (flush remaining audio, emit .ended).
-    func stop() {
+    /// Ignored if `gen` doesn't match the current session generation.
+    func stop(generation gen: UInt64) {
+        guard gen == generation else { return }
         session?.stop()
     }
 
     /// Cancel the session immediately.
-    func cancel() {
+    /// Ignored if `gen` doesn't match the current session generation.
+    func cancel(generation gen: UInt64) {
+        guard gen == generation else { return }
+
         // Clear callback context under lock FIRST so any in-flight or
         // subsequent invokeCallback sees nil and never touches the pointer.
         // Rust's close() reclaims the pointer only after this returns.
@@ -138,7 +160,7 @@ class MLXAsrManager {
 
     /// Unload the model to free memory.
     func unloadModel() {
-        cancel()
+        cancel(generation: generation)
         model = nil
         loadedModelPath = nil
     }

--- a/koe-asr/src/mlx.rs
+++ b/koe-asr/src/mlx.rs
@@ -9,15 +9,16 @@ use crate::event::AsrEvent;
 #[allow(dead_code)]
 extern "C" {
     fn koe_mlx_load_model(model_path: *const c_char) -> i32;
+    /// Returns session generation (>0) on success, 0 on failure.
     fn koe_mlx_start_session(
         language: *const c_char,
         delay_preset: *const c_char,
         callback: extern "C" fn(ctx: *mut c_void, event_type: i32, text: *const c_char),
         ctx: *mut c_void,
-    ) -> i32;
-    fn koe_mlx_feed_audio(samples: *const f32, count: u32);
-    fn koe_mlx_stop();
-    fn koe_mlx_cancel();
+    ) -> u64;
+    fn koe_mlx_feed_audio(samples: *const f32, count: u32, generation: u64);
+    fn koe_mlx_stop(generation: u64);
+    fn koe_mlx_cancel(generation: u64);
     fn koe_mlx_unload_model();
 }
 
@@ -71,6 +72,10 @@ pub struct MlxProvider {
     /// Leaked sender pointer passed as callback context.
     /// Reclaimed in close()/drop.
     event_tx_ptr: Option<*mut c_void>,
+    /// Session generation returned by the Swift singleton.
+    /// Passed to all subsequent FFI calls so stale operations from an old
+    /// provider are ignored when a new session has already started.
+    session_generation: u64,
 }
 
 // Safety: The raw pointer is only accessed from the callback (which is Send)
@@ -83,6 +88,7 @@ impl MlxProvider {
             config,
             event_rx: None,
             event_tx_ptr: None,
+            session_generation: 0,
         }
     }
 
@@ -127,7 +133,7 @@ impl crate::provider::AsrProvider for MlxProvider {
         let language = CString::new(self.config.language.clone()).unwrap_or_default();
         let delay_preset = CString::new(self.config.delay_preset.clone()).unwrap_or_default();
 
-        let ret = unsafe {
+        let gen = unsafe {
             koe_mlx_start_session(
                 language.as_ptr(),
                 delay_preset.as_ptr(),
@@ -135,12 +141,13 @@ impl crate::provider::AsrProvider for MlxProvider {
                 tx_ptr,
             )
         };
-        if ret != 0 {
+        if gen == 0 {
             self.reclaim_sender();
-            return Err(AsrError::Connection(format!(
-                "failed to start MLX session (code {ret})"
-            )));
+            return Err(AsrError::Connection(
+                "failed to start MLX session".into(),
+            ));
         }
+        self.session_generation = gen;
 
         Ok(())
     }
@@ -152,14 +159,14 @@ impl crate::provider::AsrProvider for MlxProvider {
             .collect();
 
         unsafe {
-            koe_mlx_feed_audio(samples.as_ptr(), samples.len() as u32);
+            koe_mlx_feed_audio(samples.as_ptr(), samples.len() as u32, self.session_generation);
         }
         Ok(())
     }
 
     async fn finish_input(&mut self) -> Result<()> {
         unsafe {
-            koe_mlx_stop();
+            koe_mlx_stop(self.session_generation);
         }
         Ok(())
     }
@@ -178,8 +185,12 @@ impl crate::provider::AsrProvider for MlxProvider {
         // SAFETY: koe_mlx_cancel() synchronously clears the callback context on
         // the Swift side (under a lock), ensuring no further calls through the
         // callback pointer after this returns.  Safe to reclaim the sender afterward.
+        //
+        // The generation parameter ensures that if a new session has already
+        // started on the singleton, this cancel is a no-op — it won't affect
+        // the new session.
         unsafe {
-            koe_mlx_cancel();
+            koe_mlx_cancel(self.session_generation);
         }
         self.event_rx = None;
         self.reclaim_sender();


### PR DESCRIPTION
## Why

The MLXAsrManager Swift singleton was vulnerable to session cross-talk:
when a new recording session started while the old one was still cleaning
up, the old provider's `stop()`/`cancel()` would hit the new session on
the singleton, potentially cancelling or prematurely ending it. The Rust-side
Arc isolation (commit 8b22ea8d) mitigated the Rust layer but the Swift
singleton still overwrote shared state.

## What changed

- Added a monotonically increasing `generation` counter to `MLXAsrManager`.
- `startSession()` increments generation, cancels any in-flight session,
  and returns the generation to the Rust caller.
- `feedAudio()`, `stop()`, `cancel()` all take a generation parameter —
  calls with a stale generation are silently ignored.
- The `eventTask` checks generation to stop forwarding events from
  superseded sessions.
- Rust `MlxProvider` stores the generation from `connect()` and passes it
  through all subsequent FFI calls.

## Test plan

- [x] `cargo check --no-default-features` — Rust compiles
- [x] `make` builds successfully
- [ ] Manual: rapid start/stop recording — new session should not be
  interrupted by old session cleanup