### PR TITLE
fix(clipboard): restore empty clipboard after dictation

### DIFF
--- a/KoeApp/Koe/Clipboard/SPClipboardManager.m
+++ b/KoeApp/Koe/Clipboard/SPClipboardManager.m
@@ -6,6 +6,7 @@
 @property (nonatomic, strong) NSArray<NSPasteboardItem *> *backedUpItems;
 @property (nonatomic, assign) NSInteger backedUpChangeCount;
 @property (nonatomic, assign) NSInteger writtenChangeCount;
+@property (nonatomic, assign) BOOL hasBackup;
 
 @end
 
@@ -28,6 +29,7 @@
         [items addObject:copy];
     }
     self.backedUpItems = items;
+    self.hasBackup = YES;
 }
 
 - (void)writeText:(NSString *)text {
@@ -38,7 +40,7 @@
 }
 
 - (void)scheduleRestoreAfterDelay:(NSUInteger)delayMs {
-    if (!self.backedUpItems) return;
+    if (!self.hasBackup) return;
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayMs * NSEC_PER_MSEC)),
                    dispatch_get_main_queue(), ^{
@@ -47,22 +49,25 @@
 }
 
 - (void)restoreIfUnchanged {
+    if (!self.hasBackup) return;
+
     NSPasteboard *pb = [NSPasteboard generalPasteboard];
 
     // Only restore if the clipboard hasn't been modified since we wrote to it
     if (pb.changeCount != self.writtenChangeCount) {
         NSLog(@"[Koe] Clipboard changed since write, skipping restore");
-        return;
-    }
-
-    if (!self.backedUpItems || self.backedUpItems.count == 0) {
+        self.backedUpItems = nil;
+        self.hasBackup = NO;
         return;
     }
 
     [pb clearContents];
-    [pb writeObjects:self.backedUpItems];
+    if (self.backedUpItems.count > 0) {
+        [pb writeObjects:self.backedUpItems];
+    }
+    NSLog(@"[Koe] Clipboard restored%@", self.backedUpItems.count == 0 ? @" (was empty)" : @"");
     self.backedUpItems = nil;
-    NSLog(@"[Koe] Clipboard restored");
+    self.hasBackup = NO;
 }
 
 @end


### PR DESCRIPTION
## Summary

When the clipboard was empty before a dictation session, `restoreIfUnchanged` checked `backedUpItems.count == 0` and returned early without clearing the clipboard. The dictated text was permanently left in the clipboard instead of being restored to the original empty state.

Root cause: the code could not distinguish "never backed up" (should skip restore) from "backed up an empty clipboard" (should clear contents to restore).

- Add a `hasBackup` boolean flag set in `backup` and cleared after restore
- `scheduleRestoreAfterDelay:` and `restoreIfUnchanged` now use `hasBackup` as the guard
- `restoreIfUnchanged` always calls `clearContents`, then only calls `writeObjects` if the backup had items

## Test plan

- [x] `xcodebuild` passes
- [ ] Clear the clipboard completely, run a dictation session — after ~1.5s the clipboard returns to empty
- [ ] Copy some text, run a dictation session — clipboard restores to the original text
- [ ] Copy some text, run a dictation session, then manually paste something else within 1.5s — clipboard is not overwritten by the restore