### PR TITLE
fix(permissions): stop repeated accessibility prompts, add grant actions to menu

### DIFF
--- a/KoeApp/Koe/Permissions/SPPermissionManager.h
+++ b/KoeApp/Koe/Permissions/SPPermissionManager.h
@@ -7,6 +7,7 @@ typedef void (^SPPermissionCheckCompletion)(BOOL micGranted, BOOL accessibilityG
 - (void)checkAllPermissionsWithCompletion:(SPPermissionCheckCompletion)completion;
 - (BOOL)isMicrophoneGranted;
 - (BOOL)isAccessibilityGranted;
+- (void)requestAccessibilityPermission;
 - (BOOL)isInputMonitoringGranted;
 
 /// Request notification permission from the user.

--- a/KoeApp/Koe/Permissions/SPPermissionManager.m
+++ b/KoeApp/Koe/Permissions/SPPermissionManager.m
@@ -8,6 +8,7 @@
 - (void)checkAllPermissionsWithCompletion:(SPPermissionCheckCompletion)completion {
     // Check microphone permission (async)
     [self requestMicrophonePermissionWithCompletion:^(BOOL micGranted) {
+        [self requestAccessibilityPermission];
         BOOL accessibility = [self isAccessibilityGranted];
         BOOL inputMonitoring = [self isInputMonitoringGranted];
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -35,9 +36,13 @@
 }
 
 - (BOOL)isAccessibilityGranted {
-    // AXIsProcessTrustedWithOptions with prompt
-    NSDictionary *options = @{(__bridge NSString *)kAXTrustedCheckOptionPrompt: @YES};
+    NSDictionary *options = @{(__bridge NSString *)kAXTrustedCheckOptionPrompt: @NO};
     return AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef)options);
+}
+
+- (void)requestAccessibilityPermission {
+    NSDictionary *options = @{(__bridge NSString *)kAXTrustedCheckOptionPrompt: @YES};
+    AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef)options);
 }
 
 static CGEventRef inputMonitoringProbeCallback(CGEventTapProxy proxy,

--- a/KoeApp/Koe/StatusBar/SPStatusBarManager.m
+++ b/KoeApp/Koe/StatusBar/SPStatusBarManager.m
@@ -181,26 +181,30 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     [menu addItem:permHeader];
 
     self.micPermissionItem = [[NSMenuItem alloc] initWithTitle:@"  Microphone: Checking..."
-                                                       action:nil
+                                                       action:@selector(openMicrophoneSettings)
                                                 keyEquivalent:@""];
+    self.micPermissionItem.target = self;
     self.micPermissionItem.enabled = NO;
     [menu addItem:self.micPermissionItem];
 
     self.accessibilityPermissionItem = [[NSMenuItem alloc] initWithTitle:@"  Accessibility: Checking..."
-                                                                 action:nil
+                                                                 action:@selector(requestAccessibilityPermission)
                                                           keyEquivalent:@""];
+    self.accessibilityPermissionItem.target = self;
     self.accessibilityPermissionItem.enabled = NO;
     [menu addItem:self.accessibilityPermissionItem];
 
     self.inputMonitoringPermissionItem = [[NSMenuItem alloc] initWithTitle:@"  Input Monitoring: Checking..."
-                                                                   action:nil
+                                                                   action:@selector(openInputMonitoringSettings)
                                                             keyEquivalent:@""];
+    self.inputMonitoringPermissionItem.target = self;
     self.inputMonitoringPermissionItem.enabled = NO;
     [menu addItem:self.inputMonitoringPermissionItem];
 
     self.notificationPermissionItem = [[NSMenuItem alloc] initWithTitle:@"  Notifications: Checking..."
-                                                                action:nil
+                                                                action:@selector(requestNotificationPermission)
                                                          keyEquivalent:@""];
+    self.notificationPermissionItem.target = self;
     self.notificationPermissionItem.enabled = NO;
     [menu addItem:self.notificationPermissionItem];
 
@@ -281,16 +285,36 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     BOOL inputMonitoring = [self.permissionManager isInputMonitoringGranted];
 
     self.micPermissionItem.title = [NSString stringWithFormat:@"  Microphone: %@",
-                                    mic ? @"Granted" : @"Not Granted"];
+                                    mic ? @"Granted" : @"Not Granted ▸"];
+    self.micPermissionItem.enabled = !mic;
     self.accessibilityPermissionItem.title = [NSString stringWithFormat:@"  Accessibility: %@",
-                                              accessibility ? @"Granted" : @"Not Granted"];
+                                              accessibility ? @"Granted" : @"Not Granted ▸"];
+    self.accessibilityPermissionItem.enabled = !accessibility;
     self.inputMonitoringPermissionItem.title = [NSString stringWithFormat:@"  Input Monitoring: %@",
-                                                inputMonitoring ? @"Granted" : @"Not Granted"];
+                                                inputMonitoring ? @"Granted" : @"Not Granted ▸"];
+    self.inputMonitoringPermissionItem.enabled = !inputMonitoring;
 
     [self.permissionManager checkNotificationPermissionWithCompletion:^(BOOL granted) {
         self.notificationPermissionItem.title = [NSString stringWithFormat:@"  Notifications: %@",
-                                                  granted ? @"Granted" : @"Not Granted"];
+                                                  granted ? @"Granted" : @"Not Granted ▸"];
+        self.notificationPermissionItem.enabled = !granted;
     }];
+}
+
+- (void)openMicrophoneSettings {
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"]];
+}
+
+- (void)requestAccessibilityPermission {
+    [self.permissionManager requestAccessibilityPermission];
+}
+
+- (void)openInputMonitoringSettings {
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"]];
+}
+
+- (void)requestNotificationPermission {
+    [self.permissionManager requestNotificationPermission];
 }
 
 - (void)refreshStats {


### PR DESCRIPTION
## Summary

`isAccessibilityGranted` was called with `kAXTrustedCheckOptionPrompt: @YES` in every passive code path — on each dictation session (paste decision) and every time the status bar menu opened. This caused the macOS accessibility permission dialog to appear repeatedly during normal use, which is inconsistent with the documented "degrade to copy-only when accessibility is not granted" behavior.

**Prompt separation:**
- `isAccessibilityGranted` now uses `@NO` (quiet check) for all passive callers
- New `requestAccessibilityPermission` method uses `@YES`, called only at app startup (`checkAllPermissionsWithCompletion:`) and from explicit user actions

**Permission menu items:**
All four permission items in the status bar menu are now clickable when not granted (with a `▸` indicator), giving users a clear path to fix missing permissions:
- Accessibility — triggers the system permission prompt
- Microphone — opens System Settings → Privacy → Microphone
- Input Monitoring — opens System Settings → Privacy → Input Monitoring
- Notifications — triggers the system notification authorization request

## Test plan

- [x] `xcodebuild` passes
- [ ] With accessibility not granted: open status bar menu — no system prompt appears, item shows "Not Granted ▸" and is clickable
- [ ] Click the accessibility item — system prompt appears
- [ ] Run a dictation session without accessibility — text copied to clipboard, no prompt
- [ ] Verify Microphone/Input Monitoring items open the correct Settings pane
- [ ] Verify Notification item triggers the authorization dialog