### PR TITLE
fix(config): align FeedbackSection serde defaults with config YAML

### DIFF
--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -184,11 +184,11 @@ pub enum LlmMaxTokenParameter {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct FeedbackSection {
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub start_sound: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub stop_sound: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub error_sound: bool,
 }
 


### PR DESCRIPTION
## Summary

- FeedbackSection fields (`start_sound`, `stop_sound`, `error_sound`) used `#[serde(default = "default_true")]`, but `DEFAULT_CONFIG_YAML` sets them all to `false`. When the `feedback` section is missing from a user's config file, serde fills in `true`, causing sounds to turn on unexpectedly.
- Change serde defaults to `#[serde(default)]` (bool defaults to `false`) so they match the YAML template.

## Test plan

- [x] `cargo test -p koe-core` — 27 tests pass
- [ ] Remove `feedback` section from `~/.koe/config.yaml`, relaunch app, verify no startup/stop sounds play