### PR TITLE
fix(wizard): read ASR test URLs from config instead of hardcoding

### DIFF
--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1481,7 +1481,9 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     self.asrTestResultLabel.textColor = [NSColor secondaryLabelColor];
 
     // Create WebSocket connection test
-    NSURL *url = [NSURL URLWithString:@"wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async"];
+    NSString *doubaoUrl = configGet(@"asr.doubao.url");
+    if (doubaoUrl.length == 0) doubaoUrl = @"wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async";
+    NSURL *url = [NSURL URLWithString:doubaoUrl];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     request.timeoutInterval = 5;
 
@@ -1597,7 +1599,11 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     self.asrTestResultLabel.textColor = [NSColor secondaryLabelColor];
 
     // Create WebSocket connection test
-    NSURL *url = [NSURL URLWithString:@"wss://dashscope.aliyuncs.com/api-ws/v1/realtime?model=qwen3-asr-flash-realtime"];
+    NSString *qwenBaseUrl = configGet(@"asr.qwen.url");
+    if (qwenBaseUrl.length == 0) qwenBaseUrl = @"wss://dashscope.aliyuncs.com/api-ws/v1/realtime";
+    NSString *qwenModel = configGet(@"asr.qwen.model");
+    if (qwenModel.length == 0) qwenModel = @"qwen3-asr-flash-realtime";
+    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@?model=%@", qwenBaseUrl, qwenModel]];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     request.timeoutInterval = 10;
 


### PR DESCRIPTION
## Summary

- Read `asr.doubao.url`, `asr.qwen.url`, and `asr.qwen.model` from user configuration instead of hardcoding WebSocket URLs in the setup wizard test buttons
- Fall back to default values when config entries are empty

Fixes #58

## Test plan

- [ ] Set custom `asr.qwen.url` and `asr.qwen.model` in `~/.koe/config.yaml`, verify the Test button connects to the custom endpoint
- [ ] Set custom `asr.doubao.url` in `~/.koe/config.yaml`, verify the Test button connects to the custom endpoint
- [ ] Leave config entries empty, verify the Test button still uses default URLs
- [x] Run `make build` to ensure the app builds