### PR TITLE
fix(net): enable system proxy support for model downloads

### DIFF
--- a/koe-cli/Cargo.toml
+++ b/koe-cli/Cargo.toml
@@ -12,6 +12,6 @@ koe-core = { path = "../koe-core", default-features = false }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 indicatif = "0.17"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "system-proxy"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/koe-core/Cargo.toml
+++ b/koe-core/Cargo.toml
@@ -15,7 +15,7 @@ sherpa-onnx = ["koe-asr/sherpa-onnx"]
 [dependencies]
 koe-asr = { path = "../koe-asr" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2", "stream"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2", "stream", "system-proxy"], default-features = false }
 sha2 = "0.10"
 futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Enable reqwest `system-proxy` feature so that `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / `NO_PROXY` environment variables are respected
- Allows users behind proxies (common in mainland China for Hugging Face access) to download models without needing enhanced proxy modes
- Binary size impact: ~10 KB increase

## Context

Users reported inability to download models from Hugging Face (#41). The root cause is that the project uses `default-features = false` for reqwest, which disables system proxy detection. Users using standard proxy tools (e.g. Clash Verge) could not route traffic through their proxy, while enhanced mode tools (e.g. ClashX Pro) worked by intercepting at a lower network level.

Closes #41