### PR TITLE
fix(hotkey): close race window between menuDidClose and quit action

### DIFF
--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -452,7 +452,14 @@
 }
 
 - (void)statusBarMenuDidClose {
-    self.hotkeyMonitor.suspended = NO;
+    // Defer unsuspend to the next run-loop iteration so that any menu-item
+    // action (e.g. Quit → stop()) executes first.  Without this, Cocoa's
+    // menuDidClose: fires before the item action, resetting suspended=NO
+    // and allowing FlagsChanged events through the NSEvent monitor path
+    // before stop() has a chance to set running=NO.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.hotkeyMonitor.suspended = NO;
+    });
 }
 
 - (void)statusBarDidSelectQuit {


### PR DESCRIPTION
## Summary

Follows up on 527ee64, which added a `running` flag to guard `handleTriggerDown`/`handleTriggerUp` against in-flight dispatched blocks after `stop()`. Users on the alpha channel still reported phantom key presses on quit (#57), because that fix left a synchronous race window uncovered.

### Root cause

Cocoa fires `menuDidClose:` **before** the menu-item action. The previous code reset `suspended = NO` immediately in `statusBarMenuDidClose`, re-activating the hotkey monitor before `statusBarDidSelectQuit` had a chance to call `stop()`. During this window:

- `suspended` is `NO` (just reset by `menuDidClose:`)
- `running` is still `YES` (only cleared later in `stop()`)

FlagsChanged events from the user releasing keys after clicking Quit pass both guards and reach `handleTriggerDown` synchronously via the NSEvent monitor path, potentially starting a recording session and firing Cmd+V into the frontmost app.

The `running` flag from 527ee64 only protects against the **CGEventTap path**, where `handleTriggerDown` is called via `dispatch_async` and executes after `stop()` has already set `running = NO`. It does not protect the **NSEvent path**, which processes events synchronously within the same run-loop iteration — before the action method runs.

### Fix

Defer the `suspended = NO` reset in `statusBarMenuDidClose` to the next run-loop iteration via `dispatch_async(dispatch_get_main_queue(), ...)`. Since `menuDidClose:` and the menu-item action execute synchronously within the same event-processing pass, the deferred block is guaranteed to run **after** `statusBarDidSelectQuit` → `stop()` has already removed all monitors and set `running = NO`.

This closes the synchronous race window that 527ee64 missed, and together they provide three layers of defense:

1. **`suspended` stays `YES`** throughout the action method (deferred unsuspend)
2. **`running = NO`** catches any CGEventTap `dispatch_async` blocks that were already enqueued
3. **Explicit `suspended = YES`** in `statusBarDidSelectQuit` as belt-and-suspenders

For the normal (non-quit) menu-close path, the one-iteration delay before unsuspend is imperceptible.

Fixes #57.