### PR TITLE
fix(asr): skip spurious empty Interim events in qwen and doubao providers

### DIFF
--- a/koe-asr/src/doubao.rs
+++ b/koe-asr/src/doubao.rs
@@ -382,7 +382,12 @@ impl AsrProvider for DoubaoWsProvider {
     }
 
     async fn next_event(&mut self) -> Result<AsrEvent> {
-        if let Some(ref mut ws) = self.ws {
+        let ws = self
+            .ws
+            .as_mut()
+            .ok_or_else(|| AsrError::Connection("not connected".into()))?;
+
+        loop {
             match ws.next().await {
                 Some(Ok(Message::Binary(data))) => match Self::parse_server_response(&data)? {
                     ServerMessage::Response { json, is_last } => {
@@ -407,11 +412,11 @@ impl AsrProvider for DoubaoWsProvider {
                             .unwrap_or(false);
 
                         if is_last {
-                            Ok(AsrEvent::Final(text))
+                            return Ok(AsrEvent::Final(text));
                         } else if has_definite {
-                            Ok(AsrEvent::Definite(text))
+                            return Ok(AsrEvent::Definite(text));
                         } else {
-                            Ok(AsrEvent::Interim(text))
+                            return Ok(AsrEvent::Interim(text));
                         }
                     }
                     ServerMessage::Error { code, message } => {
@@ -419,18 +424,18 @@ impl AsrProvider for DoubaoWsProvider {
                             "ASR error: code={code}, message={message}, logid={:?}",
                             self.logid
                         );
-                        Err(AsrError::Protocol(format!(
+                        return Err(AsrError::Protocol(format!(
                             "server error {code}: {message}"
-                        )))
+                        )));
                     }
                 },
-                Some(Ok(Message::Close(_))) => Ok(AsrEvent::Closed),
-                Some(Ok(_)) => Ok(AsrEvent::Interim(String::new())),
-                Some(Err(e)) => Err(AsrError::Protocol(e.to_string())),
-                None => Ok(AsrEvent::Closed),
+                Some(Ok(Message::Close(_))) => return Ok(AsrEvent::Closed),
+                Some(Ok(frame)) => {
+                    log::debug!("[Doubao ASR] Skipping frame: {:?}", frame);
+                }
+                Some(Err(e)) => return Err(AsrError::Protocol(e.to_string())),
+                None => return Ok(AsrEvent::Closed),
             }
-        } else {
-            Err(AsrError::Connection("not connected".into()))
         }
     }
 

--- a/koe-asr/src/qwen.rs
+++ b/koe-asr/src/qwen.rs
@@ -309,30 +309,36 @@ impl AsrProvider for QwenAsrProvider {
             return Ok(event);
         }
 
-        if let Some(ref mut ws) = self.ws {
-            match ws.next().await {
+        loop {
+            let msg = self
+                .ws
+                .as_mut()
+                .ok_or_else(|| AsrError::Connection("not connected".into()))?
+                .next()
+                .await;
+
+            match msg {
                 Some(Ok(Message::Text(text))) => {
                     let events = self.parse_server_event(&text)?;
                     self.pending_events.extend(events);
-                    Ok(self
-                        .pending_events
-                        .pop_front()
-                        .unwrap_or_else(|| AsrEvent::Interim(String::new())))
+                    if let Some(event) = self.pending_events.pop_front() {
+                        return Ok(event);
+                    }
+                    log::debug!("[Qwen ASR] Skipping text frame with no parseable events");
                 }
-                Some(Ok(Message::Close(_))) => Ok(AsrEvent::Closed),
+                Some(Ok(Message::Close(_))) => return Ok(AsrEvent::Closed),
                 Some(Ok(Message::Binary(data))) => {
                     log::debug!(
-                        "[Qwen ASR] Ignoring binary message ({} bytes)",
+                        "[Qwen ASR] Skipping binary frame ({} bytes)",
                         data.len()
                     );
-                    Ok(AsrEvent::Interim(String::new()))
                 }
-                Some(Ok(_)) => Ok(AsrEvent::Interim(String::new())),
-                Some(Err(e)) => Err(AsrError::Protocol(e.to_string())),
-                None => Ok(AsrEvent::Closed),
+                Some(Ok(frame)) => {
+                    log::debug!("[Qwen ASR] Skipping frame: {:?}", frame);
+                }
+                Some(Err(e)) => return Err(AsrError::Protocol(e.to_string())),
+                None => return Ok(AsrEvent::Closed),
             }
-        } else {
-            Err(AsrError::Connection("not connected".into()))
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace `AsrEvent::Interim(String::new())` fallbacks with a `loop` that skips meaningless WS frames (binary, ping/pong, empty parse results) and waits for the next real event
- Each skipped frame logs at `debug` level for protocol debugging
- Close, error, and stream-end branches remain unchanged

### Problem

Both `QwenProvider::next_event()` and `DoubaoProvider::next_event()` return a fabricated empty `Interim("")` event when they encounter non-data frames (binary, ping/pong) or when `parse_server_event` produces no events. Providers should not synthesize transcript events for frames that carry no speech data. While the core layer already guards against empty text (`!text.is_empty()`), the spurious events still cause unnecessary polling and pollute debug logs.

### Fix

Wrap the WS read in a `loop` so meaningless frames are skipped via `continue` instead of producing fake events. This cleanly separates "ignore this frame" from "emit a real ASR event" without touching the terminal branches (Close / Err / None).

## Files Changed

- `koe-asr/src/qwen.rs` — `next_event()`
- `koe-asr/src/doubao.rs` — `next_event()`

## Test Plan

- [x] `cargo check -p koe-asr` passes
- [x] `cargo test -p koe-asr` — all 10 tests pass
- [ ] Verify hold-to-talk and tap-to-toggle both work with Qwen provider
- [ ] Verify hold-to-talk and tap-to-toggle both work with Doubao provider