### PR TITLE
fix(core): redact transcription text from INFO logs

### DIFF
--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -758,7 +758,8 @@ async fn run_session(
         let candidates =
             prompt::filter_dictionary_candidates(&dictionary, &asr_text, dictionary_max_candidates);
 
-        log::info!("[{session_id}] LLM request — asr_text: \"{}\"", asr_text);
+        log::info!("[{session_id}] LLM request — asr_text_len: {}", asr_text.len());
+        log::debug!("[{session_id}] LLM request — asr_text: \"{}\"", asr_text);
         log::info!(
             "[{session_id}] LLM request — {} dictionary entries, {} interim revisions",
             candidates.len(),


### PR DESCRIPTION
## Summary

`log::info!` at `lib.rs:761` was printing the full raw ASR text at the default INFO level. For a voice input tool this exposes everything the user dictates to the terminal, Xcode console, or any environment collecting stderr.

- Move the raw transcription text to `DEBUG` level
- Keep an `INFO` log that records only the text length and session ID for diagnostics

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets` clean
- [ ] Run a dictation session with default log level — no user text in logs
- [ ] Set `RUST_LOG=debug` — full text visible at debug level