### PR TITLE
fix(model): handle nested directories in model file removal

### DIFF
--- a/koe-core/src/model_manager.rs
+++ b/koe-core/src/model_manager.rs
@@ -275,13 +275,36 @@ pub fn remove_model_files(model_dir: &Path) -> Result<usize> {
         std::fs::read_dir(model_dir).map_err(|e| KoeError::Config(format!("read dir: {e}")))?;
     for entry in entries.flatten() {
         let name = entry.file_name();
-        if name != MANIFEST_FILE && entry.path().is_file() {
-            std::fs::remove_file(entry.path())
-                .map_err(|e| KoeError::Config(format!("remove {}: {e}", entry.path().display())))?;
+        if name == MANIFEST_FILE {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            removed += count_files_recursive(&path);
+            std::fs::remove_dir_all(&path)
+                .map_err(|e| KoeError::Config(format!("remove dir {}: {e}", path.display())))?;
+        } else if path.is_file() {
+            std::fs::remove_file(&path)
+                .map_err(|e| KoeError::Config(format!("remove {}: {e}", path.display())))?;
             removed += 1;
         }
     }
     Ok(removed)
+}
+
+fn count_files_recursive(dir: &Path) -> usize {
+    let mut count = 0;
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                count += count_files_recursive(&path);
+            } else {
+                count += 1;
+            }
+        }
+    }
+    count
 }
 
 // ─── Download ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`remove_model_files()` used a shallow `read_dir` that only iterated one directory level and skipped subdirectories. Model manifests can specify nested file paths (e.g. `subdir/weights.bin`), and the download logic creates those subdirectories via `create_dir_all`. When a user deleted a model, files inside subdirectories were silently left behind — the UI reported success but disk space was not freed.

- Add `remove_dir_all` handling for subdirectories encountered during removal
- Add `count_files_recursive` helper to maintain accurate file count reporting
- Add a test that creates a model directory with nested files and verifies full cleanup

## Test plan

- [x] `cargo test --workspace` passes (including new `remove_model_files_handles_subdirectories` test)
- [x] `cargo clippy --workspace --all-targets` clean
- [ ] Download a model whose manifest contains nested paths, remove it, verify no residual files