### PR TITLE
fix(build): add missing SystemConfiguration framework linkage

### DIFF
--- a/KoeApp/project.yml
+++ b/KoeApp/project.yml
@@ -43,6 +43,7 @@ targetTemplates:
           - "-framework Security"
           - "-framework CoreFoundation"
           - "-framework UserNotifications"
+          - "-framework SystemConfiguration"
         ENABLE_APP_SANDBOX: NO
         CLANG_ENABLE_OBJC_ARC: YES
     frameworks:


### PR DESCRIPTION
## Summary

- PR #43 added the `system-proxy` feature to reqwest, which pulls in the `system-configuration` crate
- This crate requires `SystemConfiguration.framework` at link time, but the framework was missing from `OTHER_LDFLAGS` in `project.yml`
- This caused a linker error: `ld: symbol(s) not found for architecture arm64`

## Changes

- Add `-framework SystemConfiguration` to `OTHER_LDFLAGS` in `KoeApp/project.yml`

## Test plan

- [x] `make build` passes (BUILD SUCCEEDED)