### PR TITLE
feat(app): add template workflow and configurable overlay controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable user-facing changes to Koe are documented here.
 ### Added
 
 - Added a full overlay lifecycle that now shows interim ASR text, final ASR text, corrected text, and optional post-processing actions without disappearing too early.
+- Added an Overlay settings pane for choosing the live transcript font family, text size, bottom offset, and long-text visibility rules.
 - Added a Templates settings pane for managing prompt templates, including add, remove, edit, reorder, and per-template visibility control.
 - Added overlay rewrite templates with click, hover, and contextual `1-9` shortcuts for fast second-pass rewriting.
 - Added configurable trigger modes so users can choose `hold` or `toggle`.
@@ -14,6 +15,9 @@ All notable user-facing changes to Koe are documented here.
 
 ### Changed
 
+- Changed Overlay settings to preview directly in the real desktop overlay position instead of maintaining a second in-window mock preview.
+- Changed long live transcript rendering so the overlay can either stay capped to `3-5` visible lines or expand fully, depending on user preference.
+- Changed overlay spacing, corner radius, and text layout to scale with the selected font for a more consistent appearance.
 - Simplified the hotkey model to a single trigger shortcut that handles both start and stop behavior.
 - Standardized the settings experience so Controls, LLM, and Templates use more consistent native AppKit switches, segmented controls, spacing, and card surfaces.
 - Reduced the built-in prompt template set to a minimal default starter template for English translation.
@@ -21,6 +25,9 @@ All notable user-facing changes to Koe are documented here.
 
 ### Fixed
 
+- Fixed long interim transcript overflow so capped overlays now scroll within the bubble instead of spilling outside the frame.
+- Fixed overlay edge artifacts during long-text scrolling, including dark bands and fade masks that obscured text near the bubble edges.
+- Fixed overlay preview cleanup so unsaved style changes no longer leak after closing Settings or switching panes.
 - Fixed prompt template editor state sync so prompt content no longer leaks between rows or disappears when switching templates.
 - Fixed overlay template visibility and prompt restoration when creating new templates and switching back to existing ones.
 - Fixed number shortcut handling so `1-9` template shortcuts no longer leak digits into the focused app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable user-facing changes to Koe are documented here.
+
+## 1.0.14 - 2026-04-09
+
+### Added
+
+- Added a full overlay lifecycle that now shows interim ASR text, final ASR text, corrected text, and optional post-processing actions without disappearing too early.
+- Added a Templates settings pane for managing prompt templates, including add, remove, edit, reorder, and per-template visibility control.
+- Added overlay rewrite templates with click, hover, and contextual `1-9` shortcuts for fast second-pass rewriting.
+- Added configurable trigger modes so users can choose `hold` or `toggle`.
+- Added custom shortcut recording for trigger shortcuts, including modifier combinations.
+
+### Changed
+
+- Simplified the hotkey model to a single trigger shortcut that handles both start and stop behavior.
+- Standardized the settings experience so Controls, LLM, and Templates use more consistent native AppKit switches, segmented controls, spacing, and card surfaces.
+- Reduced the built-in prompt template set to a minimal default starter template for English translation.
+- Changed template rewrites to copy the rewritten result to the clipboard instead of auto-pasting it immediately.
+
+### Fixed
+
+- Fixed prompt template editor state sync so prompt content no longer leaks between rows or disappears when switching templates.
+- Fixed overlay template visibility and prompt restoration when creating new templates and switching back to existing ones.
+- Fixed number shortcut handling so `1-9` template shortcuts no longer leak digits into the focused app.
+- Fixed recorded trigger combinations so modifier shortcuts no longer leak characters like `®` into the focused app.
+- Fixed keyboard and mouse interaction polish for template buttons and overlay selection states.
+
+### Contributors
+
+- Vincent Yang
+- luolei
+
+## 1.0.13 - 2026-04-05
+
+### Added
+
+- Added Apple Speech provider for zero-config on-device ASR on macOS 26+.
+- Added custom HTTP headers support for third-party ASR WebSocket endpoints.
+- Added `no_reasoning_control` for LLM providers that need reasoning/thinking suppression.
+
+### Fixed
+
+- Fixed repeated accessibility permission prompts and added direct grant actions from the menu.
+- Fixed clipboard restore behavior when the pre-dictation clipboard was empty.
+- Fixed state machine races between Rust and Objective-C after text delivery.
+- Fixed audio capture startup failures and session startup error handling.
+- Fixed the hotkey race window between menu close and quit.
+- Reduced privacy exposure by redacting transcription text from INFO logs.
+- Hardened config writes with atomic file replacement.
+- Centralized workspace dependencies for more consistent builds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,4 +45,5 @@ Scope is auto-detected from file paths (e.g., `asr`, `llm`, `ui`, `config`). Bre
 - Ensure the app still builds (`make build`)
 - Verify hold-to-talk and tap-to-toggle both work
 - Update docs if you changed any user-facing behavior
+- For release-worthy user-facing changes, update both `CHANGELOG.md` and `docs/update-feed.json`
 - See the [Contributing Guide](https://koe.li/docs/contributing) for the full contributor workflow

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -13,6 +13,7 @@
 #import "SPSetupWizardWindowController.h"
 #import "SPUpdateManager.h"
 #import "koe_core.h"
+#import <os/log.h>
 #import <sys/stat.h>
 #import <UserNotifications/UserNotifications.h>
 
@@ -27,13 +28,54 @@
 
 @implementation SPAppDelegate
 
+static BOOL configFlagEnabled(const char *keyPath) {
+    char *rawValue = sp_config_get(keyPath);
+    if (!rawValue) return NO;
+
+    BOOL enabled = strcmp(rawValue, "true") == 0;
+    sp_core_free_string(rawValue);
+    return enabled;
+}
+
+- (BOOL)shouldShowPromptTemplateButtons {
+    return configFlagEnabled("llm.prompt_templates_enabled");
+}
+
+- (void)showPromptTemplateButtonsIfNeededOrDismiss {
+    if (![self shouldShowPromptTemplateButtons]) {
+        [self.overlayPanel lingerAndDismiss];
+        return;
+    }
+
+    NSArray *templates = [self.rustBridge promptTemplates];
+    NSMutableArray<NSDictionary *> *visibleTemplates = [NSMutableArray array];
+    NSInteger visibleShortcut = 1;
+    for (NSUInteger index = 0; index < templates.count; index++) {
+        NSDictionary *templateData = templates[index];
+        id enabledValue = templateData[@"enabled"];
+        BOOL enabled = ![enabledValue isKindOfClass:[NSNumber class]] || [enabledValue boolValue];
+        if (!enabled) continue;
+
+        NSMutableDictionary *overlayTemplate = [templateData mutableCopy] ?: [NSMutableDictionary dictionary];
+        overlayTemplate[@"shortcut"] = @(visibleShortcut++);
+        overlayTemplate[@"source_index"] = @(index);
+        [visibleTemplates addObject:overlayTemplate];
+    }
+
+    NSLog(@"[Koe] Prompt templates visible: %lu / %lu", (unsigned long)visibleTemplates.count, (unsigned long)templates.count);
+    if (visibleTemplates.count > 0 && self.lastAsrText.length > 0) {
+        [self.overlayPanel showTemplateButtons:visibleTemplates];
+        [self startNumberKeyMonitoring];
+    } else {
+        [self.overlayPanel lingerAndDismiss];
+    }
+}
+
 - (void)applyHotkeyConfig:(struct SPHotkeyConfig)hotkeyConfig restartMonitorIfNeeded:(BOOL)restartIfNeeded {
     BOOL changed = self.hotkeyMonitor.targetKeyCode != hotkeyConfig.trigger_key_code ||
                    self.hotkeyMonitor.altKeyCode != hotkeyConfig.trigger_alt_key_code ||
                    self.hotkeyMonitor.targetModifierFlag != hotkeyConfig.trigger_modifier_flag ||
-                   self.hotkeyMonitor.cancelKeyCode != hotkeyConfig.cancel_key_code ||
-                   self.hotkeyMonitor.cancelAltKeyCode != hotkeyConfig.cancel_alt_key_code ||
-                   self.hotkeyMonitor.cancelModifierFlag != hotkeyConfig.cancel_modifier_flag ||
+                   self.hotkeyMonitor.targetMatchKind != hotkeyConfig.trigger_match_kind ||
                    self.hotkeyMonitor.triggerMode != hotkeyConfig.trigger_mode;
 
     if (!changed) return;
@@ -45,9 +87,7 @@
     self.hotkeyMonitor.targetKeyCode = hotkeyConfig.trigger_key_code;
     self.hotkeyMonitor.altKeyCode = hotkeyConfig.trigger_alt_key_code;
     self.hotkeyMonitor.targetModifierFlag = hotkeyConfig.trigger_modifier_flag;
-    self.hotkeyMonitor.cancelKeyCode = hotkeyConfig.cancel_key_code;
-    self.hotkeyMonitor.cancelAltKeyCode = hotkeyConfig.cancel_alt_key_code;
-    self.hotkeyMonitor.cancelModifierFlag = hotkeyConfig.cancel_modifier_flag;
+    self.hotkeyMonitor.targetMatchKind = hotkeyConfig.trigger_match_kind;
     self.hotkeyMonitor.triggerMode = hotkeyConfig.trigger_mode;
 
     if (restartIfNeeded) {
@@ -215,13 +255,11 @@
     // Read new hotkey config
     struct SPHotkeyConfig newConfig = sp_core_get_hotkey_config();
 
-    NSLog(@"[Koe] Reloaded hotkey config: trigger=%d/%d flag=0x%llx cancel=%d/%d flag=0x%llx",
+    NSLog(@"[Koe] Reloaded hotkey config: trigger=%d/%d flag=0x%llx kind=%d",
           newConfig.trigger_key_code,
           newConfig.trigger_alt_key_code,
           (unsigned long long)newConfig.trigger_modifier_flag,
-          newConfig.cancel_key_code,
-          newConfig.cancel_alt_key_code,
-          (unsigned long long)newConfig.cancel_modifier_flag);
+          newConfig.trigger_match_kind);
     [self applyHotkeyConfig:newConfig restartMonitorIfNeeded:YES];
 }
 
@@ -324,17 +362,6 @@
                    dispatch_get_main_queue(), block);
 }
 
-- (void)hotkeyMonitorDidDetectCancel {
-    NSLog(@"[Koe] Cancel detected");
-    [self stopNumberKeyMonitoring];
-    [self cancelPendingSessionEnd];
-    [self.audioCaptureManager stopCapture];
-    [self.rustBridge cancelSession];
-    self.recordingStartTime = nil;
-    [self.statusBarManager updateState:@"idle"];
-    [self.overlayPanel updateState:@"idle"];
-}
-
 #pragma mark - SPRustBridgeDelegate
 
 - (void)rustBridgeDidBecomeReady {
@@ -374,31 +401,18 @@
             [self.clipboardManager scheduleRestoreAfterDelay:1500];
             if (token != self.rustBridge.currentSessionToken) return;
             [self.statusBarManager updateState:@"idle"];
-            // Check if prompt templates are available for rewrite
-            NSArray *templates = [self.rustBridge promptTemplates];
-            NSLog(@"[Koe] Prompt templates: %lu", (unsigned long)templates.count);
-            if (templates.count > 0 && self.lastAsrText.length > 0) {
-                [self.overlayPanel showTemplateButtons:templates];
-                [self startNumberKeyMonitoring];
-            } else {
-                [self.overlayPanel lingerAndDismiss];
-            }
+            [self showPromptTemplateButtonsIfNeededOrDismiss];
         }];
     } else {
         NSLog(@"[Koe] Accessibility not granted — text copied to clipboard only");
         [self.statusBarManager updateState:@"idle"];
-        NSArray *templates = [self.rustBridge promptTemplates];
-        if (templates.count > 0 && self.lastAsrText.length > 0) {
-            [self.overlayPanel showTemplateButtons:templates];
-            [self startNumberKeyMonitoring];
-        } else {
-            [self.overlayPanel lingerAndDismiss];
-        }
+        [self showPromptTemplateButtonsIfNeededOrDismiss];
     }
 }
 
 - (void)rustBridgeDidEncounterError:(NSString *)message {
     if (self.quitting) return;
+    os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_ERROR, "[Koe] Session error: %{public}@", message ?: @"unknown error");
     NSLog(@"[Koe] Session error: %@", message);
     self.showingError = YES;
     [self.cuePlayer playError];
@@ -461,6 +475,7 @@
 }
 
 - (void)rustBridgeDidReceiveWarning:(NSString *)message {
+    os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_DEFAULT, "[Koe] Session warning: %{public}@", message ?: @"unknown warning");
     NSLog(@"[Koe] Session warning: %@", message);
     [self sendWarningNotification:message];
 }
@@ -477,6 +492,8 @@
 
 - (void)rustBridgeDidReceiveRewriteText:(NSString *)text {
     NSLog(@"[Koe] Rewrite text received (%lu chars)", (unsigned long)text.length);
+
+    [self.clipboardManager cancelPendingRestore];
 
     // Copy to clipboard (no auto-paste — user decides where to paste)
     [self.clipboardManager writeText:text];
@@ -583,6 +600,11 @@
     NSLog(@"[Koe] Setup wizard saved config, reloading...");
     [self.rustBridge reloadConfig];
 
+    if (![self shouldShowPromptTemplateButtons]) {
+        [self stopNumberKeyMonitoring];
+        [self.overlayPanel hideTemplateButtons];
+    }
+
     // Re-apply hotkey config
     struct SPHotkeyConfig newConfig = sp_core_get_hotkey_config();
     [self applyHotkeyConfig:newConfig restartMonitorIfNeeded:YES];
@@ -594,6 +616,7 @@
 - (void)overlayPanel:(id)panel didSelectTemplateAtIndex:(NSInteger)templateIndex {
     NSLog(@"[Koe] Template selected: index %ld", (long)templateIndex);
     [self stopNumberKeyMonitoring];
+    [self.clipboardManager cancelPendingRestore];
 
     // Show rewriting state
     [self.overlayPanel updateState:@"correcting"];
@@ -608,14 +631,23 @@
 #pragma mark - Number Key Monitoring
 
 - (void)startNumberKeyMonitoring {
-    // Number key handling is done by the SPKeyablePanel (button bar) itself.
-    // It becomes key window and receives keyDown: events directly.
-    // This method is kept for the start/stop logging pattern.
-    NSLog(@"[Koe] Number key monitoring active (via button bar key window)");
+    __weak typeof(self) weakSelf = self;
+    self.hotkeyMonitor.numberKeyHandler = ^BOOL(NSInteger number) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return NO;
+
+        BOOL handled = [strongSelf.overlayPanel handleNumberKey:number];
+        if (handled) {
+            NSLog(@"[Koe] Template shortcut triggered: %ld", (long)number);
+        }
+        return handled;
+    };
+    NSLog(@"[Koe] Template selector visible (global number shortcuts active)");
 }
 
 - (void)stopNumberKeyMonitoring {
-    NSLog(@"[Koe] Number key monitoring stopped");
+    self.hotkeyMonitor.numberKeyHandler = nil;
+    NSLog(@"[Koe] Template selector hidden");
 }
 
 @end

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -31,7 +31,8 @@
                    self.hotkeyMonitor.targetModifierFlag != hotkeyConfig.trigger_modifier_flag ||
                    self.hotkeyMonitor.cancelKeyCode != hotkeyConfig.cancel_key_code ||
                    self.hotkeyMonitor.cancelAltKeyCode != hotkeyConfig.cancel_alt_key_code ||
-                   self.hotkeyMonitor.cancelModifierFlag != hotkeyConfig.cancel_modifier_flag;
+                   self.hotkeyMonitor.cancelModifierFlag != hotkeyConfig.cancel_modifier_flag ||
+                   self.hotkeyMonitor.triggerMode != hotkeyConfig.trigger_mode;
 
     if (!changed) return;
 
@@ -45,6 +46,7 @@
     self.hotkeyMonitor.cancelKeyCode = hotkeyConfig.cancel_key_code;
     self.hotkeyMonitor.cancelAltKeyCode = hotkeyConfig.cancel_alt_key_code;
     self.hotkeyMonitor.cancelModifierFlag = hotkeyConfig.cancel_modifier_flag;
+    self.hotkeyMonitor.triggerMode = hotkeyConfig.trigger_mode;
 
     if (restartIfNeeded) {
         [self.hotkeyMonitor start];
@@ -343,6 +345,9 @@
     }
     [[SPHistoryManager sharedManager] recordSessionWithDurationMs:durationMs text:text];
 
+    // Show corrected text in overlay before pasting
+    [self.overlayPanel updateDisplayText:text];
+
     [self.statusBarManager updateState:@"pasting"];
     [self.overlayPanel updateState:@"pasting"];
 
@@ -350,21 +355,20 @@
     [self.clipboardManager backup];
     [self.clipboardManager writeText:text];
 
-    // Capture token so the async completion can detect a stale session
     uint64_t token = self.rustBridge.currentSessionToken;
 
-    // Check if accessibility is available for auto-paste
     if ([self.permissionManager isAccessibilityGranted]) {
         [self.pasteManager simulatePasteWithCompletion:^{
             [self.clipboardManager scheduleRestoreAfterDelay:1500];
             if (token != self.rustBridge.currentSessionToken) return;
             [self.statusBarManager updateState:@"idle"];
-            [self.overlayPanel updateState:@"idle"];
+            // Linger to show the final result before dismissing
+            [self.overlayPanel lingerAndDismiss];
         }];
     } else {
         NSLog(@"[Koe] Accessibility not granted — text copied to clipboard only");
         [self.statusBarManager updateState:@"idle"];
-        [self.overlayPanel updateState:@"idle"];
+        [self.overlayPanel lingerAndDismiss];
     }
 }
 
@@ -438,6 +442,11 @@
 
 - (void)rustBridgeDidReceiveInterimText:(NSString *)text {
     [self.overlayPanel updateInterimText:text];
+}
+
+- (void)rustBridgeDidReceiveAsrFinalText:(NSString *)text {
+    NSLog(@"[Koe] ASR final text: %lu chars", (unsigned long)text.length);
+    [self.overlayPanel updateDisplayText:text];
 }
 
 - (void)rustBridgeDidChangeState:(NSString *)state {

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -22,6 +22,7 @@
 @property (nonatomic, copy) dispatch_block_t pendingSessionEndBlock;
 @property (nonatomic, assign) BOOL showingError;
 @property (nonatomic, copy) NSString *lastAsrText;
+@property (nonatomic, strong) id numberKeyMonitor;
 @end
 
 @implementation SPAppDelegate
@@ -601,17 +602,13 @@
 #pragma mark - Number Key Monitoring
 
 - (void)startNumberKeyMonitoring {
-    __weak typeof(self) weakSelf = self;
-    self.hotkeyMonitor.numberKeyHandler = ^(NSInteger number) {
-        if ([weakSelf.overlayPanel handleNumberKey:number]) {
-            [weakSelf stopNumberKeyMonitoring];
-        }
-    };
-    NSLog(@"[Koe] Number key monitoring started");
+    // Number key handling is done by the SPKeyablePanel (button bar) itself.
+    // It becomes key window and receives keyDown: events directly.
+    // This method is kept for the start/stop logging pattern.
+    NSLog(@"[Koe] Number key monitoring active (via button bar key window)");
 }
 
 - (void)stopNumberKeyMonitoring {
-    self.hotkeyMonitor.numberKeyHandler = nil;
     NSLog(@"[Koe] Number key monitoring stopped");
 }
 

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -22,8 +22,51 @@
 @property (nonatomic, copy) dispatch_block_t pendingSessionEndBlock;
 @property (nonatomic, assign) BOOL showingError;
 @property (nonatomic, copy) NSString *lastAsrText;
-@property (nonatomic, strong) id numberKeyMonitor;
+@property (nonatomic, assign) CFMachPortRef numberKeyTap;
+@property (nonatomic, assign) CFRunLoopSourceRef numberKeyRunLoopSource;
 @end
+
+// ─── CGEventTap callback for number key monitoring ─────────────────
+static CGEventRef numberKeyTapCallback(CGEventTapProxy proxy,
+                                        CGEventType type,
+                                        CGEventRef event,
+                                        void *userInfo) {
+    SPAppDelegate *delegate = (__bridge SPAppDelegate *)userInfo;
+
+    if (type == kCGEventTapDisabledByTimeout || type == kCGEventTapDisabledByUserInput) {
+        if (delegate.numberKeyTap) {
+            CGEventTapEnable(delegate.numberKeyTap, true);
+        }
+        return event;
+    }
+
+    if (type == kCGEventKeyDown) {
+        int64_t keyCode = CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
+        // keycodes 18-26 = number keys 1-9 on main keyboard
+        if (keyCode >= 18 && keyCode <= 26) {
+            // Map keycode to number: 18=1, 19=2, 20=3, 21=4, 23=5, 22=6, 26=7, 28=8, 25=9
+            // Actually macOS keycodes for 1-9 are: 18,19,20,21,23,22,26,28,25
+            static const int keycodeToNumber[] = {
+                [18] = 1, [19] = 2, [20] = 3, [21] = 4, [23] = 5,
+                [22] = 6, [26] = 7, [28] = 8, [25] = 9,
+            };
+            if (keyCode <= 28) {
+                NSInteger number = keycodeToNumber[keyCode];
+                if (number >= 1 && number <= 9) {
+                    // Disable tap immediately to prevent double-firing
+                    CGEventTapEnable(delegate.numberKeyTap, false);
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [delegate.overlayPanel handleNumberKey:number];
+                        // Full cleanup on main thread
+                        [delegate performSelector:@selector(stopNumberKeyMonitoring)];
+                    });
+                }
+            }
+        }
+    }
+
+    return event;
+}
 
 @implementation SPAppDelegate
 
@@ -603,27 +646,34 @@
 
 - (void)startNumberKeyMonitoring {
     [self stopNumberKeyMonitoring];
-    __weak typeof(self) weakSelf = self;
-    self.numberKeyMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown
-                                                                 handler:^NSEvent *(NSEvent *event) {
-        NSString *chars = event.charactersIgnoringModifiers;
-        if (chars.length == 1) {
-            unichar ch = [chars characterAtIndex:0];
-            if (ch >= '1' && ch <= '9') {
-                NSInteger number = ch - '0';
-                if ([weakSelf.overlayPanel handleNumberKey:number]) {
-                    return nil; // Consume the event
-                }
-            }
-        }
-        return event;
-    }];
+    CGEventMask mask = CGEventMaskBit(kCGEventKeyDown);
+    self.numberKeyTap = CGEventTapCreate(kCGHIDEventTap,
+                                          kCGHeadInsertEventTap,
+                                          kCGEventTapOptionListenOnly,
+                                          mask,
+                                          numberKeyTapCallback,
+                                          (__bridge void *)self);
+    if (self.numberKeyTap) {
+        self.numberKeyRunLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, self.numberKeyTap, 0);
+        CFRunLoopAddSource(CFRunLoopGetMain(), self.numberKeyRunLoopSource, kCFRunLoopCommonModes);
+        CGEventTapEnable(self.numberKeyTap, true);
+        NSLog(@"[Koe] Number key monitoring started (CGEventTap)");
+    } else {
+        NSLog(@"[Koe] Failed to create number key event tap");
+    }
 }
 
 - (void)stopNumberKeyMonitoring {
-    if (self.numberKeyMonitor) {
-        [NSEvent removeMonitor:self.numberKeyMonitor];
-        self.numberKeyMonitor = nil;
+    if (self.numberKeyRunLoopSource) {
+        CFRunLoopRemoveSource(CFRunLoopGetMain(), self.numberKeyRunLoopSource, kCFRunLoopCommonModes);
+        CFRelease(self.numberKeyRunLoopSource);
+        self.numberKeyRunLoopSource = NULL;
+    }
+    if (self.numberKeyTap) {
+        CGEventTapEnable(self.numberKeyTap, false);
+        CFRelease(self.numberKeyTap);
+        self.numberKeyTap = NULL;
+        NSLog(@"[Koe] Number key monitoring stopped");
     }
 }
 

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -473,13 +473,28 @@
 - (void)rustBridgeDidReceiveRewriteText:(NSString *)text {
     NSLog(@"[Koe] Rewrite text received (%lu chars)", (unsigned long)text.length);
 
-    // Copy to clipboard (don't auto-paste)
+    // Show rewritten text in overlay
+    [self.overlayPanel updateDisplayText:text];
+    [self.overlayPanel updateState:@"pasting"];
+
+    // Write to clipboard and auto-paste
+    [self.clipboardManager backup];
     [self.clipboardManager writeText:text];
 
-    // Show result with "Copied" indicator
-    [self.overlayPanel updateDisplayText:text];
-    [self.overlayPanel updateState:@"pasting"]; // green checkmark
-    [self.overlayPanel lingerAndDismiss];
+    uint64_t token = self.rustBridge.currentSessionToken;
+
+    if ([self.permissionManager isAccessibilityGranted]) {
+        [self.pasteManager simulatePasteWithCompletion:^{
+            [self.clipboardManager scheduleRestoreAfterDelay:1500];
+            if (token != self.rustBridge.currentSessionToken) return;
+            [self.statusBarManager updateState:@"idle"];
+            [self.overlayPanel lingerAndDismiss];
+        }];
+    } else {
+        NSLog(@"[Koe] Accessibility not granted — rewrite text copied to clipboard only");
+        [self.statusBarManager updateState:@"idle"];
+        [self.overlayPanel lingerAndDismiss];
+    }
 }
 
 - (void)rustBridgeDidChangeState:(NSString *)state {

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -16,11 +16,13 @@
 #import <sys/stat.h>
 #import <UserNotifications/UserNotifications.h>
 
-@interface SPAppDelegate () <SPAudioDeviceManagerDelegate>
+@interface SPAppDelegate () <SPAudioDeviceManagerDelegate, SPOverlayPanelDelegate>
 @property (nonatomic, strong) NSDate *recordingStartTime;
 @property (nonatomic, assign) time_t lastConfigModTime;
 @property (nonatomic, copy) dispatch_block_t pendingSessionEndBlock;
 @property (nonatomic, assign) BOOL showingError;
+@property (nonatomic, copy) NSString *lastAsrText;
+@property (nonatomic, strong) id numberKeyMonitor;
 @end
 
 @implementation SPAppDelegate
@@ -80,6 +82,7 @@
 
     // Initialize floating overlay
     self.overlayPanel = [[SPOverlayPanel alloc] init];
+    self.overlayPanel.delegate = self;
 
     // Initialize app update checker
     self.updateManager = [[SPUpdateManager alloc] initWithBundle:[NSBundle mainBundle]];
@@ -233,6 +236,8 @@
 
 - (void)hotkeyMonitorDidDetectHoldStart {
     NSLog(@"[Koe] Hold start detected");
+    [self stopNumberKeyMonitoring];
+    [self.overlayPanel hideTemplateButtons];
     self.showingError = NO;
     [self cancelPendingSessionEnd];
     [self.audioCaptureManager stopCapture];
@@ -277,6 +282,8 @@
 
 - (void)hotkeyMonitorDidDetectTapStart {
     NSLog(@"[Koe] Tap start detected");
+    [self stopNumberKeyMonitoring];
+    [self.overlayPanel hideTemplateButtons];
     self.showingError = NO;
     [self cancelPendingSessionEnd];
     [self.audioCaptureManager stopCapture];
@@ -319,6 +326,7 @@
 
 - (void)hotkeyMonitorDidDetectCancel {
     NSLog(@"[Koe] Cancel detected");
+    [self stopNumberKeyMonitoring];
     [self cancelPendingSessionEnd];
     [self.audioCaptureManager stopCapture];
     [self.rustBridge cancelSession];
@@ -362,13 +370,25 @@
             [self.clipboardManager scheduleRestoreAfterDelay:1500];
             if (token != self.rustBridge.currentSessionToken) return;
             [self.statusBarManager updateState:@"idle"];
-            // Linger to show the final result before dismissing
-            [self.overlayPanel lingerAndDismiss];
+            // Check if prompt templates are available for rewrite
+            NSArray *templates = [self.rustBridge promptTemplates];
+            if (templates.count > 0 && self.lastAsrText.length > 0) {
+                [self.overlayPanel showTemplateButtons:templates];
+                [self startNumberKeyMonitoring];
+            } else {
+                [self.overlayPanel lingerAndDismiss];
+            }
         }];
     } else {
         NSLog(@"[Koe] Accessibility not granted — text copied to clipboard only");
         [self.statusBarManager updateState:@"idle"];
-        [self.overlayPanel lingerAndDismiss];
+        NSArray *templates = [self.rustBridge promptTemplates];
+        if (templates.count > 0 && self.lastAsrText.length > 0) {
+            [self.overlayPanel showTemplateButtons:templates];
+            [self startNumberKeyMonitoring];
+        } else {
+            [self.overlayPanel lingerAndDismiss];
+        }
     }
 }
 
@@ -446,7 +466,20 @@
 
 - (void)rustBridgeDidReceiveAsrFinalText:(NSString *)text {
     NSLog(@"[Koe] ASR final text: %lu chars", (unsigned long)text.length);
+    self.lastAsrText = text;
     [self.overlayPanel updateDisplayText:text];
+}
+
+- (void)rustBridgeDidReceiveRewriteText:(NSString *)text {
+    NSLog(@"[Koe] Rewrite text received (%lu chars)", (unsigned long)text.length);
+
+    // Copy to clipboard (don't auto-paste)
+    [self.clipboardManager writeText:text];
+
+    // Show result with "Copied" indicator
+    [self.overlayPanel updateDisplayText:text];
+    [self.overlayPanel updateState:@"pasting"]; // green checkmark
+    [self.overlayPanel lingerAndDismiss];
 }
 
 - (void)rustBridgeDidChangeState:(NSString *)state {
@@ -548,6 +581,50 @@
     struct SPHotkeyConfig newConfig = sp_core_get_hotkey_config();
     [self applyHotkeyConfig:newConfig restartMonitorIfNeeded:YES];
     NSLog(@"[Koe] Hotkey monitor reloaded after setup wizard save");
+}
+
+#pragma mark - SPOverlayPanelDelegate
+
+- (void)overlayPanel:(id)panel didSelectTemplateAtIndex:(NSInteger)templateIndex {
+    NSLog(@"[Koe] Template selected: index %ld", (long)templateIndex);
+    [self stopNumberKeyMonitoring];
+
+    // Show rewriting state
+    [self.overlayPanel updateState:@"correcting"];
+
+    // Trigger rewrite
+    if (![self.rustBridge rewriteWithTemplateIndex:templateIndex asrText:self.lastAsrText]) {
+        NSLog(@"[Koe] Rewrite failed to start");
+        [self.overlayPanel lingerAndDismiss];
+    }
+}
+
+#pragma mark - Number Key Monitoring
+
+- (void)startNumberKeyMonitoring {
+    [self stopNumberKeyMonitoring];
+    __weak typeof(self) weakSelf = self;
+    self.numberKeyMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown
+                                                                 handler:^NSEvent *(NSEvent *event) {
+        NSString *chars = event.charactersIgnoringModifiers;
+        if (chars.length == 1) {
+            unichar ch = [chars characterAtIndex:0];
+            if (ch >= '1' && ch <= '9') {
+                NSInteger number = ch - '0';
+                if ([weakSelf.overlayPanel handleNumberKey:number]) {
+                    return nil; // Consume the event
+                }
+            }
+        }
+        return event;
+    }];
+}
+
+- (void)stopNumberKeyMonitoring {
+    if (self.numberKeyMonitor) {
+        [NSEvent removeMonitor:self.numberKeyMonitor];
+        self.numberKeyMonitor = nil;
+    }
 }
 
 @end

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -365,13 +365,18 @@
 
     uint64_t token = self.rustBridge.currentSessionToken;
 
-    if ([self.permissionManager isAccessibilityGranted]) {
+    BOOL accessOK = [self.permissionManager isAccessibilityGranted];
+    NSLog(@"[Koe] Accessibility granted: %@", accessOK ? @"YES" : @"NO");
+
+    if (accessOK) {
         [self.pasteManager simulatePasteWithCompletion:^{
+            NSLog(@"[Koe] Paste completion callback fired");
             [self.clipboardManager scheduleRestoreAfterDelay:1500];
             if (token != self.rustBridge.currentSessionToken) return;
             [self.statusBarManager updateState:@"idle"];
             // Check if prompt templates are available for rewrite
             NSArray *templates = [self.rustBridge promptTemplates];
+            NSLog(@"[Koe] Prompt templates: %lu", (unsigned long)templates.count);
             if (templates.count > 0 && self.lastAsrText.length > 0) {
                 [self.overlayPanel showTemplateButtons:templates];
                 [self startNumberKeyMonitoring];
@@ -473,29 +478,14 @@
 - (void)rustBridgeDidReceiveRewriteText:(NSString *)text {
     NSLog(@"[Koe] Rewrite text received (%lu chars)", (unsigned long)text.length);
 
-    // Show rewritten text in overlay
-    [self.overlayPanel updateDisplayText:text];
-    [self.overlayPanel updateState:@"pasting"];
-
-    // Write to clipboard and auto-paste
-    [self.clipboardManager backup];
+    // Copy to clipboard (no auto-paste — user decides where to paste)
     [self.clipboardManager writeText:text];
 
-    uint64_t token = self.rustBridge.currentSessionToken;
-
-    if ([self.permissionManager isAccessibilityGranted]) {
-        // Undo the previous default paste, then paste the rewrite result
-        [self.pasteManager simulateUndoThenPasteWithCompletion:^{
-            [self.clipboardManager scheduleRestoreAfterDelay:1500];
-            if (token != self.rustBridge.currentSessionToken) return;
-            [self.statusBarManager updateState:@"idle"];
-            [self.overlayPanel lingerAndDismiss];
-        }];
-    } else {
-        NSLog(@"[Koe] Accessibility not granted — rewrite text copied to clipboard only");
-        [self.statusBarManager updateState:@"idle"];
-        [self.overlayPanel lingerAndDismiss];
-    }
+    // Show result with "Copied" indicator
+    [self.statusBarManager updateState:@"idle"];
+    [self.overlayPanel updateDisplayText:[text stringByAppendingString:@"  ✓ Copied"]];
+    [self.overlayPanel updateState:@"pasting"];
+    [self.overlayPanel lingerAndDismiss];
 }
 
 - (void)rustBridgeDidChangeState:(NSString *)state {

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -484,7 +484,8 @@
     uint64_t token = self.rustBridge.currentSessionToken;
 
     if ([self.permissionManager isAccessibilityGranted]) {
-        [self.pasteManager simulatePasteWithCompletion:^{
+        // Undo the previous default paste, then paste the rewrite result
+        [self.pasteManager simulateUndoThenPasteWithCompletion:^{
             [self.clipboardManager scheduleRestoreAfterDelay:1500];
             if (token != self.rustBridge.currentSessionToken) return;
             [self.statusBarManager updateState:@"idle"];

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -261,6 +261,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
           (unsigned long long)newConfig.trigger_modifier_flag,
           newConfig.trigger_match_kind);
     [self applyHotkeyConfig:newConfig restartMonitorIfNeeded:YES];
+    [self.overlayPanel reloadAppearanceFromConfig];
 }
 
 #pragma mark - SPHotkeyMonitorDelegate
@@ -599,6 +600,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
 - (void)setupWizardDidSaveConfig {
     NSLog(@"[Koe] Setup wizard saved config, reloading...");
     [self.rustBridge reloadConfig];
+    [self.overlayPanel reloadAppearanceFromConfig];
 
     if (![self shouldShowPromptTemplateButtons]) {
         [self stopNumberKeyMonitoring];

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -22,51 +22,7 @@
 @property (nonatomic, copy) dispatch_block_t pendingSessionEndBlock;
 @property (nonatomic, assign) BOOL showingError;
 @property (nonatomic, copy) NSString *lastAsrText;
-@property (nonatomic, assign) CFMachPortRef numberKeyTap;
-@property (nonatomic, assign) CFRunLoopSourceRef numberKeyRunLoopSource;
 @end
-
-// ─── CGEventTap callback for number key monitoring ─────────────────
-static CGEventRef numberKeyTapCallback(CGEventTapProxy proxy,
-                                        CGEventType type,
-                                        CGEventRef event,
-                                        void *userInfo) {
-    SPAppDelegate *delegate = (__bridge SPAppDelegate *)userInfo;
-
-    if (type == kCGEventTapDisabledByTimeout || type == kCGEventTapDisabledByUserInput) {
-        if (delegate.numberKeyTap) {
-            CGEventTapEnable(delegate.numberKeyTap, true);
-        }
-        return event;
-    }
-
-    if (type == kCGEventKeyDown) {
-        int64_t keyCode = CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
-        // keycodes 18-26 = number keys 1-9 on main keyboard
-        if (keyCode >= 18 && keyCode <= 26) {
-            // Map keycode to number: 18=1, 19=2, 20=3, 21=4, 23=5, 22=6, 26=7, 28=8, 25=9
-            // Actually macOS keycodes for 1-9 are: 18,19,20,21,23,22,26,28,25
-            static const int keycodeToNumber[] = {
-                [18] = 1, [19] = 2, [20] = 3, [21] = 4, [23] = 5,
-                [22] = 6, [26] = 7, [28] = 8, [25] = 9,
-            };
-            if (keyCode <= 28) {
-                NSInteger number = keycodeToNumber[keyCode];
-                if (number >= 1 && number <= 9) {
-                    // Disable tap immediately to prevent double-firing
-                    CGEventTapEnable(delegate.numberKeyTap, false);
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [delegate.overlayPanel handleNumberKey:number];
-                        // Full cleanup on main thread
-                        [delegate performSelector:@selector(stopNumberKeyMonitoring)];
-                    });
-                }
-            }
-        }
-    }
-
-    return event;
-}
 
 @implementation SPAppDelegate
 
@@ -645,36 +601,18 @@ static CGEventRef numberKeyTapCallback(CGEventTapProxy proxy,
 #pragma mark - Number Key Monitoring
 
 - (void)startNumberKeyMonitoring {
-    [self stopNumberKeyMonitoring];
-    CGEventMask mask = CGEventMaskBit(kCGEventKeyDown);
-    self.numberKeyTap = CGEventTapCreate(kCGHIDEventTap,
-                                          kCGHeadInsertEventTap,
-                                          kCGEventTapOptionListenOnly,
-                                          mask,
-                                          numberKeyTapCallback,
-                                          (__bridge void *)self);
-    if (self.numberKeyTap) {
-        self.numberKeyRunLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, self.numberKeyTap, 0);
-        CFRunLoopAddSource(CFRunLoopGetMain(), self.numberKeyRunLoopSource, kCFRunLoopCommonModes);
-        CGEventTapEnable(self.numberKeyTap, true);
-        NSLog(@"[Koe] Number key monitoring started (CGEventTap)");
-    } else {
-        NSLog(@"[Koe] Failed to create number key event tap");
-    }
+    __weak typeof(self) weakSelf = self;
+    self.hotkeyMonitor.numberKeyHandler = ^(NSInteger number) {
+        if ([weakSelf.overlayPanel handleNumberKey:number]) {
+            [weakSelf stopNumberKeyMonitoring];
+        }
+    };
+    NSLog(@"[Koe] Number key monitoring started");
 }
 
 - (void)stopNumberKeyMonitoring {
-    if (self.numberKeyRunLoopSource) {
-        CFRunLoopRemoveSource(CFRunLoopGetMain(), self.numberKeyRunLoopSource, kCFRunLoopCommonModes);
-        CFRelease(self.numberKeyRunLoopSource);
-        self.numberKeyRunLoopSource = NULL;
-    }
-    if (self.numberKeyTap) {
-        CGEventTapEnable(self.numberKeyTap, false);
-        CFRelease(self.numberKeyTap);
-        self.numberKeyTap = NULL;
-        NSLog(@"[Koe] Number key monitoring stopped");
-    }
+    self.hotkeyMonitor.numberKeyHandler = nil;
+    NSLog(@"[Koe] Number key monitoring stopped");
 }
 
 @end

--- a/KoeApp/Koe/Bridge/SPRustBridge.h
+++ b/KoeApp/Koe/Bridge/SPRustBridge.h
@@ -14,6 +14,7 @@ typedef NS_ENUM(NSInteger, SPSessionModeObjC) {
 - (void)rustBridgeDidChangeState:(NSString *)state;
 - (void)rustBridgeDidReceiveInterimText:(NSString *)text;
 - (void)rustBridgeDidReceiveAsrFinalText:(NSString *)text;
+- (void)rustBridgeDidReceiveRewriteText:(NSString *)text;
 @end
 
 @interface SPRustBridge : NSObject
@@ -72,6 +73,14 @@ typedef NS_ENUM(NSInteger, SPModelVerifyMode) {
 
 /// Cancel an active download.
 - (void)cancelDownload:(NSString *)modelPath;
+
+// ─── Rewrite / Prompt Templates ───────────────────────────────────
+
+/// Get prompt templates as JSON array string. Returns nil if none configured.
+- (NSArray<NSDictionary *> *)promptTemplates;
+
+/// Rewrite ASR text using template at given index. Returns YES on success.
+- (BOOL)rewriteWithTemplateIndex:(NSInteger)index asrText:(NSString *)text;
 
 /// Remove downloaded model files (keeps manifest). Returns files removed.
 - (NSInteger)removeModelFiles:(NSString *)modelPath;

--- a/KoeApp/Koe/Bridge/SPRustBridge.h
+++ b/KoeApp/Koe/Bridge/SPRustBridge.h
@@ -76,7 +76,7 @@ typedef NS_ENUM(NSInteger, SPModelVerifyMode) {
 
 // ─── Rewrite / Prompt Templates ───────────────────────────────────
 
-/// Get prompt templates as array of dicts with name, shortcut, system_prompt keys.
+/// Get prompt templates as array of dicts mirroring PromptTemplate in Rust config.
 - (NSArray<NSDictionary *> *)promptTemplates;
 
 /// Save prompt templates from array of dicts. Returns YES on success.

--- a/KoeApp/Koe/Bridge/SPRustBridge.h
+++ b/KoeApp/Koe/Bridge/SPRustBridge.h
@@ -76,8 +76,11 @@ typedef NS_ENUM(NSInteger, SPModelVerifyMode) {
 
 // ─── Rewrite / Prompt Templates ───────────────────────────────────
 
-/// Get prompt templates as JSON array string. Returns nil if none configured.
+/// Get prompt templates as array of dicts with name, shortcut, system_prompt keys.
 - (NSArray<NSDictionary *> *)promptTemplates;
+
+/// Save prompt templates from array of dicts. Returns YES on success.
+- (BOOL)setPromptTemplates:(NSArray<NSDictionary *> *)templates;
 
 /// Rewrite ASR text using template at given index. Returns YES on success.
 - (BOOL)rewriteWithTemplateIndex:(NSInteger)index asrText:(NSString *)text;

--- a/KoeApp/Koe/Bridge/SPRustBridge.h
+++ b/KoeApp/Koe/Bridge/SPRustBridge.h
@@ -13,6 +13,7 @@ typedef NS_ENUM(NSInteger, SPSessionModeObjC) {
 - (void)rustBridgeDidReceiveWarning:(NSString *)message;
 - (void)rustBridgeDidChangeState:(NSString *)state;
 - (void)rustBridgeDidReceiveInterimText:(NSString *)text;
+- (void)rustBridgeDidReceiveAsrFinalText:(NSString *)text;
 @end
 
 @interface SPRustBridge : NSObject

--- a/KoeApp/Koe/Bridge/SPRustBridge.m
+++ b/KoeApp/Koe/Bridge/SPRustBridge.m
@@ -87,6 +87,17 @@ static void bridge_on_interim_text(uint64_t token, const char *text) {
     }
 }
 
+static void bridge_on_asr_final_text(uint64_t token, const char *text) {
+    NSString *txt = text ? [NSString stringWithUTF8String:text] : @"";
+    id<SPRustBridgeDelegate> delegate = _bridgeDelegate;
+    if (delegate) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (token != _currentSessionToken) return;
+            [delegate rustBridgeDidReceiveAsrFinalText:txt];
+        });
+    }
+}
+
 // ─── Download callback context ─────────────────────────────────────
 
 @interface _KoeDownloadContext : NSObject
@@ -127,6 +138,7 @@ static void bridge_on_interim_text(uint64_t token, const char *text) {
         .on_log_event = bridge_on_log_event,
         .on_state_changed = bridge_on_state_changed,
         .on_interim_text = bridge_on_interim_text,
+        .on_asr_final_text = bridge_on_asr_final_text,
     };
     sp_core_register_callbacks(callbacks);
 

--- a/KoeApp/Koe/Bridge/SPRustBridge.m
+++ b/KoeApp/Koe/Bridge/SPRustBridge.m
@@ -313,6 +313,13 @@ static void download_status_cb(void *ctx, int32_t status, const char *message) {
     return arr ?: @[];
 }
 
+- (BOOL)setPromptTemplates:(NSArray<NSDictionary *> *)templates {
+    NSData *data = [NSJSONSerialization dataWithJSONObject:templates options:0 error:nil];
+    if (!data) return NO;
+    NSString *json = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    return sp_core_set_prompt_templates_json(json.UTF8String) == 0;
+}
+
 - (BOOL)rewriteWithTemplateIndex:(NSInteger)index asrText:(NSString *)text {
     return sp_core_rewrite_with_template((int32_t)index, text.UTF8String) == 0;
 }

--- a/KoeApp/Koe/Bridge/SPRustBridge.m
+++ b/KoeApp/Koe/Bridge/SPRustBridge.m
@@ -98,6 +98,17 @@ static void bridge_on_asr_final_text(uint64_t token, const char *text) {
     }
 }
 
+static void bridge_on_rewrite_text_ready(uint64_t token, const char *text) {
+    NSString *txt = text ? [NSString stringWithUTF8String:text] : @"";
+    id<SPRustBridgeDelegate> delegate = _bridgeDelegate;
+    if (delegate) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (token != _currentSessionToken) return;
+            [delegate rustBridgeDidReceiveRewriteText:txt];
+        });
+    }
+}
+
 // ─── Download callback context ─────────────────────────────────────
 
 @interface _KoeDownloadContext : NSObject
@@ -139,6 +150,7 @@ static void bridge_on_asr_final_text(uint64_t token, const char *text) {
         .on_state_changed = bridge_on_state_changed,
         .on_interim_text = bridge_on_interim_text,
         .on_asr_final_text = bridge_on_asr_final_text,
+        .on_rewrite_text_ready = bridge_on_rewrite_text_ready,
     };
     sp_core_register_callbacks(callbacks);
 
@@ -286,6 +298,23 @@ static void download_status_cb(void *ctx, int32_t status, const char *message) {
 
 - (NSInteger)removeModelFiles:(NSString *)modelPath {
     return sp_core_remove_model_files(modelPath.UTF8String);
+}
+
+// ─── Rewrite / Prompt Templates ───────────────────────────────────
+
+- (NSArray<NSDictionary *> *)promptTemplates {
+    char *json = sp_core_get_prompt_templates_json();
+    if (!json) return @[];
+    NSString *jsonStr = [NSString stringWithUTF8String:json];
+    sp_core_free_string(json);
+    NSData *data = [jsonStr dataUsingEncoding:NSUTF8StringEncoding];
+    if (!data) return @[];
+    NSArray *arr = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    return arr ?: @[];
+}
+
+- (BOOL)rewriteWithTemplateIndex:(NSInteger)index asrText:(NSString *)text {
+    return sp_core_rewrite_with_template((int32_t)index, text.UTF8String) == 0;
 }
 
 @end

--- a/KoeApp/Koe/Clipboard/SPClipboardManager.h
+++ b/KoeApp/Koe/Clipboard/SPClipboardManager.h
@@ -12,4 +12,7 @@
 /// Will not restore if the clipboard was modified by the user in the meantime.
 - (void)scheduleRestoreAfterDelay:(NSUInteger)delayMs;
 
+/// Cancel any pending delayed restore for the current clipboard write.
+- (void)cancelPendingRestore;
+
 @end

--- a/KoeApp/Koe/Clipboard/SPClipboardManager.m
+++ b/KoeApp/Koe/Clipboard/SPClipboardManager.m
@@ -6,6 +6,7 @@
 @property (nonatomic, strong) NSArray<NSPasteboardItem *> *backedUpItems;
 @property (nonatomic, assign) NSInteger backedUpChangeCount;
 @property (nonatomic, assign) NSInteger writtenChangeCount;
+@property (nonatomic, assign) NSUInteger pendingRestoreGeneration;
 @property (nonatomic, assign) BOOL hasBackup;
 
 @end
@@ -42,19 +43,26 @@
 - (void)scheduleRestoreAfterDelay:(NSUInteger)delayMs {
     if (!self.hasBackup) return;
 
+    NSUInteger generation = ++self.pendingRestoreGeneration;
+    NSInteger expectedChangeCount = self.writtenChangeCount;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayMs * NSEC_PER_MSEC)),
                    dispatch_get_main_queue(), ^{
-        [self restoreIfUnchanged];
+        [self restoreIfUnchangedExpectedChangeCount:expectedChangeCount generation:generation];
     });
 }
 
-- (void)restoreIfUnchanged {
+- (void)cancelPendingRestore {
+    self.pendingRestoreGeneration += 1;
+}
+
+- (void)restoreIfUnchangedExpectedChangeCount:(NSInteger)expectedChangeCount generation:(NSUInteger)generation {
     if (!self.hasBackup) return;
+    if (generation != self.pendingRestoreGeneration) return;
 
     NSPasteboard *pb = [NSPasteboard generalPasteboard];
 
     // Only restore if the clipboard hasn't been modified since we wrote to it
-    if (pb.changeCount != self.writtenChangeCount) {
+    if (pb.changeCount != expectedChangeCount) {
         NSLog(@"[Koe] Clipboard changed since write, skipping restore");
         self.backedUpItems = nil;
         self.hasBackup = NO;
@@ -66,6 +74,7 @@
         [pb writeObjects:self.backedUpItems];
     }
     NSLog(@"[Koe] Clipboard restored%@", self.backedUpItems.count == 0 ? @" (was empty)" : @"");
+    self.pendingRestoreGeneration += 1;
     self.backedUpItems = nil;
     self.hasBackup = NO;
 }

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
@@ -46,4 +46,9 @@
 /// terminates a recording session outside the normal hotkey flow.
 - (void)resetToIdle;
 
+/// Optional block called on the main thread when a number key (1-9) is pressed.
+/// Set to non-nil to enable number key forwarding via the existing CGEventTap.
+/// The block receives the number (1-9). Set to nil to disable.
+@property (nonatomic, copy) void (^numberKeyHandler)(NSInteger number);
+
 @end

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
@@ -14,6 +14,9 @@
 /// Threshold in milliseconds to distinguish tap from hold. Default 180ms.
 @property (nonatomic, assign) NSTimeInterval holdThresholdMs;
 
+/// Trigger mode: 0 = hold (short press ignored), 1 = toggle (tap to start/stop).
+@property (nonatomic, assign) uint8_t triggerMode;
+
 /// Primary key code to monitor (default: 63 = Fn/Globe)
 @property (nonatomic, assign) NSInteger targetKeyCode;
 

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
@@ -6,8 +6,12 @@
 - (void)hotkeyMonitorDidDetectHoldEnd;
 - (void)hotkeyMonitorDidDetectTapStart;
 - (void)hotkeyMonitorDidDetectTapEnd;
-- (void)hotkeyMonitorDidDetectCancel;
 @end
+
+typedef NS_ENUM(uint8_t, SPHotkeyMatchKind) {
+    SPHotkeyMatchKindModifierOnly = 0,
+    SPHotkeyMatchKindKeyDown = 1,
+};
 
 @interface SPHotkeyMonitor : NSObject
 
@@ -26,14 +30,8 @@
 /// Modifier flag to check for key state (default: 0x800000 = NSEventModifierFlagFunction)
 @property (nonatomic, assign) NSUInteger targetModifierFlag;
 
-/// Primary key code for the cancel hotkey.
-@property (nonatomic, assign) NSInteger cancelKeyCode;
-
-/// Alternative key code for the cancel hotkey, 0 to disable.
-@property (nonatomic, assign) NSInteger cancelAltKeyCode;
-
-/// Modifier flag to check for cancel key state.
-@property (nonatomic, assign) NSUInteger cancelModifierFlag;
+/// How the trigger hotkey should be matched.
+@property (nonatomic, assign) uint8_t targetMatchKind;
 
 - (instancetype)initWithDelegate:(id<SPHotkeyMonitorDelegate>)delegate;
 - (void)start;
@@ -46,9 +44,8 @@
 /// terminates a recording session outside the normal hotkey flow.
 - (void)resetToIdle;
 
-/// Optional block called on the main thread when a number key (1-9) is pressed.
-/// Set to non-nil to enable number key forwarding via the existing CGEventTap.
-/// The block receives the number (1-9). Set to nil to disable.
-@property (nonatomic, copy) void (^numberKeyHandler)(NSInteger number);
+/// Optional block called when a number key (1-9) is pressed.
+/// Return YES to consume the key event so it does not continue to the target app.
+@property (nonatomic, copy) BOOL (^numberKeyHandler)(NSInteger number);
 
 @end

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
@@ -22,16 +22,40 @@ typedef NS_ENUM(NSInteger, SPHotkeyState) {
 @property (nonatomic, strong) id globalMonitorRef;
 @property (nonatomic, strong) id localMonitorRef;
 @property (nonatomic, assign) BOOL running;
+@property (nonatomic, strong) NSMutableSet<NSNumber *> *suppressedNumberKeyCodes;
+@property (nonatomic, strong) NSMutableSet<NSNumber *> *suppressedHotkeyKeyCodes;
 
 - (void)handleFlagsChangedEvent:(CGEventRef)event;
 - (BOOL)isTargetKeyCode:(NSInteger)keyCode;
-- (BOOL)isCancelKeyCode:(NSInteger)keyCode;
+- (BOOL)isModifierOnlyMatchKind:(uint8_t)matchKind;
+- (BOOL)keyModifiers:(NSUInteger)flags matchRequiredModifiers:(NSUInteger)requiredFlags;
 - (BOOL)isRecordingState;
 - (void)handleTriggerDown;
 - (void)handleTriggerUp;
-- (void)handleCancelRequestFromSource:(NSString *)source;
 
 @end
+
+static NSInteger numberForKeyCode(NSInteger keyCode) {
+    switch (keyCode) {
+        case 18: return 1;
+        case 19: return 2;
+        case 20: return 3;
+        case 21: return 4;
+        case 23: return 5;
+        case 22: return 6;
+        case 26: return 7;
+        case 28: return 8;
+        case 25: return 9;
+        default: return 0;
+    }
+}
+
+static const NSUInteger SPHotkeyRelevantModifierMask =
+    NSEventModifierFlagCommand |
+    NSEventModifierFlagOption |
+    NSEventModifierFlagControl |
+    NSEventModifierFlagShift |
+    NSEventModifierFlagFunction;
 
 // C callback for CGEventTap
 static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
@@ -56,43 +80,73 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
         [monitor handleFlagsChangedEvent:event];
     } else if (type == kCGEventKeyDown || type == kCGEventKeyUp) {
         NSInteger keyCode = (NSInteger)CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
+        NSNumber *keyCodeNumber = @(keyCode);
+        NSUInteger flags = (NSUInteger)CGEventGetFlags(event);
+        BOOL isRepeat = CGEventGetIntegerValueField(event, kCGKeyboardEventAutorepeat) != 0;
+        BOOL suppressedTriggerKey = [monitor.suppressedHotkeyKeyCodes containsObject:keyCodeNumber];
 
-        if (type == kCGEventKeyDown && [monitor isCancelKeyCode:keyCode] && [monitor isRecordingState]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [monitor handleCancelRequestFromSource:@"CGEventTap keyDown"];
-            });
+        if (type == kCGEventKeyUp && [monitor.suppressedNumberKeyCodes containsObject:keyCodeNumber]) {
+            [monitor.suppressedNumberKeyCodes removeObject:keyCodeNumber];
+            return NULL;
         }
 
-        // Forward number keys 1-9 if handler is set
-        if (type == kCGEventKeyDown) {
-            NSLog(@"[Koe] CGEventTap keyDown: keyCode=%ld handler=%@", (long)keyCode, monitor.numberKeyHandler ? @"YES" : @"NO");
+        if (isRepeat) {
+            return event;
         }
+
+        // Forward number keys 1-9 if handler is set.
+        // When handled, suppress both keyDown and keyUp so the typed digit
+        // does not leak into the user's target app.
         if (type == kCGEventKeyDown && monitor.numberKeyHandler) {
-            // macOS keycodes: 1=18, 2=19, 3=20, 4=21, 5=23, 6=22, 7=26, 8=28, 9=25
-            NSInteger number = 0;
-            switch (keyCode) {
-                case 18: number = 1; break;
-                case 19: number = 2; break;
-                case 20: number = 3; break;
-                case 21: number = 4; break;
-                case 23: number = 5; break;
-                case 22: number = 6; break;
-                case 26: number = 7; break;
-                case 28: number = 8; break;
-                case 25: number = 9; break;
-            }
+            NSInteger number = numberForKeyCode(keyCode);
             if (number > 0) {
-                void (^handler)(NSInteger) = monitor.numberKeyHandler;
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    handler(number);
-                });
+                BOOL (^handler)(NSInteger) = monitor.numberKeyHandler;
+                __block BOOL handled = NO;
+                if ([NSThread isMainThread]) {
+                    handled = handler(number);
+                } else {
+                    dispatch_sync(dispatch_get_main_queue(), ^{
+                        handled = handler(number);
+                    });
+                }
+                if (handled) {
+                    [monitor.suppressedNumberKeyCodes addObject:keyCodeNumber];
+                    return NULL;
+                }
             }
         }
 
-        if ([monitor isTargetKeyCode:keyCode]) {
+        if (![monitor isModifierOnlyMatchKind:monitor.targetMatchKind] &&
+            [monitor isTargetKeyCode:keyCode] &&
+            ([monitor keyModifiers:flags matchRequiredModifiers:monitor.targetModifierFlag] ||
+             (type == kCGEventKeyUp && suppressedTriggerKey))) {
             CGEventFlags flags = CGEventGetFlags(event);
             NSLog(@"[Koe] Key event: type=%d keyCode=%ld flags=0x%llx",
                   type, (long)keyCode, (unsigned long long)flags);
+            BOOL isDown = (type == kCGEventKeyDown);
+            if (isDown != monitor.triggerDown) {
+                monitor.triggerDown = isDown;
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (isDown) {
+                        [monitor handleTriggerDown];
+                    } else {
+                        [monitor handleTriggerUp];
+                    }
+                });
+            }
+            if (isDown) {
+                [monitor.suppressedHotkeyKeyCodes addObject:keyCodeNumber];
+                return NULL;
+            }
+            if (suppressedTriggerKey) {
+                [monitor.suppressedHotkeyKeyCodes removeObject:keyCodeNumber];
+                return NULL;
+            }
+        }
+
+        if (type == kCGEventKeyUp && [monitor.suppressedHotkeyKeyCodes containsObject:keyCodeNumber]) {
+            [monitor.suppressedHotkeyKeyCodes removeObject:keyCodeNumber];
+            return NULL;
         }
     }
 
@@ -111,9 +165,9 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
         _targetKeyCode = 63;       // kVK_Function (Fn)
         _altKeyCode = 179;         // Globe key on newer keyboards
         _targetModifierFlag = 0x00800000; // NX_SECONDARYFNMASK
-        _cancelKeyCode = 58;       // Left Option
-        _cancelAltKeyCode = 0;
-        _cancelModifierFlag = 0x00000020; // NX_DEVICELALTKEYMASK
+        _targetMatchKind = SPHotkeyMatchKindModifierOnly;
+        _suppressedNumberKeyCodes = [NSMutableSet set];
+        _suppressedHotkeyKeyCodes = [NSMutableSet set];
     }
     return self;
 }
@@ -138,33 +192,50 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
         return event;
     }];
 
-    NSLog(@"[Koe] Hotkey monitor started via NSEvent monitors (trigger=%ld/%ld flag=0x%lx cancel=%ld/%ld flag=0x%lx threshold=%.0fms)",
+    NSLog(@"[Koe] Hotkey monitor started via NSEvent monitors (trigger=%ld/%ld flag=0x%lx kind=%u threshold=%.0fms)",
           (long)self.targetKeyCode,
           (long)self.altKeyCode,
           (unsigned long)self.targetModifierFlag,
-          (long)self.cancelKeyCode,
-          (long)self.cancelAltKeyCode,
-          (unsigned long)self.cancelModifierFlag,
+          self.targetMatchKind,
           self.holdThresholdMs);
-    NSLog(@"[Koe] Cancel hotkey configured (keyCode=%ld altKeyCode=%ld modifierFlag=0x%lx)",
-          (long)self.cancelKeyCode, (long)self.cancelAltKeyCode, (unsigned long)self.cancelModifierFlag);
 
-    // Also try CGEventTap as additional source
+    // Also try CGEventTap as additional source.
+    // Prefer active taps that can swallow handled number shortcuts so they do
+    // not leak into the user's focused app. Some systems reject one tap
+    // location but allow another, so try both before degrading to listen-only.
     CGEventMask mask = CGEventMaskBit(kCGEventFlagsChanged)
                      | CGEventMaskBit(kCGEventKeyDown)
                      | CGEventMaskBit(kCGEventKeyUp);
-    self.eventTap = CGEventTapCreate(kCGHIDEventTap,
-                                      kCGHeadInsertEventTap,
-                                      kCGEventTapOptionListenOnly,
-                                      mask,
-                                      hotkeyEventCallback,
-                                      (__bridge void *)self);
-    if (self.eventTap) {
+    struct {
+        CGEventTapLocation location;
+        CGEventTapOptions options;
+        NSString *logMessage;
+    } attempts[] = {
+        { kCGSessionEventTap, kCGEventTapOptionDefault, @"[Koe] CGEventTap active on session stream (event suppression enabled)" },
+        { kCGHIDEventTap, kCGEventTapOptionDefault, @"[Koe] CGEventTap active on HID stream (event suppression enabled)" },
+        { kCGSessionEventTap, kCGEventTapOptionListenOnly, @"[Koe] CGEventTap active in listen-only fallback mode on session stream" },
+        { kCGHIDEventTap, kCGEventTapOptionListenOnly, @"[Koe] CGEventTap active in listen-only fallback mode on HID stream" },
+    };
+
+    for (NSUInteger i = 0; i < sizeof(attempts) / sizeof(attempts[0]); i++) {
+        self.eventTap = CGEventTapCreate(attempts[i].location,
+                                         kCGHeadInsertEventTap,
+                                         attempts[i].options,
+                                         mask,
+                                         hotkeyEventCallback,
+                                         (__bridge void *)self);
+        if (!self.eventTap) {
+            continue;
+        }
+
         self.runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, self.eventTap, 0);
         CFRunLoopAddSource(CFRunLoopGetMain(), self.runLoopSource, kCFRunLoopCommonModes);
         CGEventTapEnable(self.eventTap, true);
-        NSLog(@"[Koe] CGEventTap also active");
-    } else {
+        NSLog(@"%@", attempts[i].logMessage);
+        break;
+    }
+
+    if (!self.eventTap) {
         NSLog(@"[Koe] CGEventTap unavailable (ok, NSEvent monitors active)");
     }
 }
@@ -185,19 +256,16 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
     return keyCode == self.targetKeyCode || (self.altKeyCode != 0 && keyCode == self.altKeyCode);
 }
 
-- (BOOL)isCancelKeyCode:(NSInteger)keyCode {
-    return keyCode == self.cancelKeyCode || (self.cancelAltKeyCode != 0 && keyCode == self.cancelAltKeyCode);
+- (BOOL)isModifierOnlyMatchKind:(uint8_t)matchKind {
+    return matchKind == SPHotkeyMatchKindModifierOnly;
+}
+
+- (BOOL)keyModifiers:(NSUInteger)flags matchRequiredModifiers:(NSUInteger)requiredFlags {
+    return (flags & SPHotkeyRelevantModifierMask) == requiredFlags;
 }
 
 - (BOOL)isRecordingState {
     return self.state == SPHotkeyStateRecordingHold || self.state == SPHotkeyStateRecordingToggle;
-}
-
-- (void)handleCancelRequestFromSource:(NSString *)source {
-    if (![self isRecordingState]) return;
-    NSLog(@"[Koe] Cancel hotkey pressed during recording (%@)", source);
-    [self resetToIdle];
-    [self.delegate hotkeyMonitorDidDetectCancel];
 }
 
 - (void)handleNSEvent:(NSEvent *)event {
@@ -208,7 +276,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
         NSInteger keyCode = event.keyCode;
         NSLog(@"[Koe] NSEvent FlagsChanged: keyCode=%ld flags=0x%lx", (long)keyCode, (unsigned long)flags);
 
-        if ([self isTargetKeyCode:keyCode]) {
+        if ([self isModifierOnlyMatchKind:self.targetMatchKind] && [self isTargetKeyCode:keyCode]) {
             BOOL keyNow = (flags & self.targetModifierFlag) != 0;
             if (keyNow != self.triggerDown) {
                 self.triggerDown = keyNow;
@@ -218,22 +286,17 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
                     [self handleTriggerUp];
                 }
             }
-        } else if ([self isCancelKeyCode:keyCode]) {
-            BOOL cancelNow = (flags & self.cancelModifierFlag) != 0;
-            if (cancelNow && [self isRecordingState]) {
-                [self handleCancelRequestFromSource:@"NSEvent flagsChanged"];
-            }
         }
     } else if (event.type == NSEventTypeKeyDown || event.type == NSEventTypeKeyUp) {
+        if ([event isARepeat]) return;
         NSInteger keyCode = event.keyCode;
+        NSUInteger flags = event.modifierFlags;
 
-        if (event.type == NSEventTypeKeyDown && [self isCancelKeyCode:keyCode] && [self isRecordingState]) {
-            [self handleCancelRequestFromSource:@"NSEvent keyDown"];
-            return;
-        }
-
-        // Some macOS versions send modifier keys as keyDown/keyUp events
-        if ([self isTargetKeyCode:keyCode]) {
+        // Some macOS versions send modifier keys as keyDown/keyUp events. For
+        // keyDown-matched shortcuts, only trigger when the exact modifier set matches.
+        if (![self isModifierOnlyMatchKind:self.targetMatchKind] &&
+            [self isTargetKeyCode:keyCode] &&
+            [self keyModifiers:flags matchRequiredModifiers:self.targetModifierFlag]) {
             BOOL isDown = (event.type == NSEventTypeKeyDown);
             NSLog(@"[Koe] NSEvent Key%@: keyCode=%ld", isDown ? @"Down" : @"Up", (long)keyCode);
             if (isDown != self.triggerDown) {
@@ -274,6 +337,8 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
 
     [self cancelHoldTimer];
     self.state = SPHotkeyStateIdle;
+    [self.suppressedNumberKeyCodes removeAllObjects];
+    [self.suppressedHotkeyKeyCodes removeAllObjects];
     NSLog(@"[Koe] Hotkey monitor stopped");
 }
 
@@ -288,16 +353,8 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
     // 1. Check if keyCode matches the configured trigger key
     // 2. Check modifier flag bit for key state
     BOOL triggerNow;
-    if ([self isTargetKeyCode:keyCode]) {
+    if ([self isModifierOnlyMatchKind:self.targetMatchKind] && [self isTargetKeyCode:keyCode]) {
         triggerNow = (flags & self.targetModifierFlag) != 0;
-    } else if ([self isCancelKeyCode:keyCode]) {
-        BOOL cancelNow = (flags & self.cancelModifierFlag) != 0;
-        if (cancelNow) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [self handleCancelRequestFromSource:@"CGEventTap flagsChanged"];
-            });
-        }
-        return;
     } else {
         return;
     }
@@ -392,6 +449,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
     [self cancelHoldTimer];
     self.triggerDown = NO;
     self.state = SPHotkeyStateIdle;
+    [self.suppressedNumberKeyCodes removeAllObjects];
 }
 
 @end

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
@@ -63,6 +63,29 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
             });
         }
 
+        // Forward number keys 1-9 if handler is set
+        if (type == kCGEventKeyDown && monitor.numberKeyHandler) {
+            // macOS keycodes: 1=18, 2=19, 3=20, 4=21, 5=23, 6=22, 7=26, 8=28, 9=25
+            NSInteger number = 0;
+            switch (keyCode) {
+                case 18: number = 1; break;
+                case 19: number = 2; break;
+                case 20: number = 3; break;
+                case 21: number = 4; break;
+                case 23: number = 5; break;
+                case 22: number = 6; break;
+                case 26: number = 7; break;
+                case 28: number = 8; break;
+                case 25: number = 9; break;
+            }
+            if (number > 0) {
+                void (^handler)(NSInteger) = monitor.numberKeyHandler;
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    handler(number);
+                });
+            }
+        }
+
         if ([monitor isTargetKeyCode:keyCode]) {
             CGEventFlags flags = CGEventGetFlags(event);
             NSLog(@"[Koe] Key event: type=%d keyCode=%ld flags=0x%llx",

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
@@ -64,6 +64,9 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
         }
 
         // Forward number keys 1-9 if handler is set
+        if (type == kCGEventKeyDown) {
+            NSLog(@"[Koe] CGEventTap keyDown: keyCode=%ld handler=%@", (long)keyCode, monitor.numberKeyHandler ? @"YES" : @"NO");
+        }
         if (type == kCGEventKeyDown && monitor.numberKeyHandler) {
             // macOS keycodes: 1=18, 2=19, 3=20, 4=21, 5=23, 6=22, 7=26, 8=28, 9=25
             NSInteger number = 0;

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
@@ -316,8 +316,14 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
     switch (self.state) {
         case SPHotkeyStatePending:
             [self cancelHoldTimer];
-            self.state = SPHotkeyStateRecordingToggle;
-            [self.delegate hotkeyMonitorDidDetectTapStart];
+            if (self.triggerMode == 1) {
+                // Toggle mode: short press starts recording
+                self.state = SPHotkeyStateRecordingToggle;
+                [self.delegate hotkeyMonitorDidDetectTapStart];
+            } else {
+                // Hold mode: short press is ignored
+                self.state = SPHotkeyStateIdle;
+            }
             break;
 
         case SPHotkeyStateRecordingHold:

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.h
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.h
@@ -27,6 +27,7 @@
 - (void)lingerAndDismiss;
 
 /// Show template selection buttons. Templates is array of dicts with "name" and "shortcut" keys.
+/// Optional "source_index" is preserved and returned to the delegate on selection.
 - (void)showTemplateButtons:(NSArray<NSDictionary *> *)templates;
 
 /// Hide template buttons and return to normal display.

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.h
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.h
@@ -26,6 +26,20 @@
 /// Dismiss the overlay after a dynamic linger period based on text length.
 - (void)lingerAndDismiss;
 
+/// Reload overlay typography and bottom position from config.yaml.
+- (void)reloadAppearanceFromConfig;
+
+/// Show a temporary on-screen preview using unsaved overlay settings.
+- (void)showPreviewWithText:(NSString *)text
+                   fontSize:(CGFloat)fontSize
+                 fontFamily:(NSString *)fontFamily
+               bottomMargin:(CGFloat)bottomMargin
+          limitVisibleLines:(BOOL)limitVisibleLines
+            maxVisibleLines:(NSInteger)maxVisibleLines;
+
+/// Hide the temporary on-screen preview and restore configured appearance.
+- (void)hidePreview;
+
 /// Show template selection buttons. Templates is array of dicts with "name" and "shortcut" keys.
 /// Optional "source_index" is preserved and returned to the delegate on selection.
 - (void)showTemplateButtons:(NSArray<NSDictionary *> *)templates;

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.h
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.h
@@ -1,21 +1,38 @@
 #import <Cocoa/Cocoa.h>
 
+@protocol SPOverlayPanelDelegate <NSObject>
+@optional
+/// Called when user selects a prompt template (by click or keyboard shortcut).
+/// templateIndex is 0-based index into the prompt_templates array.
+- (void)overlayPanel:(id)panel didSelectTemplateAtIndex:(NSInteger)templateIndex;
+@end
+
 /// Floating status pill displayed at bottom-center of screen, above the Dock.
-/// Shows current state (recording, processing, etc.) and auto-hides when idle.
 @interface SPOverlayPanel : NSObject
+
+@property (nonatomic, weak) id<SPOverlayPanelDelegate> delegate;
 
 - (instancetype)init;
 
-/// Update displayed state. Same state strings as SPStatusBarManager.
+/// Update displayed state.
 - (void)updateState:(NSString *)state;
 
 /// Update interim ASR text shown during recording.
 - (void)updateInterimText:(NSString *)text;
 
-/// Update display text shown during non-recording phases (ASR result, LLM result).
+/// Update display text shown during non-recording phases.
 - (void)updateDisplayText:(NSString *)text;
 
 /// Dismiss the overlay after a dynamic linger period based on text length.
 - (void)lingerAndDismiss;
+
+/// Show template selection buttons. Templates is array of dicts with "name" and "shortcut" keys.
+- (void)showTemplateButtons:(NSArray<NSDictionary *> *)templates;
+
+/// Hide template buttons and return to normal display.
+- (void)hideTemplateButtons;
+
+/// Handle a number key press (1-9). Returns YES if a template was triggered.
+- (BOOL)handleNumberKey:(NSInteger)number;
 
 @end

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.h
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.h
@@ -12,4 +12,10 @@
 /// Update interim ASR text shown during recording.
 - (void)updateInterimText:(NSString *)text;
 
+/// Update display text shown during non-recording phases (ASR result, LLM result).
+- (void)updateDisplayText:(NSString *)text;
+
+/// Dismiss the overlay after a dynamic linger period based on text length.
+- (void)lingerAndDismiss;
+
 @end

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -40,6 +40,23 @@ static const NSTimeInterval kResizeDuration    = 0.15;
 static const NSTimeInterval kMinLingerDuration = 0.45;
 static const NSTimeInterval kMaxLingerDuration = 1.2;
 static const NSTimeInterval kTemplateLingerDuration = 3.0;
+static const NSTimeInterval kPanelEntranceDuration = 0.22;
+static const NSTimeInterval kPanelExitDuration = 0.18;
+static const CGFloat kPanelEntranceLift = 10.0;
+static const CGFloat kPanelExitDrop = 8.0;
+static const CGFloat kBaseShadowOpacity = 0.11;
+static const CGFloat kBaseShadowRadius = 4.0;
+static const CGFloat kEntranceShadowOpacity = 0.17;
+static const CGFloat kEntranceShadowRadius = 8.0;
+static const NSTimeInterval kRippleDuration = 0.42;
+
+static NSColor *SPOverlaySurfaceTintColor(void) {
+    return [NSColor colorWithSRGBRed:0.07 green:0.065 blue:0.03 alpha:0.34];
+}
+
+static NSColor *SPOverlayShadowColor(void) {
+    return [NSColor colorWithSRGBRed:0.04 green:0.035 blue:0.015 alpha:1.0];
+}
 
 static CGFloat SPOverlayClampTextFontSize(CGFloat fontSize) {
     return fmin(fmax(fontSize, kMinTextFontSize), kMaxTextFontSize);
@@ -248,6 +265,29 @@ static CGFloat SPOverlayMeasureVisibleHeightForLineLimit(NSString *text, NSFont 
 
     CGFloat totalHeight = ceil([layoutManager usedRectForTextContainer:textContainer].size.height);
     return fmin(fmax(SPOverlayLineHeightForFont(font), visibleHeight), totalHeight);
+}
+
+static BOOL SPOverlayShouldReduceMotion(void) {
+    if (@available(macOS 10.15, *)) {
+        return NSWorkspace.sharedWorkspace.accessibilityDisplayShouldReduceMotion;
+    }
+    return NO;
+}
+
+static NSRect SPOverlayPresentationStartFrame(NSRect finalFrame) {
+    CGFloat insetX = fmin(10.0, floor(finalFrame.size.width * 0.018));
+    CGFloat insetY = fmin(6.0, floor(finalFrame.size.height * 0.08));
+    NSRect startFrame = NSInsetRect(finalFrame, insetX, insetY);
+    startFrame.origin.y -= kPanelEntranceLift;
+    return startFrame;
+}
+
+static NSRect SPOverlayDismissalEndFrame(NSRect currentFrame) {
+    CGFloat insetX = fmin(8.0, floor(currentFrame.size.width * 0.012));
+    CGFloat insetY = fmin(5.0, floor(currentFrame.size.height * 0.06));
+    NSRect endFrame = NSInsetRect(currentFrame, insetX, insetY);
+    endFrame.origin.y -= kPanelExitDrop;
+    return endFrame;
 }
 
 // ── Animation mode ───────────────────────────────────────
@@ -566,21 +606,12 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 
 - (void)drawRect:(NSRect)dirtyRect {
     NSRect bounds = self.bounds;
-    CGFloat cornerRadius = self.cornerRadius > 0 ? self.cornerRadius : 18.0;
     CGFloat iconAreaWidth = self.iconAreaWidth > 0 ? self.iconAreaWidth : 28.0;
     CGFloat horizontalPad = SPOverlayHorizontalPadForFont([self contentFont]);
 
     // ── Dark tint (minimum contrast for white text on any background) ──
-    [[NSColor colorWithWhite:0.0 alpha:0.35] setFill];
+    [SPOverlaySurfaceTintColor() setFill];
     [NSBezierPath fillRect:bounds];
-
-    // ── Border (edge definition on dark backgrounds) ──
-    NSBezierPath *border = [NSBezierPath bezierPathWithRoundedRect:NSInsetRect(bounds, 0.5, 0.5)
-                                                            xRadius:cornerRadius
-                                                            yRadius:cornerRadius];
-    [[NSColor colorWithWhite:1.0 alpha:0.20] setStroke];
-    border.lineWidth = 0.5;
-    [border stroke];
 
     // ── Left icon area ──
     CGFloat iconCenterX = horizontalPad + iconAreaWidth / 2.0;
@@ -735,6 +766,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) BOOL configuredLimitVisibleLinesEnabled;
 @property (nonatomic, assign) NSInteger configuredMaxVisibleLines;
 @property (nonatomic, assign, getter=isPreviewActive) BOOL previewActive;
+@property (nonatomic, strong) CAShapeLayer *recordingRippleLayer;
 
 @end
 
@@ -788,8 +820,131 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     self.contentView.fontFamily = self.fontFamily;
     self.contentView.cornerRadius = [self overlayCornerRadius];
     self.contentView.iconAreaWidth = [self iconAreaWidth];
+    self.contentView.layer.cornerRadius = [self overlayCornerRadius];
+    self.contentView.layer.masksToBounds = YES;
     [self.contentView updateTextAttributes];
     [self.contentView setNeedsLayout:YES];
+}
+
+- (void)clearRecordingRippleIfNeeded {
+    [self.recordingRippleLayer removeAllAnimations];
+    [self.recordingRippleLayer removeFromSuperlayer];
+    self.recordingRippleLayer = nil;
+}
+
+- (void)resetMotionPresentationState {
+    [self.contentView.layer removeAnimationForKey:@"overlayContentEntrance"];
+    [self.contentView.layer removeAnimationForKey:@"overlayContentExit"];
+    [self.effectView.layer removeAnimationForKey:@"overlayShadowEntrance"];
+    [self.effectView.layer removeAnimationForKey:@"overlayShadowExit"];
+    self.contentView.layer.transform = CATransform3DIdentity;
+    self.contentView.layer.opacity = 1.0;
+    self.effectView.layer.shadowOpacity = kBaseShadowOpacity;
+    self.effectView.layer.shadowRadius = kBaseShadowRadius;
+}
+
+- (void)animateContentLayerFromTransform:(CATransform3D)fromTransform
+                             toTransform:(CATransform3D)toTransform
+                             fromOpacity:(CGFloat)fromOpacity
+                               toOpacity:(CGFloat)toOpacity
+                                duration:(CFTimeInterval)duration
+                               animation:(NSString *)animationKey {
+    if (!self.contentView.layer) return;
+
+    [self.contentView.layer removeAnimationForKey:animationKey];
+    self.contentView.layer.transform = toTransform;
+    self.contentView.layer.opacity = toOpacity;
+
+    CABasicAnimation *transformAnimation = [CABasicAnimation animationWithKeyPath:@"transform"];
+    transformAnimation.fromValue = [NSValue valueWithCATransform3D:fromTransform];
+    transformAnimation.toValue = [NSValue valueWithCATransform3D:toTransform];
+
+    CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
+    opacityAnimation.fromValue = @(fromOpacity);
+    opacityAnimation.toValue = @(toOpacity);
+
+    CAAnimationGroup *group = [CAAnimationGroup animation];
+    group.animations = @[transformAnimation, opacityAnimation];
+    group.duration = duration;
+    group.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+    [self.contentView.layer addAnimation:group forKey:animationKey];
+}
+
+- (void)animateShadowFromOpacity:(CGFloat)fromOpacity
+                       toOpacity:(CGFloat)toOpacity
+                      fromRadius:(CGFloat)fromRadius
+                        toRadius:(CGFloat)toRadius
+                        duration:(CFTimeInterval)duration
+                       animation:(NSString *)animationKey {
+    if (!self.effectView.layer) return;
+
+    [self.effectView.layer removeAnimationForKey:animationKey];
+    self.effectView.layer.shadowOpacity = toOpacity;
+    self.effectView.layer.shadowRadius = toRadius;
+
+    CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"shadowOpacity"];
+    opacityAnimation.fromValue = @(fromOpacity);
+    opacityAnimation.toValue = @(toOpacity);
+
+    CABasicAnimation *radiusAnimation = [CABasicAnimation animationWithKeyPath:@"shadowRadius"];
+    radiusAnimation.fromValue = @(fromRadius);
+    radiusAnimation.toValue = @(toRadius);
+
+    CAAnimationGroup *group = [CAAnimationGroup animation];
+    group.animations = @[opacityAnimation, radiusAnimation];
+    group.duration = duration;
+    group.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+    [self.effectView.layer addAnimation:group forKey:animationKey];
+}
+
+- (void)playRecordingRippleIfNeeded {
+    if (SPOverlayShouldReduceMotion()) return;
+    if (![self.currentState hasPrefix:@"recording"]) return;
+    if (!self.contentView.layer) return;
+
+    [self clearRecordingRippleIfNeeded];
+
+    CGFloat maxRadius = fmax(22.0, [self basePillHeight] * 0.72);
+    CGFloat baseRadius = maxRadius * 0.34;
+    CGFloat centerX = SPOverlayHorizontalPadForFont([self contentFont]) + [self iconAreaWidth] / 2.0;
+    CGFloat centerY = NSMidY(self.contentView.bounds);
+
+    CAShapeLayer *ringLayer = [CAShapeLayer layer];
+    ringLayer.bounds = CGRectMake(0, 0, maxRadius * 2.0, maxRadius * 2.0);
+    ringLayer.position = CGPointMake(centerX, centerY);
+    CGPathRef ringPath = CGPathCreateWithEllipseInRect(CGRectInset(ringLayer.bounds, 1.0, 1.0), NULL);
+    ringLayer.path = ringPath;
+    CGPathRelease(ringPath);
+    ringLayer.fillColor = NSColor.clearColor.CGColor;
+    ringLayer.strokeColor = [NSColor colorWithWhite:1.0 alpha:0.20].CGColor;
+    ringLayer.lineWidth = 1.3;
+    ringLayer.opacity = 0.0;
+    self.recordingRippleLayer = ringLayer;
+    [self.contentView.layer addSublayer:ringLayer];
+
+    CABasicAnimation *scaleAnimation = [CABasicAnimation animationWithKeyPath:@"transform.scale"];
+    scaleAnimation.fromValue = @(baseRadius / maxRadius);
+    scaleAnimation.toValue = @1.0;
+
+    CAKeyframeAnimation *opacityAnimation = [CAKeyframeAnimation animationWithKeyPath:@"opacity"];
+    opacityAnimation.values = @[@0.0, @0.22, @0.0];
+    opacityAnimation.keyTimes = @[@0.0, @0.3, @1.0];
+
+    CAAnimationGroup *group = [CAAnimationGroup animation];
+    group.animations = @[scaleAnimation, opacityAnimation];
+    group.duration = kRippleDuration;
+    group.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+    group.removedOnCompletion = YES;
+    [ringLayer addAnimation:group forKey:@"recordingRipple"];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((kRippleDuration + 0.05) * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (self.recordingRippleLayer == ringLayer) {
+            [self clearRecordingRippleIfNeeded];
+        } else {
+            [ringLayer removeFromSuperlayer];
+        }
+    });
 }
 
 - (NSString *)currentDisplayText {
@@ -904,10 +1059,10 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     };
 
     // Light glow shadow (visible on dark backgrounds)
-    effectView.layer.shadowColor   = [[NSColor whiteColor] CGColor];
-    effectView.layer.shadowOpacity = 0.15;
-    effectView.layer.shadowRadius  = 6.0;
-    effectView.layer.shadowOffset  = CGSizeMake(0, 0);
+    effectView.layer.shadowColor   = SPOverlayShadowColor().CGColor;
+    effectView.layer.shadowOpacity = kBaseShadowOpacity;
+    effectView.layer.shadowRadius  = kBaseShadowRadius;
+    effectView.layer.shadowOffset  = CGSizeMake(0, -1.0);
 
     panel.contentView = effectView;
     self.effectView = effectView;
@@ -1269,17 +1424,17 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     bgView.maskImage = mask;
 
     // Glow shadow (match main pill)
-    bgView.layer.shadowColor = [[NSColor whiteColor] CGColor];
-    bgView.layer.shadowOpacity = 0.15;
-    bgView.layer.shadowRadius = 6.0;
-    bgView.layer.shadowOffset = CGSizeMake(0, 0);
+    bgView.layer.shadowColor = SPOverlayShadowColor().CGColor;
+    bgView.layer.shadowOpacity = kBaseShadowOpacity;
+    bgView.layer.shadowRadius = kBaseShadowRadius;
+    bgView.layer.shadowOffset = CGSizeMake(0, -1.0);
 
     bar.contentView = bgView;
 
     // Dark tint overlay (match main pill contrast)
     NSView *tintView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, totalW, barH)];
     tintView.wantsLayer = YES;
-    tintView.layer.backgroundColor = [[NSColor colorWithWhite:0.0 alpha:0.35] CGColor];
+    tintView.layer.backgroundColor = SPOverlaySurfaceTintColor().CGColor;
     tintView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     [bgView addSubview:tintView];
 
@@ -1493,21 +1648,102 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 #pragma mark - Show / Hide
 
 - (void)show {
+    BOOL wasVisible = self.panel.isVisible && self.panel.alphaValue > 0.01;
+    [self resetMotionPresentationState];
     [self.panel orderFrontRegardless];
+
+    if (wasVisible || SPOverlayShouldReduceMotion()) {
+        if (!wasVisible) {
+            self.panel.alphaValue = 0.0;
+        }
+        [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
+            ctx.duration = SPOverlayShouldReduceMotion() ? kFadeInDuration : 0.12;
+            ctx.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+            self.panel.animator.alphaValue = 1.0;
+        }];
+        return;
+    }
+
+    NSRect finalFrame = self.panel.frame;
+    NSRect startFrame = SPOverlayPresentationStartFrame(finalFrame);
+    [self.panel setFrame:startFrame display:YES];
+    self.panel.alphaValue = 0.0;
+
+    CATransform3D startTransform = CATransform3DMakeScale(0.982, 0.982, 1.0);
+    startTransform = CATransform3DTranslate(startTransform, 0.0, -6.0, 0.0);
+    [self animateContentLayerFromTransform:startTransform
+                               toTransform:CATransform3DIdentity
+                               fromOpacity:0.94
+                                 toOpacity:1.0
+                                  duration:kPanelEntranceDuration
+                                 animation:@"overlayContentEntrance"];
+    [self animateShadowFromOpacity:0.05
+                         toOpacity:kEntranceShadowOpacity
+                        fromRadius:2.0
+                          toRadius:kEntranceShadowRadius
+                          duration:kPanelEntranceDuration
+                         animation:@"overlayShadowEntrance"];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((kPanelEntranceDuration * 0.55) * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if (!self.panel.isVisible || self.panel.alphaValue <= 0.0) return;
+        [self animateShadowFromOpacity:kEntranceShadowOpacity
+                             toOpacity:kBaseShadowOpacity
+                            fromRadius:kEntranceShadowRadius
+                              toRadius:kBaseShadowRadius
+                              duration:0.18
+                             animation:@"overlayShadowEntranceSettle"];
+    });
+
     [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
-        ctx.duration = kFadeInDuration;
+        ctx.duration = kPanelEntranceDuration;
+        ctx.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+        [[self.panel animator] setFrame:finalFrame display:YES];
         self.panel.animator.alphaValue = 1.0;
     }];
+    [self playRecordingRippleIfNeeded];
 }
 
 - (void)hide {
     [self hideTemplateButtons];
     [self stopAnimation];
     [self setMainPanelInteractive:NO];
+
+    if (!self.panel.isVisible || self.panel.alphaValue <= 0.01) {
+        [self.panel orderOut:nil];
+        return;
+    }
+
+    [self clearRecordingRippleIfNeeded];
+
+    NSRect currentFrame = self.panel.frame;
+    BOOL reduceMotion = SPOverlayShouldReduceMotion();
+    NSRect endFrame = reduceMotion ? currentFrame : SPOverlayDismissalEndFrame(currentFrame);
+
+    if (!reduceMotion) {
+        CATransform3D endTransform = CATransform3DMakeScale(0.992, 0.992, 1.0);
+        endTransform = CATransform3DTranslate(endTransform, 0.0, -4.0, 0.0);
+        [self animateContentLayerFromTransform:CATransform3DIdentity
+                                   toTransform:endTransform
+                                   fromOpacity:1.0
+                                     toOpacity:0.96
+                                      duration:kPanelExitDuration
+                                     animation:@"overlayContentExit"];
+        [self animateShadowFromOpacity:kBaseShadowOpacity
+                             toOpacity:0.04
+                            fromRadius:kBaseShadowRadius
+                              toRadius:2.0
+                              duration:kPanelExitDuration
+                             animation:@"overlayShadowExit"];
+    }
+
     [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
-        ctx.duration = kFadeOutDuration;
+        ctx.duration = reduceMotion ? kFadeOutDuration : kPanelExitDuration;
+        ctx.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+        [[self.panel animator] setFrame:endFrame display:YES];
         self.panel.animator.alphaValue = 0.0;
     } completionHandler:^{
+        [self resetMotionPresentationState];
         if ([self.currentState isEqualToString:@"idle"] || [self.currentState isEqualToString:@"completed"]) {
             [self.panel orderOut:nil];
         }

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -521,6 +521,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         NSButton *btn = [[NSButton alloc] initWithFrame:NSMakeRect(x, barPad, w, btnH)];
         btn.title = label;
         btn.bordered = NO;
+        btn.focusRingType = NSFocusRingTypeNone;
         btn.wantsLayer = YES;
         btn.layer.cornerRadius = btnH / 2.0;
         btn.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:0.1] CGColor];

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -470,7 +470,20 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     mask.resizingMode = NSImageResizingModeStretch;
     bgView.maskImage = mask;
 
+    // Glow shadow (match main pill)
+    bgView.layer.shadowColor = [[NSColor whiteColor] CGColor];
+    bgView.layer.shadowOpacity = 0.15;
+    bgView.layer.shadowRadius = 6.0;
+    bgView.layer.shadowOffset = CGSizeMake(0, 0);
+
     bar.contentView = bgView;
+
+    // Dark tint overlay (match main pill contrast)
+    NSView *tintView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, totalW, barH)];
+    tintView.wantsLayer = YES;
+    tintView.layer.backgroundColor = [[NSColor colorWithWhite:0.0 alpha:0.35] CGColor];
+    tintView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    [bgView addSubview:tintView];
 
     // Add buttons (name only, no number)
     self.templateButtonViews = [NSMutableArray array];
@@ -480,13 +493,12 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         NSString *label = tmpl[@"name"] ?: @"";
         CGFloat w = [widths[i] floatValue];
 
-        NSButton *btn = [[NSButton alloc] initWithFrame:NSMakeRect(x, barPad, w, btnH)];
-        btn.title = label;
+        NSButton *btn = [NSButton buttonWithTitle:label target:self action:@selector(templateButtonClicked:)];
+        btn.frame = NSMakeRect(x, barPad, w, btnH);
         btn.bezelStyle = NSBezelStyleInline;
         btn.font = [NSFont systemFontOfSize:11 weight:NSFontWeightMedium];
+        btn.contentTintColor = [NSColor colorWithWhite:1.0 alpha:0.85];
         btn.tag = (NSInteger)i;
-        btn.target = self;
-        btn.action = @selector(templateButtonClicked:);
         [bgView addSubview:btn];
         [self.templateButtonViews addObject:btn];
 

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -510,7 +510,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     tintView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     [bgView addSubview:tintView];
 
-    // Add buttons (name only, no number)
+    // Add buttons (borderless, plain text style)
     self.templateButtonViews = [NSMutableArray array];
     CGFloat x = barPad;
     for (NSUInteger i = 0; i < templates.count; i++) {
@@ -518,12 +518,17 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         NSString *label = tmpl[@"name"] ?: @"";
         CGFloat w = [widths[i] floatValue];
 
-        NSButton *btn = [NSButton buttonWithTitle:label target:self action:@selector(templateButtonClicked:)];
-        btn.frame = NSMakeRect(x, barPad, w, btnH);
-        btn.bezelStyle = NSBezelStyleInline;
+        NSButton *btn = [[NSButton alloc] initWithFrame:NSMakeRect(x, barPad, w, btnH)];
+        btn.title = label;
+        btn.bordered = NO;
+        btn.wantsLayer = YES;
+        btn.layer.cornerRadius = btnH / 2.0;
+        btn.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:0.1] CGColor];
         btn.font = [NSFont systemFontOfSize:11 weight:NSFontWeightMedium];
         btn.contentTintColor = [NSColor colorWithWhite:1.0 alpha:0.85];
         btn.tag = (NSInteger)i;
+        btn.target = self;
+        btn.action = @selector(templateButtonClicked:);
         [bgView addSubview:btn];
         [self.templateButtonViews addObject:btn];
 
@@ -606,30 +611,25 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     return NO;
 }
 
-/// Briefly highlight a button with a scale+glow animation, then trigger the delegate.
+/// Smoothly highlight a button, then trigger the delegate.
 - (void)highlightButtonAtIndex:(NSInteger)index thenDismiss:(BOOL)dismiss {
     if (index < 0 || index >= (NSInteger)self.templateButtonViews.count) return;
 
     NSButton *btn = self.templateButtonViews[index];
     NSInteger templateIndex = index;
 
-    // Flash highlight animation
-    btn.wantsLayer = YES;
-    btn.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:0.4] CGColor];
+    // Dim all other buttons, brighten selected one
+    for (NSButton *b in self.templateButtonViews) {
+        b.alphaValue = (b == btn) ? 1.0 : 0.3;
+    }
+    btn.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:0.3] CGColor];
 
-    [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
-        ctx.duration = 0.15;
-        ctx.allowsImplicitAnimation = YES;
-        btn.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:0.6] CGColor];
-        btn.alphaValue = 1.0;
-    } completionHandler:^{
-        // Brief pause then dismiss
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
-                       dispatch_get_main_queue(), ^{
-            [self hideTemplateButtons];
-            [self.delegate overlayPanel:self didSelectTemplateAtIndex:templateIndex];
-        });
-    }];
+    // Brief hold then dismiss
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        [self hideTemplateButtons];
+        [self.delegate overlayPanel:self didSelectTemplateAtIndex:templateIndex];
+    });
 }
 
 #pragma mark - Layout

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -43,6 +43,12 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 
 // ── Content view ─────────────────────────────────────────
 
+@class SPOverlayPanel;
+
+@interface SPOverlayPanel (ContentViewCallbacks)
+- (void)handleTemplateClick:(NSInteger)index;
+@end
+
 @interface SPOverlayContentView : NSView
 @property (nonatomic, copy)   NSString      *statusText;
 @property (nonatomic, copy)   NSString      *interimText;
@@ -50,6 +56,10 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) SPOverlayMode  mode;
 @property (nonatomic, assign) NSInteger      tick;  // animation counter
 @property (nonatomic, assign) CGFloat       layoutWidth;
+@property (nonatomic, strong) NSArray<NSDictionary *> *templates;
+@property (nonatomic, assign) BOOL showingTemplates;
+@property (nonatomic, assign) NSInteger hoveredIndex;
+@property (nonatomic, weak)   SPOverlayPanel *owner;
 @end
 
 @implementation SPOverlayContentView
@@ -109,6 +119,48 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         CGFloat textY = (bounds.size.height - textRect.size.height) / 2.0;
         [str drawWithRect:NSMakeRect(textX, textY, textMaxW, textRect.size.height)
                   options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine];
+    }
+
+    // Draw template buttons if showing
+    if (self.showingTemplates && self.templates.count > 0) {
+        CGFloat buttonY = 4;
+        CGFloat buttonH = 28;
+        CGFloat buttonPad = 8;
+        CGFloat buttonSpacing = 8;
+        CGFloat startX = kHorizontalPad;
+
+        // Separator line
+        CGFloat sepY = buttonH + buttonPad + 2;
+        [[NSColor colorWithWhite:1.0 alpha:0.15] setFill];
+        NSRectFill(NSMakeRect(kHorizontalPad, sepY, bounds.size.width - 2 * kHorizontalPad, 1));
+
+        CGFloat x = startX;
+        for (NSUInteger i = 0; i < self.templates.count; i++) {
+            NSDictionary *tmpl = self.templates[i];
+            NSString *name = tmpl[@"name"] ?: @"";
+            NSNumber *shortcut = tmpl[@"shortcut"];
+            NSString *label = [NSString stringWithFormat:@"%@  %@", shortcut, name];
+
+            NSDictionary *attrs = @{
+                NSFontAttributeName: [NSFont systemFontOfSize:12 weight:NSFontWeightMedium],
+                NSForegroundColorAttributeName: [NSColor colorWithWhite:1.0 alpha:0.9],
+            };
+            NSSize textSize = [label sizeWithAttributes:attrs];
+            CGFloat btnW = textSize.width + 16;
+
+            // Button background
+            NSRect btnRect = NSMakeRect(x, buttonY, btnW, buttonH);
+            CGFloat alpha = (self.hoveredIndex == (NSInteger)i) ? 0.35 : 0.15;
+            NSBezierPath *btnPath = [NSBezierPath bezierPathWithRoundedRect:btnRect xRadius:6 yRadius:6];
+            [[NSColor colorWithWhite:1.0 alpha:alpha] setFill];
+            [btnPath fill];
+
+            // Button text
+            NSRect textRect = NSMakeRect(x + 8, buttonY + (buttonH - textSize.height) / 2.0, textSize.width, textSize.height);
+            [label drawInRect:textRect withAttributes:attrs];
+
+            x += btnW + buttonSpacing;
+        }
     }
 }
 
@@ -209,6 +261,76 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     [path stroke];
 }
 
+#pragma mark - Mouse tracking for template buttons
+
+- (void)updateTrackingAreas {
+    [super updateTrackingAreas];
+    for (NSTrackingArea *area in self.trackingAreas) {
+        [self removeTrackingArea:area];
+    }
+    if (self.showingTemplates) {
+        NSTrackingArea *area = [[NSTrackingArea alloc]
+            initWithRect:self.bounds
+                 options:NSTrackingMouseMoved | NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways
+                   owner:self
+                userInfo:nil];
+        [self addTrackingArea:area];
+    }
+}
+
+- (void)mouseMoved:(NSEvent *)event {
+    if (!self.showingTemplates) return;
+    NSPoint point = [self convertPoint:event.locationInWindow fromView:nil];
+    NSInteger newIndex = [self templateIndexAtPoint:point];
+    if (newIndex != self.hoveredIndex) {
+        self.hoveredIndex = newIndex;
+        [self setNeedsDisplay:YES];
+    }
+}
+
+- (void)mouseExited:(NSEvent *)event {
+    if (self.hoveredIndex != -1) {
+        self.hoveredIndex = -1;
+        [self setNeedsDisplay:YES];
+    }
+}
+
+- (void)mouseDown:(NSEvent *)event {
+    if (!self.showingTemplates) return;
+    NSPoint point = [self convertPoint:event.locationInWindow fromView:nil];
+    NSInteger idx = [self templateIndexAtPoint:point];
+    if (idx >= 0 && idx < (NSInteger)self.templates.count) {
+        [self.owner handleTemplateClick:idx];
+    }
+}
+
+- (NSInteger)templateIndexAtPoint:(NSPoint)point {
+    CGFloat buttonY = 4;
+    CGFloat buttonH = 28;
+    if (point.y < buttonY || point.y > buttonY + buttonH) return -1;
+
+    CGFloat x = kHorizontalPad;
+    CGFloat buttonSpacing = 8;
+    NSDictionary *attrs = @{
+        NSFontAttributeName: [NSFont systemFontOfSize:12 weight:NSFontWeightMedium],
+    };
+
+    for (NSUInteger i = 0; i < self.templates.count; i++) {
+        NSDictionary *tmpl = self.templates[i];
+        NSString *name = tmpl[@"name"] ?: @"";
+        NSNumber *shortcut = tmpl[@"shortcut"];
+        NSString *label = [NSString stringWithFormat:@"%@  %@", shortcut, name];
+        NSSize textSize = [label sizeWithAttributes:attrs];
+        CGFloat btnW = textSize.width + 16;
+
+        if (point.x >= x && point.x <= x + btnW) {
+            return (NSInteger)i;
+        }
+        x += btnW + buttonSpacing;
+    }
+    return -1;
+}
+
 @end
 
 // ── Main overlay controller ──────────────────────────────
@@ -223,6 +345,9 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, copy)   NSString *currentState;
 @property (nonatomic, assign) CGFloat sessionMaxWidth;
 @property (nonatomic, assign) CGFloat sessionMaxHeight;
+@property (nonatomic, strong) NSArray<NSDictionary *> *templateButtons;
+@property (nonatomic, assign) BOOL showingTemplates;
+@property (nonatomic, assign) NSInteger hoveredButtonIndex;
 
 @end
 
@@ -293,6 +418,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     self.contentView = [[SPOverlayContentView alloc] initWithFrame:rect];
     self.contentView.wantsLayer = YES;
     self.contentView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    self.contentView.owner = self;
     [effectView addSubview:self.contentView];
 
     self.panel = panel;
@@ -399,6 +525,64 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     }];
 }
 
+- (void)showTemplateButtons:(NSArray<NSDictionary *> *)templates {
+    if (templates.count == 0) return;
+    self.templateButtons = templates;
+    self.showingTemplates = YES;
+    self.hoveredButtonIndex = -1;
+    self.contentView.templates = templates;
+    self.contentView.showingTemplates = YES;
+    self.contentView.hoveredIndex = -1;
+
+    // Make panel interactive
+    self.panel.ignoresMouseEvents = NO;
+
+    // Extend linger time when templates are showing
+    [self.lingerTimer invalidate];
+    self.lingerTimer = nil;
+    self.lingerTimer = [NSTimer scheduledTimerWithTimeInterval:5.0
+                                                      repeats:NO
+                                                        block:^(NSTimer *timer) {
+        self.lingerTimer = nil;
+        [self hideTemplateButtons];
+        self.sessionMaxWidth = 0;
+        self.sessionMaxHeight = 0;
+        [self hide];
+        self.currentState = @"idle";
+    }];
+
+    [self resizeAndCenterAnimated:YES];
+    [self.contentView setNeedsDisplay:YES];
+}
+
+- (void)hideTemplateButtons {
+    self.showingTemplates = NO;
+    self.templateButtons = nil;
+    self.contentView.showingTemplates = NO;
+    self.contentView.templates = nil;
+    self.panel.ignoresMouseEvents = YES;
+    [self.contentView setNeedsDisplay:YES];
+}
+
+- (BOOL)handleNumberKey:(NSInteger)number {
+    if (!self.showingTemplates || !self.templateButtons) return NO;
+    for (NSUInteger i = 0; i < self.templateButtons.count; i++) {
+        NSDictionary *tmpl = self.templateButtons[i];
+        NSNumber *shortcut = tmpl[@"shortcut"];
+        if (shortcut && shortcut.integerValue == number) {
+            [self hideTemplateButtons];
+            [self.delegate overlayPanel:self didSelectTemplateAtIndex:i];
+            return YES;
+        }
+    }
+    return NO;
+}
+
+- (void)handleTemplateClick:(NSInteger)index {
+    [self hideTemplateButtons];
+    [self.delegate overlayPanel:self didSelectTemplateAtIndex:index];
+}
+
 #pragma mark - Layout
 
 - (void)resizeAndCenterAnimated:(BOOL)animated {
@@ -424,13 +608,24 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     CGFloat pillW = desiredW;
     CGFloat pillH = kPillHeight;
 
+    // Add height for template buttons row
+    if (self.showingTemplates && self.contentView.templates.count > 0) {
+        pillH += 38; // button row height (28) + padding (10)
+    }
+
     if (desiredW > absoluteMaxW) {
         pillW = absoluteMaxW;
         // Only calculate height (multi-line) if it actually overflows absoluteMaxW
         CGFloat textMaxW = pillW - iconSpace - kHorizontalPad;
         NSRect textRect = [str boundingRectWithSize:NSMakeSize(textMaxW, kMaxHeight)
                                             options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine];
-        pillH = fmax(kPillHeight, ceil(textRect.size.height) + 20.0);
+        CGFloat textH = fmax(kPillHeight, ceil(textRect.size.height) + 20.0);
+        // Preserve template button row height if already added
+        if (self.showingTemplates && self.contentView.templates.count > 0) {
+            pillH = fmax(textH, pillH);
+        } else {
+            pillH = textH;
+        }
     }
 
     // 3. Stabilization: Only-grow during active session

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -43,23 +43,13 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 
 // ── Content view ─────────────────────────────────────────
 
-@class SPOverlayPanel;
-
-@interface SPOverlayPanel (ContentViewCallbacks)
-- (void)handleTemplateClick:(NSInteger)index;
-@end
-
 @interface SPOverlayContentView : NSView
 @property (nonatomic, copy)   NSString      *statusText;
 @property (nonatomic, copy)   NSString      *interimText;
 @property (nonatomic, strong) NSColor       *accentColor;
 @property (nonatomic, assign) SPOverlayMode  mode;
 @property (nonatomic, assign) NSInteger      tick;  // animation counter
-@property (nonatomic, assign) CGFloat       layoutWidth;
-@property (nonatomic, strong) NSArray<NSDictionary *> *templates;
-@property (nonatomic, assign) BOOL showingTemplates;
-@property (nonatomic, assign) NSInteger hoveredIndex;
-@property (nonatomic, weak)   SPOverlayPanel *owner;
+@property (nonatomic, assign) CGFloat        layoutWidth;
 @end
 
 @implementation SPOverlayContentView
@@ -121,47 +111,6 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
                   options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine];
     }
 
-    // Draw template buttons if showing
-    if (self.showingTemplates && self.templates.count > 0) {
-        CGFloat buttonY = 4;
-        CGFloat buttonH = 28;
-        CGFloat buttonPad = 8;
-        CGFloat buttonSpacing = 8;
-        CGFloat startX = kHorizontalPad;
-
-        // Separator line
-        CGFloat sepY = buttonH + buttonPad + 2;
-        [[NSColor colorWithWhite:1.0 alpha:0.15] setFill];
-        NSRectFill(NSMakeRect(kHorizontalPad, sepY, bounds.size.width - 2 * kHorizontalPad, 1));
-
-        CGFloat x = startX;
-        for (NSUInteger i = 0; i < self.templates.count; i++) {
-            NSDictionary *tmpl = self.templates[i];
-            NSString *name = tmpl[@"name"] ?: @"";
-            NSNumber *shortcut = tmpl[@"shortcut"];
-            NSString *label = [NSString stringWithFormat:@"%@  %@", shortcut, name];
-
-            NSDictionary *attrs = @{
-                NSFontAttributeName: [NSFont systemFontOfSize:12 weight:NSFontWeightMedium],
-                NSForegroundColorAttributeName: [NSColor colorWithWhite:1.0 alpha:0.9],
-            };
-            NSSize textSize = [label sizeWithAttributes:attrs];
-            CGFloat btnW = textSize.width + 16;
-
-            // Button background
-            NSRect btnRect = NSMakeRect(x, buttonY, btnW, buttonH);
-            CGFloat alpha = (self.hoveredIndex == (NSInteger)i) ? 0.35 : 0.15;
-            NSBezierPath *btnPath = [NSBezierPath bezierPathWithRoundedRect:btnRect xRadius:6 yRadius:6];
-            [[NSColor colorWithWhite:1.0 alpha:alpha] setFill];
-            [btnPath fill];
-
-            // Button text
-            NSRect textRect = NSMakeRect(x + 8, buttonY + (buttonH - textSize.height) / 2.0, textSize.width, textSize.height);
-            [label drawInRect:textRect withAttributes:attrs];
-
-            x += btnW + buttonSpacing;
-        }
-    }
 }
 
 #pragma mark - Waveform (recording)
@@ -261,76 +210,6 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     [path stroke];
 }
 
-#pragma mark - Mouse tracking for template buttons
-
-- (void)updateTrackingAreas {
-    [super updateTrackingAreas];
-    for (NSTrackingArea *area in self.trackingAreas) {
-        [self removeTrackingArea:area];
-    }
-    if (self.showingTemplates) {
-        NSTrackingArea *area = [[NSTrackingArea alloc]
-            initWithRect:self.bounds
-                 options:NSTrackingMouseMoved | NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways
-                   owner:self
-                userInfo:nil];
-        [self addTrackingArea:area];
-    }
-}
-
-- (void)mouseMoved:(NSEvent *)event {
-    if (!self.showingTemplates) return;
-    NSPoint point = [self convertPoint:event.locationInWindow fromView:nil];
-    NSInteger newIndex = [self templateIndexAtPoint:point];
-    if (newIndex != self.hoveredIndex) {
-        self.hoveredIndex = newIndex;
-        [self setNeedsDisplay:YES];
-    }
-}
-
-- (void)mouseExited:(NSEvent *)event {
-    if (self.hoveredIndex != -1) {
-        self.hoveredIndex = -1;
-        [self setNeedsDisplay:YES];
-    }
-}
-
-- (void)mouseDown:(NSEvent *)event {
-    if (!self.showingTemplates) return;
-    NSPoint point = [self convertPoint:event.locationInWindow fromView:nil];
-    NSInteger idx = [self templateIndexAtPoint:point];
-    if (idx >= 0 && idx < (NSInteger)self.templates.count) {
-        [self.owner handleTemplateClick:idx];
-    }
-}
-
-- (NSInteger)templateIndexAtPoint:(NSPoint)point {
-    CGFloat buttonY = 4;
-    CGFloat buttonH = 28;
-    if (point.y < buttonY || point.y > buttonY + buttonH) return -1;
-
-    CGFloat x = kHorizontalPad;
-    CGFloat buttonSpacing = 8;
-    NSDictionary *attrs = @{
-        NSFontAttributeName: [NSFont systemFontOfSize:12 weight:NSFontWeightMedium],
-    };
-
-    for (NSUInteger i = 0; i < self.templates.count; i++) {
-        NSDictionary *tmpl = self.templates[i];
-        NSString *name = tmpl[@"name"] ?: @"";
-        NSNumber *shortcut = tmpl[@"shortcut"];
-        NSString *label = [NSString stringWithFormat:@"%@  %@", shortcut, name];
-        NSSize textSize = [label sizeWithAttributes:attrs];
-        CGFloat btnW = textSize.width + 16;
-
-        if (point.x >= x && point.x <= x + btnW) {
-            return (NSInteger)i;
-        }
-        x += btnW + buttonSpacing;
-    }
-    return -1;
-}
-
 @end
 
 // ── Main overlay controller ──────────────────────────────
@@ -347,7 +226,8 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) CGFloat sessionMaxHeight;
 @property (nonatomic, strong) NSArray<NSDictionary *> *templateButtons;
 @property (nonatomic, assign) BOOL showingTemplates;
-@property (nonatomic, assign) NSInteger hoveredButtonIndex;
+@property (nonatomic, strong) NSPanel *buttonBarPanel;
+@property (nonatomic, strong) NSMutableArray<NSButton *> *templateButtonViews;
 
 @end
 
@@ -418,7 +298,6 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     self.contentView = [[SPOverlayContentView alloc] initWithFrame:rect];
     self.contentView.wantsLayer = YES;
     self.contentView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-    self.contentView.owner = self;
     [effectView addSubview:self.contentView];
 
     self.panel = panel;
@@ -529,13 +408,106 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     if (templates.count == 0) return;
     self.templateButtons = templates;
     self.showingTemplates = YES;
-    self.hoveredButtonIndex = -1;
-    self.contentView.templates = templates;
-    self.contentView.showingTemplates = YES;
-    self.contentView.hoveredIndex = -1;
 
-    // Make panel interactive
-    self.panel.ignoresMouseEvents = NO;
+    // Remove old button bar
+    [self.buttonBarPanel orderOut:nil];
+    self.buttonBarPanel = nil;
+    self.templateButtonViews = nil;
+
+    // Calculate button sizes — only show name, no shortcut number
+    CGFloat btnH = 26;
+    CGFloat btnSpacing = 8;
+    CGFloat barPad = 6;
+    NSDictionary *attrs = @{
+        NSFontAttributeName: [NSFont systemFontOfSize:11 weight:NSFontWeightMedium],
+    };
+
+    CGFloat totalW = 0;
+    NSMutableArray<NSNumber *> *widths = [NSMutableArray array];
+    for (NSDictionary *tmpl in templates) {
+        NSString *label = tmpl[@"name"] ?: @"";
+        CGFloat w = [label sizeWithAttributes:attrs].width + 24;
+        w = fmax(w, 60); // minimum button width
+        [widths addObject:@(w)];
+        totalW += w;
+    }
+    totalW += (templates.count - 1) * btnSpacing + 2 * barPad;
+    CGFloat barH = btnH + 2 * barPad;
+
+    // Create button bar panel
+    NSPanel *bar = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, totalW, barH)
+                                              styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
+                                                backing:NSBackingStoreBuffered
+                                                  defer:YES];
+    bar.level = NSStatusWindowLevel;
+    bar.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces |
+                             NSWindowCollectionBehaviorStationary |
+                             NSWindowCollectionBehaviorFullScreenAuxiliary;
+    bar.backgroundColor = [NSColor clearColor];
+    bar.opaque = NO;
+    bar.hasShadow = NO;
+    bar.ignoresMouseEvents = NO;
+    bar.hidesOnDeactivate = NO;
+
+    // Background with vibrancy
+    NSVisualEffectView *bgView = [[NSVisualEffectView alloc] initWithFrame:NSMakeRect(0, 0, totalW, barH)];
+    bgView.material = NSVisualEffectMaterialHUDWindow;
+    bgView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
+    bgView.state = NSVisualEffectStateActive;
+    bgView.appearance = [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
+    bgView.wantsLayer = YES;
+
+    // Pill shape mask for button bar
+    CGFloat cornerR = barH / 2.0;
+    NSImage *mask = [NSImage imageWithSize:NSMakeSize(cornerR * 2 + 1, barH)
+                                   flipped:NO
+                            drawingHandler:^BOOL(NSRect dstRect) {
+        [[NSColor blackColor] setFill];
+        [[NSBezierPath bezierPathWithRoundedRect:dstRect xRadius:cornerR yRadius:cornerR] fill];
+        return YES;
+    }];
+    mask.capInsets = NSEdgeInsetsMake(cornerR, cornerR, cornerR, cornerR);
+    mask.resizingMode = NSImageResizingModeStretch;
+    bgView.maskImage = mask;
+
+    bar.contentView = bgView;
+
+    // Add buttons (name only, no number)
+    self.templateButtonViews = [NSMutableArray array];
+    CGFloat x = barPad;
+    for (NSUInteger i = 0; i < templates.count; i++) {
+        NSDictionary *tmpl = templates[i];
+        NSString *label = tmpl[@"name"] ?: @"";
+        CGFloat w = [widths[i] floatValue];
+
+        NSButton *btn = [[NSButton alloc] initWithFrame:NSMakeRect(x, barPad, w, btnH)];
+        btn.title = label;
+        btn.bezelStyle = NSBezelStyleInline;
+        btn.font = [NSFont systemFontOfSize:11 weight:NSFontWeightMedium];
+        btn.tag = (NSInteger)i;
+        btn.target = self;
+        btn.action = @selector(templateButtonClicked:);
+        [bgView addSubview:btn];
+        [self.templateButtonViews addObject:btn];
+
+        x += w + btnSpacing;
+    }
+
+    // Position above the main pill with 6pt gap
+    NSRect pillFrame = self.panel.frame;
+    CGFloat barX = NSMidX(pillFrame) - totalW / 2.0;
+    CGFloat barY = NSMaxY(pillFrame) + 6;
+    [bar setFrame:NSMakeRect(barX, barY, totalW, barH) display:YES];
+
+    // Fade in
+    bar.alphaValue = 0.0;
+    [bar orderFrontRegardless];
+    [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
+        ctx.duration = 0.2;
+        bar.animator.alphaValue = 1.0;
+    }];
+
+    self.buttonBarPanel = bar;
 
     // Extend linger time when templates are showing
     [self.lingerTimer invalidate];
@@ -550,18 +522,27 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         [self hide];
         self.currentState = @"idle";
     }];
+}
 
-    [self resizeAndCenterAnimated:YES];
-    [self.contentView setNeedsDisplay:YES];
+- (void)templateButtonClicked:(NSButton *)sender {
+    NSInteger index = sender.tag;
+    [self highlightButtonAtIndex:index thenDismiss:YES];
 }
 
 - (void)hideTemplateButtons {
     self.showingTemplates = NO;
     self.templateButtons = nil;
-    self.contentView.showingTemplates = NO;
-    self.contentView.templates = nil;
-    self.panel.ignoresMouseEvents = YES;
-    [self.contentView setNeedsDisplay:YES];
+    self.templateButtonViews = nil;
+    if (self.buttonBarPanel) {
+        NSPanel *barToHide = self.buttonBarPanel;
+        self.buttonBarPanel = nil;
+        [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
+            ctx.duration = 0.2;
+            barToHide.animator.alphaValue = 0.0;
+        } completionHandler:^{
+            [barToHide orderOut:nil];
+        }];
+    }
 }
 
 - (BOOL)handleNumberKey:(NSInteger)number {
@@ -570,17 +551,37 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         NSDictionary *tmpl = self.templateButtons[i];
         NSNumber *shortcut = tmpl[@"shortcut"];
         if (shortcut && shortcut.integerValue == number) {
-            [self hideTemplateButtons];
-            [self.delegate overlayPanel:self didSelectTemplateAtIndex:i];
+            [self highlightButtonAtIndex:(NSInteger)i thenDismiss:YES];
             return YES;
         }
     }
     return NO;
 }
 
-- (void)handleTemplateClick:(NSInteger)index {
-    [self hideTemplateButtons];
-    [self.delegate overlayPanel:self didSelectTemplateAtIndex:index];
+/// Briefly highlight a button with a scale+glow animation, then trigger the delegate.
+- (void)highlightButtonAtIndex:(NSInteger)index thenDismiss:(BOOL)dismiss {
+    if (index < 0 || index >= (NSInteger)self.templateButtonViews.count) return;
+
+    NSButton *btn = self.templateButtonViews[index];
+    NSInteger templateIndex = index;
+
+    // Flash highlight animation
+    btn.wantsLayer = YES;
+    btn.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:0.4] CGColor];
+
+    [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
+        ctx.duration = 0.15;
+        ctx.allowsImplicitAnimation = YES;
+        btn.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:0.6] CGColor];
+        btn.alphaValue = 1.0;
+    } completionHandler:^{
+        // Brief pause then dismiss
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            [self hideTemplateButtons];
+            [self.delegate overlayPanel:self didSelectTemplateAtIndex:templateIndex];
+        });
+    }];
 }
 
 #pragma mark - Layout
@@ -608,24 +609,12 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     CGFloat pillW = desiredW;
     CGFloat pillH = kPillHeight;
 
-    // Add height for template buttons row
-    if (self.showingTemplates && self.contentView.templates.count > 0) {
-        pillH += 38; // button row height (28) + padding (10)
-    }
-
     if (desiredW > absoluteMaxW) {
         pillW = absoluteMaxW;
-        // Only calculate height (multi-line) if it actually overflows absoluteMaxW
         CGFloat textMaxW = pillW - iconSpace - kHorizontalPad;
         NSRect textRect = [str boundingRectWithSize:NSMakeSize(textMaxW, kMaxHeight)
                                             options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine];
-        CGFloat textH = fmax(kPillHeight, ceil(textRect.size.height) + 20.0);
-        // Preserve template button row height if already added
-        if (self.showingTemplates && self.contentView.templates.count > 0) {
-            pillH = fmax(textH, pillH);
-        } else {
-            pillH = textH;
-        }
+        pillH = fmax(kPillHeight, ceil(textRect.size.height) + 20.0);
     }
 
     // 3. Stabilization: Only-grow during active session
@@ -671,6 +660,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 }
 
 - (void)hide {
+    [self hideTemplateButtons];
     [self stopAnimation];
     [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
         ctx.duration = kFadeOutDuration;

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -1,15 +1,21 @@
 #import "SPOverlayPanel.h"
+#import "koe_core.h"
 #import <QuartzCore/QuartzCore.h>
 
 // ── Geometry ──────────────────────────────────────────────
-static const CGFloat kPillHeight       = 36.0;
-static const CGFloat kPillCornerRadius = 18.0;
-static const CGFloat kBottomMargin     = 10.0;
-static const CGFloat kHorizontalPad    = 14.0;
-static const CGFloat kIconAreaWidth    = 28.0;
-static const CGFloat kIconTextGap      = 6.0;
+static const CGFloat kMinimumPillHeight = 36.0;
+static const CGFloat kDefaultBottomMargin = 10.0;
+static const CGFloat kDefaultTextFontSize = 13.0;
+static NSString *const kDefaultFontFamily = @"system";
+static const BOOL kDefaultLimitVisibleLines = YES;
+static const NSInteger kDefaultMaxVisibleLines = 3;
+static const NSInteger kMinVisibleLines = 3;
+static const NSInteger kMaxVisibleLines = 5;
+static const CGFloat kMinTextFontSize = 12.0;
+static const CGFloat kMaxTextFontSize = 28.0;
+static const CGFloat kMaxBottomMargin = 180.0;
 static const CGFloat kMaxWidth         = 600.0;
-static const CGFloat kMaxHeight        = 300.0;
+static const NSTimeInterval kTextScrollDuration = 0.18;
 
 // Waveform bars
 static const NSInteger kBarCount   = 5;
@@ -34,6 +40,215 @@ static const NSTimeInterval kResizeDuration    = 0.15;
 static const NSTimeInterval kMinLingerDuration = 0.45;
 static const NSTimeInterval kMaxLingerDuration = 1.2;
 static const NSTimeInterval kTemplateLingerDuration = 3.0;
+
+static CGFloat SPOverlayClampTextFontSize(CGFloat fontSize) {
+    return fmin(fmax(fontSize, kMinTextFontSize), kMaxTextFontSize);
+}
+
+static CGFloat SPOverlayClampBottomMargin(CGFloat bottomMargin) {
+    return fmin(fmax(bottomMargin, 0.0), kMaxBottomMargin);
+}
+
+static NSInteger SPOverlayClampMaxVisibleLines(NSInteger maxVisibleLines) {
+    return MAX(kMinVisibleLines, MIN(kMaxVisibleLines, maxVisibleLines));
+}
+
+static CGFloat SPOverlayConfigCGFloat(const char *keyPath, CGFloat fallback) {
+    char *raw = sp_config_get(keyPath);
+    if (!raw) return fallback;
+
+    NSString *value = [NSString stringWithUTF8String:raw];
+    sp_core_free_string(raw);
+    if (value.length == 0) return fallback;
+
+    NSScanner *scanner = [NSScanner scannerWithString:value];
+    double parsedValue = 0.0;
+    if (![scanner scanDouble:&parsedValue] || !scanner.isAtEnd) {
+        return fallback;
+    }
+
+    return parsedValue;
+}
+
+static BOOL SPOverlayConfigBOOL(const char *keyPath, BOOL fallback) {
+    char *raw = sp_config_get(keyPath);
+    if (!raw) return fallback;
+
+    NSString *value = [[[NSString stringWithUTF8String:raw] ?: @""
+        stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    sp_core_free_string(raw);
+    if (value.length == 0) return fallback;
+
+    if ([value isEqualToString:@"1"] ||
+        [value isEqualToString:@"true"] ||
+        [value isEqualToString:@"yes"] ||
+        [value isEqualToString:@"on"]) {
+        return YES;
+    }
+
+    if ([value isEqualToString:@"0"] ||
+        [value isEqualToString:@"false"] ||
+        [value isEqualToString:@"no"] ||
+        [value isEqualToString:@"off"]) {
+        return NO;
+    }
+
+    return fallback;
+}
+
+static NSString *SPOverlayNormalizeFontFamily(NSString *fontFamily) {
+    NSString *normalized = [[fontFamily ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+    if (normalized.length == 0) {
+        return kDefaultFontFamily;
+    }
+    return normalized;
+}
+
+static BOOL SPOverlayUsesSystemFont(NSString *fontFamily) {
+    return [SPOverlayNormalizeFontFamily(fontFamily) caseInsensitiveCompare:kDefaultFontFamily] == NSOrderedSame;
+}
+
+static NSString *SPOverlayConfigString(const char *keyPath, NSString *fallback) {
+    char *raw = sp_config_get(keyPath);
+    if (!raw) return fallback;
+
+    NSString *value = [NSString stringWithUTF8String:raw] ?: @"";
+    sp_core_free_string(raw);
+    NSString *normalized = SPOverlayNormalizeFontFamily(value);
+    return normalized.length > 0 ? normalized : fallback;
+}
+
+static NSFont *SPOverlayFontForFamily(NSString *fontFamily, CGFloat fontSize) {
+    CGFloat clampedFontSize = SPOverlayClampTextFontSize(fontSize);
+    NSString *normalized = SPOverlayNormalizeFontFamily(fontFamily);
+
+    if (SPOverlayUsesSystemFont(normalized)) {
+        return [NSFont systemFontOfSize:clampedFontSize weight:NSFontWeightMedium];
+    }
+
+    NSFont *font = [NSFont fontWithName:normalized size:clampedFontSize];
+    if (font) {
+        return font;
+    }
+
+    NSFontManager *fontManager = [NSFontManager sharedFontManager];
+    font = [fontManager fontWithFamily:normalized traits:0 weight:5 size:clampedFontSize];
+    if (font) {
+        return font;
+    }
+
+    for (NSArray *member in [fontManager availableMembersOfFontFamily:normalized]) {
+        if (member.count == 0) continue;
+        NSString *memberName = member[0];
+        font = [NSFont fontWithName:memberName size:clampedFontSize];
+        if (font) {
+            return font;
+        }
+    }
+
+    return [NSFont systemFontOfSize:clampedFontSize weight:NSFontWeightMedium];
+}
+
+static CGFloat SPOverlayLineHeightForFont(NSFont *font) {
+    if (!font) return ceil(kDefaultTextFontSize);
+    NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
+    return ceil([layoutManager defaultLineHeightForFont:font]);
+}
+
+static CGFloat SPOverlayHorizontalPadForFont(NSFont *font) {
+    CGFloat lineHeight = SPOverlayLineHeightForFont(font);
+    return ceil(MAX(14.0, MIN(22.0, lineHeight * 0.55)));
+}
+
+static CGFloat SPOverlayIconTextGapForFont(NSFont *font) {
+    CGFloat lineHeight = SPOverlayLineHeightForFont(font);
+    return ceil(MAX(6.0, MIN(10.0, lineHeight * 0.24)));
+}
+
+static CGFloat SPOverlayTextTopPadForFont(NSFont *font) {
+    CGFloat lineHeight = SPOverlayLineHeightForFont(font);
+    return ceil(MAX(12.0, MIN(18.0, lineHeight * 0.48)));
+}
+
+static CGFloat SPOverlayTextBottomPadForFont(NSFont *font) {
+    CGFloat lineHeight = SPOverlayLineHeightForFont(font);
+    return ceil(MAX(12.0, MIN(18.0, lineHeight * 0.44)));
+}
+
+static CGFloat SPOverlayTextTrailingPadForFont(NSFont *font) {
+    CGFloat lineHeight = SPOverlayLineHeightForFont(font);
+    return ceil(MAX(18.0, MIN(26.0, lineHeight * 0.72)));
+}
+
+static CGFloat SPOverlayLineLimitSlackForFont(NSFont *font) {
+    CGFloat lineHeight = SPOverlayLineHeightForFont(font);
+    return ceil(MAX(2.0, MIN(4.0, lineHeight * 0.12)));
+}
+
+static NSDictionary *SPOverlayTextAttributes(NSFont *font) {
+    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
+    return @{
+        NSFontAttributeName: font ?: [NSFont systemFontOfSize:kDefaultTextFontSize weight:NSFontWeightMedium],
+        NSForegroundColorAttributeName: [NSColor colorWithWhite:1.0 alpha:0.92],
+        NSParagraphStyleAttributeName: paragraphStyle,
+    };
+}
+
+static CGFloat SPOverlayMeasureTextHeight(NSString *text, NSFont *font, CGFloat width) {
+    CGFloat safeWidth = fmax(1.0, width);
+    NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:
+        [[NSAttributedString alloc] initWithString:text ?: @""
+                                        attributes:SPOverlayTextAttributes(font)]];
+    NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
+    NSTextContainer *textContainer = [[NSTextContainer alloc] initWithContainerSize:NSMakeSize(safeWidth, CGFLOAT_MAX)];
+    textContainer.lineFragmentPadding = 0.0;
+    textContainer.widthTracksTextView = NO;
+    [layoutManager addTextContainer:textContainer];
+    [textStorage addLayoutManager:layoutManager];
+    [layoutManager ensureLayoutForTextContainer:textContainer];
+    return ceil([layoutManager usedRectForTextContainer:textContainer].size.height);
+}
+
+static CGFloat SPOverlayMeasureVisibleHeightForLineLimit(NSString *text, NSFont *font, CGFloat width, NSInteger maxVisibleLines) {
+    CGFloat safeWidth = fmax(1.0, width);
+    NSInteger clampedMaxVisibleLines = SPOverlayClampMaxVisibleLines(maxVisibleLines);
+    NSDictionary *attrs = SPOverlayTextAttributes(font);
+    NSTextStorage *textStorage = [[NSTextStorage alloc] initWithAttributedString:
+        [[NSAttributedString alloc] initWithString:text ?: @""
+                                        attributes:attrs]];
+    NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
+    NSTextContainer *textContainer = [[NSTextContainer alloc] initWithContainerSize:NSMakeSize(safeWidth, CGFLOAT_MAX)];
+    textContainer.lineFragmentPadding = 0.0;
+    textContainer.widthTracksTextView = NO;
+    [layoutManager addTextContainer:textContainer];
+    [textStorage addLayoutManager:layoutManager];
+    [layoutManager ensureLayoutForTextContainer:textContainer];
+
+    NSUInteger glyphCount = layoutManager.numberOfGlyphs;
+    if (glyphCount == 0) {
+        return SPOverlayLineHeightForFont(font);
+    }
+
+    NSUInteger glyphIndex = 0;
+    NSInteger lineCount = 0;
+    CGFloat visibleHeight = 0.0;
+    while (glyphIndex < glyphCount) {
+        NSRange lineGlyphRange = NSMakeRange(0, 0);
+        NSRect lineFragmentRect = [layoutManager lineFragmentRectForGlyphAtIndex:glyphIndex
+                                                                  effectiveRange:&lineGlyphRange
+                                                            withoutAdditionalLayout:YES];
+        lineCount += 1;
+        visibleHeight = ceil(NSMaxY(lineFragmentRect));
+        glyphIndex = NSMaxRange(lineGlyphRange);
+        if (lineCount >= clampedMaxVisibleLines) {
+            break;
+        }
+    }
+
+    CGFloat totalHeight = ceil([layoutManager usedRectForTextContainer:textContainer].size.height);
+    return fmin(fmax(SPOverlayLineHeightForFont(font), visibleHeight), totalHeight);
+}
 
 // ── Animation mode ───────────────────────────────────────
 typedef NS_ENUM(NSInteger, SPOverlayMode) {
@@ -184,14 +399,176 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) SPOverlayMode  mode;
 @property (nonatomic, assign) NSInteger      tick;  // animation counter
 @property (nonatomic, assign) CGFloat        layoutWidth;
+@property (nonatomic, assign) CGFloat        textFontSize;
+@property (nonatomic, copy)   NSString      *fontFamily;
+@property (nonatomic, assign) CGFloat        cornerRadius;
+@property (nonatomic, assign) CGFloat        iconAreaWidth;
+@property (nonatomic, assign) CGFloat        textViewportHeight;
+- (void)updateTextAttributes;
+- (void)refreshDisplayedTextAnimated:(BOOL)animated;
+@end
+
+@interface SPOverlayContentView ()
+@property (nonatomic, strong) NSScrollView *textScrollView;
+@property (nonatomic, strong) NSTextView *textView;
 @end
 
 @implementation SPOverlayContentView
 
 - (BOOL)isFlipped { return NO; }
 
+- (instancetype)initWithFrame:(NSRect)frameRect {
+    self = [super initWithFrame:frameRect];
+    if (self) {
+        [self setupTextViewport];
+    }
+    return self;
+}
+
+- (NSFont *)contentFont {
+    return SPOverlayFontForFamily(self.fontFamily, self.textFontSize > 0 ? self.textFontSize : kDefaultTextFontSize);
+}
+
+- (void)setupTextViewport {
+    self.textScrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+    self.textScrollView.drawsBackground = NO;
+    self.textScrollView.borderType = NSNoBorder;
+    self.textScrollView.hasVerticalScroller = NO;
+    self.textScrollView.hasHorizontalScroller = NO;
+    self.textScrollView.autohidesScrollers = YES;
+    self.textScrollView.scrollerStyle = NSScrollerStyleOverlay;
+    self.textScrollView.verticalScrollElasticity = NSScrollElasticityNone;
+    self.textScrollView.horizontalScrollElasticity = NSScrollElasticityNone;
+    self.textScrollView.wantsLayer = YES;
+
+    NSTextView *textView = [[NSTextView alloc] initWithFrame:NSZeroRect];
+    textView.drawsBackground = NO;
+    textView.editable = NO;
+    textView.selectable = NO;
+    textView.richText = NO;
+    textView.importsGraphics = NO;
+    textView.usesFontPanel = NO;
+    textView.usesFindPanel = NO;
+    textView.textContainerInset = NSZeroSize;
+    textView.textContainer.lineFragmentPadding = 0.0;
+    textView.verticallyResizable = YES;
+    textView.horizontallyResizable = NO;
+    textView.autoresizingMask = NSViewWidthSizable;
+    textView.textContainer.widthTracksTextView = YES;
+    textView.textContainer.containerSize = NSMakeSize(1.0, CGFLOAT_MAX);
+
+    self.textView = textView;
+    self.textScrollView.documentView = textView;
+    [self addSubview:self.textScrollView];
+}
+
+- (NSString *)displayText {
+    return (self.interimText.length > 0) ? self.interimText : self.statusText;
+}
+
+- (void)setLayoutWidth:(CGFloat)layoutWidth {
+    _layoutWidth = layoutWidth;
+    [self setNeedsLayout:YES];
+}
+
+- (void)setIconAreaWidth:(CGFloat)iconAreaWidth {
+    _iconAreaWidth = iconAreaWidth;
+    [self setNeedsLayout:YES];
+    [self setNeedsDisplay:YES];
+}
+
+- (void)setTextViewportHeight:(CGFloat)textViewportHeight {
+    _textViewportHeight = textViewportHeight;
+    [self setNeedsLayout:YES];
+}
+
+- (void)setTextFontSize:(CGFloat)textFontSize {
+    _textFontSize = textFontSize;
+    [self updateTextAttributes];
+    [self setNeedsDisplay:YES];
+}
+
+- (void)setFontFamily:(NSString *)fontFamily {
+    _fontFamily = [fontFamily copy];
+    [self updateTextAttributes];
+    [self setNeedsDisplay:YES];
+}
+
+- (NSRect)textViewportFrame {
+    NSFont *font = [self contentFont];
+    CGFloat effectiveWidth = self.layoutWidth > 0 ? self.layoutWidth : NSWidth(self.bounds);
+    CGFloat topPad = SPOverlayTextTopPadForFont(font);
+    CGFloat bottomPad = SPOverlayTextBottomPadForFont(font);
+    CGFloat horizontalPad = SPOverlayHorizontalPadForFont(font);
+    CGFloat iconGap = SPOverlayIconTextGapForFont(font);
+    CGFloat trailingPad = SPOverlayTextTrailingPadForFont(font);
+    CGFloat effectiveViewportHeight = self.textViewportHeight > 0
+        ? self.textViewportHeight
+        : fmax(1.0, NSHeight(self.bounds) - topPad - bottomPad);
+    CGFloat textX = horizontalPad + (self.iconAreaWidth > 0 ? self.iconAreaWidth : 28.0) + iconGap;
+    CGFloat textWidth = fmax(1.0, effectiveWidth - textX - trailingPad);
+    return NSMakeRect(textX, bottomPad, textWidth, effectiveViewportHeight);
+}
+
+- (void)layout {
+    [super layout];
+    [self updateTextLayout];
+}
+
+- (void)updateTextLayout {
+    if (!self.textScrollView || !self.textView) return;
+
+    NSRect textFrame = [self textViewportFrame];
+    self.textScrollView.frame = textFrame;
+    self.textView.frame = NSMakeRect(0, 0, textFrame.size.width, MAX(textFrame.size.height, self.textView.frame.size.height));
+    self.textView.textContainer.containerSize = NSMakeSize(textFrame.size.width, CGFLOAT_MAX);
+}
+
+- (void)updateTextAttributes {
+    NSDictionary *attrs = SPOverlayTextAttributes([self contentFont]);
+    if (self.textView.string.length > 0) {
+        [self.textView.textStorage setAttributedString:[[NSAttributedString alloc] initWithString:self.textView.string attributes:attrs]];
+    } else {
+        self.textView.typingAttributes = attrs;
+    }
+}
+
+- (void)refreshDisplayedTextAnimated:(BOOL)animated {
+    NSString *displayText = [self displayText] ?: @"";
+    NSDictionary *attrs = SPOverlayTextAttributes([self contentFont]);
+    NSClipView *clipView = self.textScrollView.contentView;
+    CGFloat oldOffsetY = clipView.bounds.origin.y;
+
+    [self.textView.textStorage setAttributedString:[[NSAttributedString alloc] initWithString:displayText attributes:attrs]];
+    [self updateTextLayout];
+
+    [self.textView.layoutManager ensureLayoutForTextContainer:self.textView.textContainer];
+    CGFloat contentHeight = ceil([self.textView.layoutManager usedRectForTextContainer:self.textView.textContainer].size.height);
+    CGFloat viewportHeight = NSHeight(self.textScrollView.frame);
+    CGFloat documentHeight = MAX(viewportHeight, contentHeight);
+    self.textView.frame = NSMakeRect(0, 0, NSWidth(self.textScrollView.frame), documentHeight);
+
+    CGFloat targetOffsetY = MAX(0.0, documentHeight - viewportHeight);
+    NSPoint targetPoint = NSMakePoint(0.0, targetOffsetY);
+    if (animated && targetOffsetY > oldOffsetY + 0.5) {
+        [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
+            ctx.duration = kTextScrollDuration;
+            ctx.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+            [[clipView animator] setBoundsOrigin:targetPoint];
+        } completionHandler:^{
+            [self.textScrollView reflectScrolledClipView:clipView];
+        }];
+    } else {
+        [clipView setBoundsOrigin:targetPoint];
+        [self.textScrollView reflectScrolledClipView:clipView];
+    }
+}
+
 - (void)drawRect:(NSRect)dirtyRect {
     NSRect bounds = self.bounds;
+    CGFloat cornerRadius = self.cornerRadius > 0 ? self.cornerRadius : 18.0;
+    CGFloat iconAreaWidth = self.iconAreaWidth > 0 ? self.iconAreaWidth : 28.0;
+    CGFloat horizontalPad = SPOverlayHorizontalPadForFont([self contentFont]);
 
     // ── Dark tint (minimum contrast for white text on any background) ──
     [[NSColor colorWithWhite:0.0 alpha:0.35] setFill];
@@ -199,14 +576,14 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 
     // ── Border (edge definition on dark backgrounds) ──
     NSBezierPath *border = [NSBezierPath bezierPathWithRoundedRect:NSInsetRect(bounds, 0.5, 0.5)
-                                                            xRadius:kPillCornerRadius
-                                                            yRadius:kPillCornerRadius];
+                                                            xRadius:cornerRadius
+                                                            yRadius:cornerRadius];
     [[NSColor colorWithWhite:1.0 alpha:0.20] setStroke];
     border.lineWidth = 0.5;
     [border stroke];
 
     // ── Left icon area ──
-    CGFloat iconCenterX = kHorizontalPad + kIconAreaWidth / 2.0;
+    CGFloat iconCenterX = horizontalPad + iconAreaWidth / 2.0;
     CGFloat centerY = NSMidY(bounds);
 
     switch (self.mode) {
@@ -225,26 +602,6 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         default:
             break;
     }
-
-    // ── Text ──
-    NSString *displayText = (self.interimText.length > 0) ? self.interimText : self.statusText;
-    if (displayText.length > 0) {
-        NSDictionary *attrs = @{
-            NSFontAttributeName: [NSFont systemFontOfSize:13.0 weight:NSFontWeightMedium],
-            NSForegroundColorAttributeName: [NSColor colorWithWhite:1.0 alpha:0.92],
-        };
-        NSAttributedString *str = [[NSAttributedString alloc] initWithString:displayText
-                                                                  attributes:attrs];
-        CGFloat textX = kHorizontalPad + kIconAreaWidth + kIconTextGap;
-        // Use layoutWidth to avoid wrapping into animated/intermediate bounds
-        CGFloat textMaxW = fmax(1.0, self.layoutWidth - textX - kHorizontalPad);
-        NSRect textRect = [str boundingRectWithSize:NSMakeSize(textMaxW, CGFLOAT_MAX)
-                                            options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine];
-        CGFloat textY = (bounds.size.height - textRect.size.height) / 2.0;
-        [str drawWithRect:NSMakeRect(textX, textY, textMaxW, textRect.size.height)
-                  options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine];
-    }
-
 }
 
 #pragma mark - Waveform (recording)
@@ -367,6 +724,17 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) BOOL templateBarHovered;
 @property (nonatomic, assign) NSTimeInterval remainingLingerDuration;
 @property (nonatomic, strong) NSDate *lingerDeadline;
+@property (nonatomic, assign) CGFloat textFontSize;
+@property (nonatomic, assign) CGFloat bottomMargin;
+@property (nonatomic, copy) NSString *fontFamily;
+@property (nonatomic, assign) CGFloat configuredTextFontSize;
+@property (nonatomic, assign) CGFloat configuredBottomMargin;
+@property (nonatomic, copy) NSString *configuredFontFamily;
+@property (nonatomic, assign) BOOL limitVisibleLinesEnabled;
+@property (nonatomic, assign) NSInteger maxVisibleLines;
+@property (nonatomic, assign) BOOL configuredLimitVisibleLinesEnabled;
+@property (nonatomic, assign) NSInteger configuredMaxVisibleLines;
+@property (nonatomic, assign, getter=isPreviewActive) BOOL previewActive;
 
 @end
 
@@ -376,13 +744,135 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     self = [super init];
     if (self) {
         _currentState = @"idle";
+        _textFontSize = kDefaultTextFontSize;
+        _bottomMargin = kDefaultBottomMargin;
+        _fontFamily = kDefaultFontFamily;
+        _configuredTextFontSize = kDefaultTextFontSize;
+        _configuredBottomMargin = kDefaultBottomMargin;
+        _configuredFontFamily = kDefaultFontFamily;
+        _limitVisibleLinesEnabled = kDefaultLimitVisibleLines;
+        _maxVisibleLines = kDefaultMaxVisibleLines;
+        _configuredLimitVisibleLinesEnabled = kDefaultLimitVisibleLines;
+        _configuredMaxVisibleLines = kDefaultMaxVisibleLines;
         [self setupPanel];
+        [self reloadAppearanceFromConfig];
     }
     return self;
 }
 
+- (NSFont *)contentFont {
+    return SPOverlayFontForFamily(self.fontFamily, self.textFontSize);
+}
+
+- (CGFloat)basePillHeight {
+    NSFont *font = [self contentFont];
+    CGFloat lineHeight = SPOverlayLineHeightForFont(font);
+    return fmax(kMinimumPillHeight, lineHeight + SPOverlayTextTopPadForFont(font) + SPOverlayTextBottomPadForFont(font));
+}
+
+- (CGFloat)overlayCornerRadius {
+    return floor(fmin(24.0, [self basePillHeight] / 2.0));
+}
+
+- (CGFloat)iconAreaWidth {
+    return fmax(28.0, floor([self basePillHeight] * 0.78));
+}
+
+- (CGFloat)textVerticalPadding {
+    NSFont *font = [self contentFont];
+    return SPOverlayTextTopPadForFont(font) + SPOverlayTextBottomPadForFont(font);
+}
+
+- (void)updateContentAppearance {
+    self.contentView.textFontSize = self.textFontSize;
+    self.contentView.fontFamily = self.fontFamily;
+    self.contentView.cornerRadius = [self overlayCornerRadius];
+    self.contentView.iconAreaWidth = [self iconAreaWidth];
+    [self.contentView updateTextAttributes];
+    [self.contentView setNeedsLayout:YES];
+}
+
+- (NSString *)currentDisplayText {
+    return (self.contentView.interimText.length > 0) ? self.contentView.interimText : self.contentView.statusText;
+}
+
+- (BOOL)shouldUseScrollingTranscriptLayout {
+    return self.limitVisibleLinesEnabled && self.contentView.interimText.length > 0;
+}
+
+- (NSInteger)visibleLineLimitForCurrentState {
+    return SPOverlayClampMaxVisibleLines(self.maxVisibleLines);
+}
+
+- (void)applyAppearanceWithFontSize:(CGFloat)fontSize
+                         fontFamily:(NSString *)fontFamily
+                       bottomMargin:(CGFloat)bottomMargin
+                  limitVisibleLines:(BOOL)limitVisibleLines
+                    maxVisibleLines:(NSInteger)maxVisibleLines
+                resetSessionMetrics:(BOOL)resetMetrics {
+    self.textFontSize = SPOverlayClampTextFontSize(fontSize);
+    self.bottomMargin = SPOverlayClampBottomMargin(bottomMargin);
+    self.fontFamily = SPOverlayNormalizeFontFamily(fontFamily);
+    self.limitVisibleLinesEnabled = limitVisibleLines;
+    self.maxVisibleLines = SPOverlayClampMaxVisibleLines(maxVisibleLines);
+    [self updateContentAppearance];
+    if (resetMetrics) {
+        self.sessionMaxWidth = 0;
+        self.sessionMaxHeight = 0;
+    }
+}
+
+- (void)restoreConfiguredAppearanceIfNeeded {
+    if (!self.isPreviewActive) return;
+    self.previewActive = NO;
+    [self applyAppearanceWithFontSize:self.configuredTextFontSize
+                           fontFamily:self.configuredFontFamily
+                         bottomMargin:self.configuredBottomMargin
+                   limitVisibleLines:self.configuredLimitVisibleLinesEnabled
+                     maxVisibleLines:self.configuredMaxVisibleLines
+                  resetSessionMetrics:YES];
+}
+
+- (void)updateMainPanelMaskForHeight:(CGFloat)height {
+    if (!self.effectView) return;
+
+    CGFloat cornerRadius = [self overlayCornerRadius];
+    CGFloat maskHeight = fmax(height, [self basePillHeight]);
+    NSImage *mask = [NSImage imageWithSize:NSMakeSize(cornerRadius * 2 + 1, maskHeight)
+                                   flipped:NO
+                            drawingHandler:^BOOL(NSRect dstRect) {
+        [[NSColor blackColor] setFill];
+        [[NSBezierPath bezierPathWithRoundedRect:dstRect
+                                         xRadius:cornerRadius
+                                         yRadius:cornerRadius] fill];
+        return YES;
+    }];
+    mask.capInsets = NSEdgeInsetsMake(cornerRadius, cornerRadius, cornerRadius, cornerRadius);
+    mask.resizingMode = NSImageResizingModeStretch;
+    self.effectView.maskImage = mask;
+}
+
+- (void)repositionTemplateBarAnimated:(BOOL)animated {
+    if (!self.buttonBarPanel) return;
+
+    NSRect pillFrame = self.panel.frame;
+    NSRect barFrame = self.buttonBarPanel.frame;
+    NSRect newFrame = NSMakeRect(NSMidX(pillFrame) - barFrame.size.width / 2.0,
+                                 NSMaxY(pillFrame) + 6.0,
+                                 barFrame.size.width,
+                                 barFrame.size.height);
+    if (animated) {
+        [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
+            ctx.duration = kResizeDuration;
+            [[self.buttonBarPanel animator] setFrame:newFrame display:YES];
+        }];
+    } else {
+        [self.buttonBarPanel setFrame:newFrame display:YES];
+    }
+}
+
 - (void)setupPanel {
-    NSRect rect = NSMakeRect(0, 0, 180, kPillHeight);
+    NSRect rect = NSMakeRect(0, 0, 180, [self basePillHeight]);
 
     NSPanel *panel = [[NSPanel alloc] initWithContentRect:rect
                                                  styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
@@ -413,22 +903,6 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         [weakSelf setMainPanelHovered:hovering];
     };
 
-    // Pill shape via maskImage (Apple-recommended for shaping NSVisualEffectView)
-    CGFloat diameter = kPillCornerRadius * 2;
-    NSImage *mask = [NSImage imageWithSize:NSMakeSize(diameter + 1, kPillHeight)
-                                   flipped:NO
-                            drawingHandler:^BOOL(NSRect dstRect) {
-        [[NSColor blackColor] setFill];
-        [[NSBezierPath bezierPathWithRoundedRect:dstRect
-                                         xRadius:kPillCornerRadius
-                                         yRadius:kPillCornerRadius] fill];
-        return YES;
-    }];
-    mask.capInsets     = NSEdgeInsetsMake(kPillCornerRadius, kPillCornerRadius,
-                                          kPillCornerRadius, kPillCornerRadius);
-    mask.resizingMode  = NSImageResizingModeStretch;
-    effectView.maskImage = mask;
-
     // Light glow shadow (visible on dark backgrounds)
     effectView.layer.shadowColor   = [[NSColor whiteColor] CGColor];
     effectView.layer.shadowOpacity = 0.15;
@@ -443,6 +917,8 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     self.contentView.wantsLayer = YES;
     self.contentView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     [effectView addSubview:self.contentView];
+    [self updateContentAppearance];
+    [self updateMainPanelMaskForHeight:rect.size.height];
 
     self.panel = panel;
 }
@@ -524,6 +1000,11 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 #pragma mark - Public
 
 - (void)updateState:(NSString *)state {
+    BOOL isPreviewState = [state hasSuffix:@"_preview"];
+    if (self.isPreviewActive && !isPreviewState) {
+        [self restoreConfiguredAppearanceIfNeeded];
+    }
+
     // Cancel any pending linger dismiss from a previous session
     [self clearLingerTimer];
     [self setMainPanelInteractive:NO];
@@ -603,6 +1084,71 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     [self setMainPanelInteractive:YES];
     [self resizeAndCenterAnimated:YES];
     [self.contentView setNeedsDisplay:YES];
+}
+
+- (void)reloadAppearanceFromConfig {
+    NSString *configuredFontFamily = SPOverlayConfigString("overlay.font_family", kDefaultFontFamily);
+    CGFloat configuredFontSize = SPOverlayConfigCGFloat("overlay.font_size", kDefaultTextFontSize);
+    CGFloat configuredBottomMargin = SPOverlayConfigCGFloat("overlay.bottom_margin", kDefaultBottomMargin);
+    BOOL configuredLimitVisibleLinesEnabled = SPOverlayConfigBOOL("overlay.limit_visible_lines", kDefaultLimitVisibleLines);
+    NSInteger configuredMaxVisibleLines = SPOverlayClampMaxVisibleLines(lround(SPOverlayConfigCGFloat("overlay.max_visible_lines", kDefaultMaxVisibleLines)));
+
+    self.configuredFontFamily = SPOverlayNormalizeFontFamily(configuredFontFamily);
+    self.configuredTextFontSize = SPOverlayClampTextFontSize(configuredFontSize);
+    self.configuredBottomMargin = SPOverlayClampBottomMargin(configuredBottomMargin);
+    self.configuredLimitVisibleLinesEnabled = configuredLimitVisibleLinesEnabled;
+    self.configuredMaxVisibleLines = configuredMaxVisibleLines;
+
+    if (!self.isPreviewActive) {
+        [self applyAppearanceWithFontSize:self.configuredTextFontSize
+                               fontFamily:self.configuredFontFamily
+                             bottomMargin:self.configuredBottomMargin
+                       limitVisibleLines:self.configuredLimitVisibleLinesEnabled
+                         maxVisibleLines:self.configuredMaxVisibleLines
+                      resetSessionMetrics:YES];
+        [self resizeAndCenterAnimated:NO];
+        [self.contentView setNeedsDisplay:YES];
+        [self repositionTemplateBarAnimated:NO];
+    }
+}
+
+- (void)showPreviewWithText:(NSString *)text
+                   fontSize:(CGFloat)fontSize
+                 fontFamily:(NSString *)fontFamily
+               bottomMargin:(CGFloat)bottomMargin
+          limitVisibleLines:(BOOL)limitVisibleLines
+            maxVisibleLines:(NSInteger)maxVisibleLines {
+    if (!self.isPreviewActive &&
+        self.currentState.length > 0 &&
+        ![self.currentState isEqualToString:@"idle"] &&
+        ![self.currentState isEqualToString:@"completed"]) {
+        return;
+    }
+
+    self.previewActive = YES;
+    [self hideTemplateButtons];
+    [self applyAppearanceWithFontSize:fontSize
+                           fontFamily:fontFamily
+                         bottomMargin:bottomMargin
+                   limitVisibleLines:limitVisibleLines
+                     maxVisibleLines:maxVisibleLines
+                  resetSessionMetrics:YES];
+    [self updateState:@"recording_preview"];
+    [self updateInterimText:text ?: @""];
+}
+
+- (void)hidePreview {
+    if (!self.isPreviewActive) return;
+
+    [self clearLingerTimer];
+    [self hideTemplateButtons];
+    [self setMainPanelInteractive:NO];
+    self.mainPanelHovered = NO;
+    self.templateBarHovered = NO;
+    self.contentView.interimText = nil;
+    [self restoreConfiguredAppearanceIfNeeded];
+    self.currentState = @"idle";
+    [self hide];
 }
 
 - (void)lingerAndDismiss {
@@ -856,55 +1402,79 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 #pragma mark - Layout
 
 - (void)resizeAndCenterAnimated:(BOOL)animated {
+    NSFont *font = [self contentFont];
     NSDictionary *attrs = @{
-        NSFontAttributeName: [NSFont systemFontOfSize:13.0 weight:NSFontWeightMedium],
+        NSFontAttributeName: font,
     };
-    NSString *displayText = (self.contentView.interimText.length > 0)
-                            ? self.contentView.interimText
-                            : self.contentView.statusText;
+    NSString *displayText = [self currentDisplayText];
     NSAttributedString *str = [[NSAttributedString alloc] initWithString:displayText ?: @"" attributes:attrs];
-    
-    CGFloat iconSpace = kHorizontalPad + kIconAreaWidth + kIconTextGap;
-    
+
+    CGFloat horizontalPad = SPOverlayHorizontalPadForFont(font);
+    CGFloat iconGap = SPOverlayIconTextGapForFont(font);
+    CGFloat trailingPad = SPOverlayTextTrailingPadForFont(font);
+    CGFloat iconSpace = horizontalPad + [self iconAreaWidth] + iconGap;
+
     // 1. Determine natural single-line width
     CGFloat naturalW = [str size].width;
-    CGFloat desiredW = iconSpace + naturalW + kHorizontalPad;
-    
+    CGFloat desiredW = iconSpace + naturalW + trailingPad;
+
     // 2. Clamp to screen/max limits
     NSScreen *screen = [NSScreen mainScreen];
     NSRect visible = screen.visibleFrame;
     CGFloat absoluteMaxW = fmin(kMaxWidth, visible.size.width - 2 * kScreenHorizontalMargin);
-    
+
     CGFloat pillW = desiredW;
-    CGFloat pillH = kPillHeight;
+    CGFloat pillH = [self basePillHeight];
+    CGFloat lineHeight = SPOverlayLineHeightForFont(font);
+    CGFloat textViewportHeight = lineHeight;
+    BOOL usesScrollingTranscriptLayout = [self shouldUseScrollingTranscriptLayout];
+    BOOL shouldStabilizeWidth = animated && self.sessionMaxWidth > 0;
+    BOOL shouldStabilizeHeight = animated && usesScrollingTranscriptLayout && self.sessionMaxHeight > 0;
 
-    if (desiredW > absoluteMaxW) {
-        pillW = absoluteMaxW;
-        CGFloat textMaxW = pillW - iconSpace - kHorizontalPad;
-        NSRect textRect = [str boundingRectWithSize:NSMakeSize(textMaxW, kMaxHeight)
-                                            options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine];
-        pillH = fmax(kPillHeight, ceil(textRect.size.height) + 20.0);
+    if (displayText.length > 0) {
+        pillW = fmin(MAX(desiredW, iconSpace + 120.0), absoluteMaxW);
+
+        // Keep width monotonic during a live session first, then measure height
+        // using that final width so we don't preserve a stale tall layout.
+        if (shouldStabilizeWidth) {
+            pillW = fmax(pillW, self.sessionMaxWidth);
+        }
+
+        CGFloat textMaxW = fmax(1.0, pillW - iconSpace - trailingPad);
+        CGFloat measuredTextHeight = SPOverlayMeasureTextHeight(displayText, font, textMaxW);
+
+        if (usesScrollingTranscriptLayout) {
+            CGFloat maxVisibleTextHeight = SPOverlayMeasureVisibleHeightForLineLimit(displayText,
+                                                                                    font,
+                                                                                    textMaxW,
+                                                                                    [self visibleLineLimitForCurrentState]) + SPOverlayLineLimitSlackForFont(font);
+            textViewportHeight = fmin(fmax(lineHeight, measuredTextHeight), maxVisibleTextHeight);
+        } else {
+            textViewportHeight = fmax(lineHeight, measuredTextHeight);
+        }
+
+        pillH = fmax([self basePillHeight], ceil(textViewportHeight) + [self textVerticalPadding]);
     }
 
-    // 3. Stabilization: Only-grow during active session
-    if (animated && self.sessionMaxWidth > 0) {
-        pillW = fmax(pillW, self.sessionMaxWidth);
-    }
-    if (animated && self.sessionMaxHeight > 0) {
+    // 3. Stabilization: only keep height monotonic when line limiting is enabled.
+    if (shouldStabilizeHeight) {
         pillH = fmax(pillH, self.sessionMaxHeight);
     }
     
     if (animated) {
         self.sessionMaxWidth = pillW;
-        self.sessionMaxHeight = pillH;
+        self.sessionMaxHeight = usesScrollingTranscriptLayout ? pillH : 0;
     }
 
     // 4. Update internal layout width to prevent wrapping mid-animation
     self.contentView.layoutWidth = pillW;
+    self.contentView.textViewportHeight = textViewportHeight;
+    [self updateMainPanelMaskForHeight:pillH];
+    [self.contentView refreshDisplayedTextAnimated:animated];
 
     // 5. Final Frame
     CGFloat x = NSMidX(visible) - pillW / 2.0;
-    CGFloat y = NSMinY(visible) + kBottomMargin;
+    CGFloat y = NSMinY(visible) + self.bottomMargin;
     NSRect newFrame = NSMakeRect(x, y, pillW, pillH);
 
     if (animated) {
@@ -913,8 +1483,10 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
             ctx.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
             [[self.panel animator] setFrame:newFrame display:YES];
         }];
+        [self repositionTemplateBarAnimated:YES];
     } else {
         [self.panel setFrame:newFrame display:YES];
+        [self repositionTemplateBarAnimated:NO];
     }
 }
 

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -41,6 +41,31 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     SPOverlayModeError,
 };
 
+// ── Key-accepting panel for template button bar ─────────
+// NSPanel subclass that can become key window without activating the app.
+// This allows it to receive keyboard events (number keys 1-9) while
+// the user's frontmost app retains focus.
+
+@interface SPKeyablePanel : NSPanel
+@property (nonatomic, copy) void (^keyHandler)(NSInteger number);
+@end
+
+@implementation SPKeyablePanel
+- (BOOL)canBecomeKeyWindow { return YES; }
+
+- (void)keyDown:(NSEvent *)event {
+    NSString *chars = event.charactersIgnoringModifiers;
+    if (chars.length == 1 && self.keyHandler) {
+        unichar ch = [chars characterAtIndex:0];
+        if (ch >= '1' && ch <= '9') {
+            self.keyHandler(ch - '0');
+            return;
+        }
+    }
+    [super keyDown:event];
+}
+@end
+
 // ── Content view ─────────────────────────────────────────
 
 @interface SPOverlayContentView : NSView
@@ -226,7 +251,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) CGFloat sessionMaxHeight;
 @property (nonatomic, strong) NSArray<NSDictionary *> *templateButtons;
 @property (nonatomic, assign) BOOL showingTemplates;
-@property (nonatomic, strong) NSPanel *buttonBarPanel;
+@property (nonatomic, strong) SPKeyablePanel *buttonBarPanel;
 @property (nonatomic, strong) NSMutableArray<NSButton *> *templateButtonViews;
 
 @end
@@ -434,11 +459,11 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     totalW += (templates.count - 1) * btnSpacing + 2 * barPad;
     CGFloat barH = btnH + 2 * barPad;
 
-    // Create button bar panel
-    NSPanel *bar = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, totalW, barH)
-                                              styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
-                                                backing:NSBackingStoreBuffered
-                                                  defer:YES];
+    // Create button bar panel (SPKeyablePanel to receive keyboard events)
+    SPKeyablePanel *bar = [[SPKeyablePanel alloc] initWithContentRect:NSMakeRect(0, 0, totalW, barH)
+                                                            styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
+                                                              backing:NSBackingStoreBuffered
+                                                                defer:YES];
     bar.level = NSStatusWindowLevel;
     bar.collectionBehavior = NSWindowCollectionBehaviorCanJoinAllSpaces |
                              NSWindowCollectionBehaviorStationary |
@@ -520,6 +545,17 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     }];
 
     self.buttonBarPanel = bar;
+
+    // Set up keyboard handler for number keys
+    __weak typeof(self) weakSelf = self;
+    bar.keyHandler = ^(NSInteger number) {
+        [weakSelf handleNumberKey:number];
+    };
+
+    // Make the button bar the key window so it receives keyboard events.
+    // NSNonactivatingPanel + canBecomeKeyWindow = receives keys without
+    // stealing focus from the user's frontmost app.
+    [bar makeKeyAndOrderFront:nil];
 
     // Extend linger time when templates are showing
     [self.lingerTimer invalidate];

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -31,6 +31,9 @@ static const NSTimeInterval kAnimInterval      = 1.0 / 30.0;
 static const NSTimeInterval kFadeInDuration    = 0.2;
 static const NSTimeInterval kFadeOutDuration   = 0.3;
 static const NSTimeInterval kResizeDuration    = 0.15;
+static const NSTimeInterval kMinLingerDuration = 0.45;
+static const NSTimeInterval kMaxLingerDuration = 1.2;
+static const NSTimeInterval kTemplateLingerDuration = 3.0;
 
 // ── Animation mode ───────────────────────────────────────
 typedef NS_ENUM(NSInteger, SPOverlayMode) {
@@ -64,6 +67,112 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     }
     [super keyDown:event];
 }
+@end
+
+// ── Hover-aware effect view ──────────────────────────────
+
+@interface SPHoverEffectView : NSVisualEffectView
+@property (nonatomic, copy) void (^hoverChangedHandler)(BOOL hovering);
+@end
+
+@implementation SPHoverEffectView {
+    NSTrackingArea *_trackingArea;
+}
+
+- (void)updateTrackingAreas {
+    [super updateTrackingAreas];
+
+    if (_trackingArea) {
+        [self removeTrackingArea:_trackingArea];
+        _trackingArea = nil;
+    }
+
+    _trackingArea = [[NSTrackingArea alloc] initWithRect:NSZeroRect
+                                                 options:NSTrackingMouseEnteredAndExited |
+                                                         NSTrackingActiveAlways |
+                                                         NSTrackingInVisibleRect
+                                                   owner:self
+                                                userInfo:nil];
+    [self addTrackingArea:_trackingArea];
+}
+
+- (void)mouseEntered:(NSEvent *)event {
+    if (self.hoverChangedHandler) {
+        self.hoverChangedHandler(YES);
+    }
+}
+
+- (void)mouseExited:(NSEvent *)event {
+    if (self.hoverChangedHandler) {
+        self.hoverChangedHandler(NO);
+    }
+}
+
+@end
+
+// ── Hover-aware template button ──────────────────────────
+
+@interface SPTemplateButton : NSButton
+@property (nonatomic, assign, getter=isHovering) BOOL hovering;
+@property (nonatomic, assign, getter=isEmphasized) BOOL emphasized;
+- (void)applyCurrentAppearance;
+@end
+
+@implementation SPTemplateButton {
+    NSTrackingArea *_trackingArea;
+}
+
+- (void)updateTrackingAreas {
+    [super updateTrackingAreas];
+
+    if (_trackingArea) {
+        [self removeTrackingArea:_trackingArea];
+        _trackingArea = nil;
+    }
+
+    _trackingArea = [[NSTrackingArea alloc] initWithRect:NSZeroRect
+                                                 options:NSTrackingMouseEnteredAndExited |
+                                                         NSTrackingActiveAlways |
+                                                         NSTrackingInVisibleRect
+                                                   owner:self
+                                                userInfo:nil];
+    [self addTrackingArea:_trackingArea];
+}
+
+- (void)mouseEntered:(NSEvent *)event {
+    self.hovering = YES;
+    [self applyCurrentAppearance];
+}
+
+- (void)mouseExited:(NSEvent *)event {
+    self.hovering = NO;
+    [self applyCurrentAppearance];
+}
+
+- (void)setEmphasized:(BOOL)emphasized {
+    _emphasized = emphasized;
+    [self applyCurrentAppearance];
+}
+
+- (void)applyCurrentAppearance {
+    if (!self.layer) return;
+
+    CGFloat backgroundAlpha = 0.1;
+    CGFloat textAlpha = 0.85;
+    CGFloat borderAlpha = 0.0;
+
+    if (self.isEmphasized || self.isHovering) {
+        backgroundAlpha = 0.3;
+        textAlpha = 1.0;
+        borderAlpha = 0.2;
+    }
+
+    self.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:backgroundAlpha] CGColor];
+    self.layer.borderWidth = borderAlpha > 0 ? 1.0 : 0.0;
+    self.layer.borderColor = [[NSColor colorWithWhite:1.0 alpha:borderAlpha] CGColor];
+    self.contentTintColor = [NSColor colorWithWhite:1.0 alpha:textAlpha];
+}
+
 @end
 
 // ── Content view ─────────────────────────────────────────
@@ -242,7 +351,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @interface SPOverlayPanel ()
 
 @property (nonatomic, strong) NSPanel *panel;
-@property (nonatomic, strong) NSVisualEffectView *effectView;
+@property (nonatomic, strong) SPHoverEffectView *effectView;
 @property (nonatomic, strong) SPOverlayContentView *contentView;
 @property (nonatomic, strong) NSTimer *animationTimer;
 @property (nonatomic, strong) NSTimer *lingerTimer;
@@ -250,9 +359,14 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) CGFloat sessionMaxWidth;
 @property (nonatomic, assign) CGFloat sessionMaxHeight;
 @property (nonatomic, strong) NSArray<NSDictionary *> *templateButtons;
+@property (nonatomic, strong) NSArray<NSNumber *> *templateShortcutNumbers;
 @property (nonatomic, assign) BOOL showingTemplates;
 @property (nonatomic, strong) SPKeyablePanel *buttonBarPanel;
 @property (nonatomic, strong) NSMutableArray<NSButton *> *templateButtonViews;
+@property (nonatomic, assign) BOOL mainPanelHovered;
+@property (nonatomic, assign) BOOL templateBarHovered;
+@property (nonatomic, assign) NSTimeInterval remainingLingerDuration;
+@property (nonatomic, strong) NSDate *lingerDeadline;
 
 @end
 
@@ -286,13 +400,18 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     panel.alphaValue = 0.0;
 
     // Visual effect background (HUD material for contrast on any desktop)
-    NSVisualEffectView *effectView = [[NSVisualEffectView alloc] initWithFrame:rect];
+    SPHoverEffectView *effectView = [[SPHoverEffectView alloc] initWithFrame:rect];
     effectView.material     = NSVisualEffectMaterialHUDWindow;
     effectView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
     effectView.state        = NSVisualEffectStateActive;
     effectView.appearance   = [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
     effectView.wantsLayer   = YES;
     effectView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+
+    __weak typeof(self) weakSelf = self;
+    effectView.hoverChangedHandler = ^(BOOL hovering) {
+        [weakSelf setMainPanelHovered:hovering];
+    };
 
     // Pill shape via maskImage (Apple-recommended for shaping NSVisualEffectView)
     CGFloat diameter = kPillCornerRadius * 2;
@@ -328,12 +447,88 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     self.panel = panel;
 }
 
+- (void)setMainPanelInteractive:(BOOL)interactive {
+    self.panel.ignoresMouseEvents = !interactive;
+}
+
+- (BOOL)isHoveringOverlay {
+    return self.mainPanelHovered || self.templateBarHovered;
+}
+
+- (void)clearLingerTimer {
+    [self.lingerTimer invalidate];
+    self.lingerTimer = nil;
+    self.lingerDeadline = nil;
+    self.remainingLingerDuration = 0;
+}
+
+- (void)updateLingerTimerForHoverState {
+    if (self.showingTemplates == NO && self.currentState != nil &&
+        ([self.currentState isEqualToString:@"idle"] || [self.currentState isEqualToString:@"completed"])) {
+        return;
+    }
+
+    if ([self isHoveringOverlay]) {
+        if (self.lingerTimer && self.lingerDeadline) {
+            self.remainingLingerDuration = fmax(0.1, [self.lingerDeadline timeIntervalSinceNow]);
+            [self.lingerTimer invalidate];
+            self.lingerTimer = nil;
+            self.lingerDeadline = nil;
+        }
+        return;
+    }
+
+    if (!self.lingerTimer && self.remainingLingerDuration > 0) {
+        [self scheduleDismissAfter:self.remainingLingerDuration];
+    }
+}
+
+- (void)setMainPanelHovered:(BOOL)mainPanelHovered {
+    _mainPanelHovered = mainPanelHovered;
+    [self updateLingerTimerForHoverState];
+}
+
+- (void)setTemplateBarHovered:(BOOL)templateBarHovered {
+    _templateBarHovered = templateBarHovered;
+    [self updateLingerTimerForHoverState];
+}
+
+- (void)dismissToIdle {
+    [self clearLingerTimer];
+    self.sessionMaxWidth = 0;
+    self.sessionMaxHeight = 0;
+    self.currentState = @"idle";
+    [self hide];
+}
+
+- (void)scheduleDismissAfter:(NSTimeInterval)duration {
+    [self.lingerTimer invalidate];
+    self.lingerTimer = nil;
+
+    self.remainingLingerDuration = duration;
+    self.lingerDeadline = [NSDate dateWithTimeIntervalSinceNow:duration];
+
+    __weak typeof(self) weakSelf = self;
+    self.lingerTimer = [NSTimer scheduledTimerWithTimeInterval:duration
+                                                       repeats:NO
+                                                         block:^(NSTimer *timer) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        strongSelf.lingerTimer = nil;
+        strongSelf.lingerDeadline = nil;
+        strongSelf.remainingLingerDuration = 0;
+        [strongSelf dismissToIdle];
+    }];
+}
+
 #pragma mark - Public
 
 - (void)updateState:(NSString *)state {
     // Cancel any pending linger dismiss from a previous session
-    [self.lingerTimer invalidate];
-    self.lingerTimer = nil;
+    [self clearLingerTimer];
+    [self setMainPanelInteractive:NO];
+    self.mainPanelHovered = NO;
+    self.templateBarHovered = NO;
 
     self.currentState = state;
     [self stopAnimation];
@@ -405,41 +600,68 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 
 - (void)updateDisplayText:(NSString *)text {
     self.contentView.interimText = text;
+    [self setMainPanelInteractive:YES];
     [self resizeAndCenterAnimated:YES];
     [self.contentView setNeedsDisplay:YES];
 }
 
 - (void)lingerAndDismiss {
-    [self.lingerTimer invalidate];
-    self.lingerTimer = nil;
+    [self clearLingerTimer];
+    [self setMainPanelInteractive:YES];
 
-    // Dynamic linger: clamp(charCount * 0.03, 0.8, 2.5)
+    // Keep the confirmation short by default, but allow hover to pin it.
     NSString *displayText = self.contentView.interimText ?: self.contentView.statusText ?: @"";
     NSUInteger charCount = displayText.length;
-    NSTimeInterval linger = fmin(fmax(charCount * 0.03, 0.8), 2.5);
+    NSTimeInterval linger = fmin(fmax(charCount * 0.015, kMinLingerDuration), kMaxLingerDuration);
+    self.remainingLingerDuration = linger;
+    if (![self isHoveringOverlay]) {
+        [self scheduleDismissAfter:linger];
+    }
+}
 
-    self.lingerTimer = [NSTimer scheduledTimerWithTimeInterval:linger
-                                                      repeats:NO
-                                                        block:^(NSTimer *timer) {
-        self.lingerTimer = nil;
-        self.sessionMaxWidth = 0;
-        self.sessionMaxHeight = 0;
-        [self hide];
-        self.currentState = @"idle";
-    }];
+- (NSArray<NSNumber *> *)resolvedShortcutNumbersForTemplates:(NSArray<NSDictionary *> *)templates {
+    NSMutableArray<NSNumber *> *resolved = [NSMutableArray arrayWithCapacity:templates.count];
+    NSMutableSet<NSNumber *> *used = [NSMutableSet set];
+
+    for (NSDictionary *tmpl in templates) {
+        NSNumber *shortcut = [tmpl[@"shortcut"] isKindOfClass:[NSNumber class]] ? tmpl[@"shortcut"] : nil;
+        NSInteger value = shortcut.integerValue;
+        if (shortcut && value >= 1 && value <= 9 && ![used containsObject:shortcut]) {
+            [resolved addObject:@(value)];
+            [used addObject:@(value)];
+        } else {
+            [resolved addObject:@0];
+        }
+    }
+
+    NSInteger nextShortcut = 1;
+    for (NSUInteger i = 0; i < resolved.count; i++) {
+        if (resolved[i].integerValue > 0) continue;
+        while (nextShortcut <= 9 && [used containsObject:@(nextShortcut)]) {
+            nextShortcut += 1;
+        }
+        if (nextShortcut > 9) break;
+        resolved[i] = @(nextShortcut);
+        [used addObject:@(nextShortcut)];
+    }
+
+    return resolved;
 }
 
 - (void)showTemplateButtons:(NSArray<NSDictionary *> *)templates {
     if (templates.count == 0) return;
     self.templateButtons = templates;
+    self.templateShortcutNumbers = [self resolvedShortcutNumbersForTemplates:templates];
     self.showingTemplates = YES;
+    self.templateBarHovered = NO;
+    [self setMainPanelInteractive:YES];
 
     // Remove old button bar
     [self.buttonBarPanel orderOut:nil];
     self.buttonBarPanel = nil;
     self.templateButtonViews = nil;
 
-    // Calculate button sizes — only show name, no shortcut number
+    // Calculate button sizes using only the template label.
     CGFloat btnH = 26;
     CGFloat btnSpacing = 8;
     CGFloat barPad = 6;
@@ -449,7 +671,8 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 
     CGFloat totalW = 0;
     NSMutableArray<NSNumber *> *widths = [NSMutableArray array];
-    for (NSDictionary *tmpl in templates) {
+    for (NSUInteger i = 0; i < templates.count; i++) {
+        NSDictionary *tmpl = templates[i];
         NSString *label = tmpl[@"name"] ?: @"";
         CGFloat w = [label sizeWithAttributes:attrs].width + 24;
         w = fmax(w, 60); // minimum button width
@@ -475,12 +698,16 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     bar.hidesOnDeactivate = NO;
 
     // Background with vibrancy
-    NSVisualEffectView *bgView = [[NSVisualEffectView alloc] initWithFrame:NSMakeRect(0, 0, totalW, barH)];
+    SPHoverEffectView *bgView = [[SPHoverEffectView alloc] initWithFrame:NSMakeRect(0, 0, totalW, barH)];
     bgView.material = NSVisualEffectMaterialHUDWindow;
     bgView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
     bgView.state = NSVisualEffectStateActive;
     bgView.appearance = [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
     bgView.wantsLayer = YES;
+    __weak typeof(self) weakSelf = self;
+    bgView.hoverChangedHandler = ^(BOOL hovering) {
+        [weakSelf setTemplateBarHovered:hovering];
+    };
 
     // Pill shape mask for button bar
     CGFloat cornerR = barH / 2.0;
@@ -518,18 +745,17 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         NSString *label = tmpl[@"name"] ?: @"";
         CGFloat w = [widths[i] floatValue];
 
-        NSButton *btn = [[NSButton alloc] initWithFrame:NSMakeRect(x, barPad, w, btnH)];
+        SPTemplateButton *btn = [[SPTemplateButton alloc] initWithFrame:NSMakeRect(x, barPad, w, btnH)];
         btn.title = label;
         btn.bordered = NO;
         btn.focusRingType = NSFocusRingTypeNone;
         btn.wantsLayer = YES;
         btn.layer.cornerRadius = btnH / 2.0;
-        btn.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:0.1] CGColor];
         btn.font = [NSFont systemFontOfSize:11 weight:NSFontWeightMedium];
-        btn.contentTintColor = [NSColor colorWithWhite:1.0 alpha:0.85];
         btn.tag = (NSInteger)i;
         btn.target = self;
         btn.action = @selector(templateButtonClicked:);
+        [btn applyCurrentAppearance];
         [bgView addSubview:btn];
         [self.templateButtonViews addObject:btn];
 
@@ -552,30 +778,17 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 
     self.buttonBarPanel = bar;
 
-    // Set up keyboard handler for number keys
-    __weak typeof(self) weakSelf = self;
+    // Set up keyboard handler for future consumers that choose to focus the bar explicitly.
     bar.keyHandler = ^(NSInteger number) {
         [weakSelf handleNumberKey:number];
     };
 
-    // Make the button bar the key window so it receives keyboard events.
-    // NSNonactivatingPanel + canBecomeKeyWindow = receives keys without
-    // stealing focus from the user's frontmost app.
-    [bar makeKeyAndOrderFront:nil];
-
-    // Extend linger time when templates are showing
-    [self.lingerTimer invalidate];
-    self.lingerTimer = nil;
-    self.lingerTimer = [NSTimer scheduledTimerWithTimeInterval:5.0
-                                                      repeats:NO
-                                                        block:^(NSTimer *timer) {
-        self.lingerTimer = nil;
-        [self hideTemplateButtons];
-        self.sessionMaxWidth = 0;
-        self.sessionMaxHeight = 0;
-        [self hide];
-        self.currentState = @"idle";
-    }];
+    // Keep the template bar around a bit longer, and pause auto-dismiss while hovered.
+    [self clearLingerTimer];
+    self.remainingLingerDuration = kTemplateLingerDuration;
+    if (![self isHoveringOverlay]) {
+        [self scheduleDismissAfter:kTemplateLingerDuration];
+    }
 }
 
 - (void)templateButtonClicked:(NSButton *)sender {
@@ -586,7 +799,9 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 - (void)hideTemplateButtons {
     self.showingTemplates = NO;
     self.templateButtons = nil;
+    self.templateShortcutNumbers = nil;
     self.templateButtonViews = nil;
+    self.templateBarHovered = NO;
     if (self.buttonBarPanel) {
         NSPanel *barToHide = self.buttonBarPanel;
         self.buttonBarPanel = nil;
@@ -602,9 +817,8 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 - (BOOL)handleNumberKey:(NSInteger)number {
     if (!self.showingTemplates || !self.templateButtons) return NO;
     for (NSUInteger i = 0; i < self.templateButtons.count; i++) {
-        NSDictionary *tmpl = self.templateButtons[i];
-        NSNumber *shortcut = tmpl[@"shortcut"];
-        if (shortcut && shortcut.integerValue == number) {
+        NSInteger shortcut = i < self.templateShortcutNumbers.count ? self.templateShortcutNumbers[i].integerValue : 0;
+        if (shortcut == number) {
             [self highlightButtonAtIndex:(NSInteger)i thenDismiss:YES];
             return YES;
         }
@@ -617,13 +831,19 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     if (index < 0 || index >= (NSInteger)self.templateButtonViews.count) return;
 
     NSButton *btn = self.templateButtonViews[index];
-    NSInteger templateIndex = index;
+    NSDictionary *templateData = index < (NSInteger)self.templateButtons.count ? self.templateButtons[index] : nil;
+    NSNumber *sourceIndex = [templateData[@"source_index"] isKindOfClass:[NSNumber class]] ? templateData[@"source_index"] : nil;
+    NSInteger templateIndex = sourceIndex != nil ? sourceIndex.integerValue : index;
 
     // Dim all other buttons, brighten selected one
     for (NSButton *b in self.templateButtonViews) {
         b.alphaValue = (b == btn) ? 1.0 : 0.3;
     }
-    btn.layer.backgroundColor = [[NSColor colorWithWhite:1.0 alpha:0.3] CGColor];
+    for (NSButton *button in self.templateButtonViews) {
+        if ([button isKindOfClass:[SPTemplateButton class]]) {
+            ((SPTemplateButton *)button).emphasized = (button == btn);
+        }
+    }
 
     // Brief hold then dismiss
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
@@ -711,6 +931,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 - (void)hide {
     [self hideTemplateButtons];
     [self stopAnimation];
+    [self setMainPanelInteractive:NO];
     [NSAnimationContext runAnimationGroup:^(NSAnimationContext *ctx) {
         ctx.duration = kFadeOutDuration;
         self.panel.animator.alphaValue = 0.0;

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -219,6 +219,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, strong) NSVisualEffectView *effectView;
 @property (nonatomic, strong) SPOverlayContentView *contentView;
 @property (nonatomic, strong) NSTimer *animationTimer;
+@property (nonatomic, strong) NSTimer *lingerTimer;
 @property (nonatomic, copy)   NSString *currentState;
 @property (nonatomic, assign) CGFloat sessionMaxWidth;
 @property (nonatomic, assign) CGFloat sessionMaxHeight;
@@ -300,11 +301,17 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 #pragma mark - Public
 
 - (void)updateState:(NSString *)state {
+    // Cancel any pending linger dismiss from a previous session
+    [self.lingerTimer invalidate];
+    self.lingerTimer = nil;
+
     self.currentState = state;
     [self stopAnimation];
 
-    // Clear interim text on any state change
-    self.contentView.interimText = nil;
+    // Only clear display text when starting a new recording session
+    if ([state hasPrefix:@"recording"]) {
+        self.contentView.interimText = nil;
+    }
 
     if ([state isEqualToString:@"idle"] || [state isEqualToString:@"completed"]) {
         self.sessionMaxWidth = 0;
@@ -364,6 +371,32 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     self.contentView.interimText = text;
     [self resizeAndCenterAnimated:YES];
     [self.contentView setNeedsDisplay:YES];
+}
+
+- (void)updateDisplayText:(NSString *)text {
+    self.contentView.interimText = text;
+    [self resizeAndCenterAnimated:YES];
+    [self.contentView setNeedsDisplay:YES];
+}
+
+- (void)lingerAndDismiss {
+    [self.lingerTimer invalidate];
+    self.lingerTimer = nil;
+
+    // Dynamic linger: clamp(charCount * 0.03, 0.8, 2.5)
+    NSString *displayText = self.contentView.interimText ?: self.contentView.statusText ?: @"";
+    NSUInteger charCount = displayText.length;
+    NSTimeInterval linger = fmin(fmax(charCount * 0.03, 0.8), 2.5);
+
+    self.lingerTimer = [NSTimer scheduledTimerWithTimeInterval:linger
+                                                      repeats:NO
+                                                        block:^(NSTimer *timer) {
+        self.lingerTimer = nil;
+        self.sessionMaxWidth = 0;
+        self.sessionMaxHeight = 0;
+        [self hide];
+        self.currentState = @"idle";
+    }];
 }
 
 #pragma mark - Layout

--- a/KoeApp/Koe/Paste/SPPasteManager.h
+++ b/KoeApp/Koe/Paste/SPPasteManager.h
@@ -6,4 +6,8 @@
 /// The completion block is called after a short delay to allow the paste to take effect.
 - (void)simulatePasteWithCompletion:(void (^)(void))completion;
 
+/// Simulate Cmd+Z undo, then Cmd+V paste. Used to replace previously pasted text.
+/// The completion block is called after the paste takes effect.
+- (void)simulateUndoThenPasteWithCompletion:(void (^)(void))completion;
+
 @end

--- a/KoeApp/Koe/Paste/SPPasteManager.m
+++ b/KoeApp/Koe/Paste/SPPasteManager.m
@@ -46,4 +46,49 @@
     NSLog(@"[Koe] Cmd+V simulated");
 }
 
+- (void)simulateUndoThenPasteWithCompletion:(void (^)(void))completion {
+    // First simulate Cmd+Z to undo previous paste
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(50 * NSEC_PER_MSEC)),
+                   dispatch_get_main_queue(), ^{
+        [self performUndo];
+
+        // Wait for undo to take effect, then paste new content
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(150 * NSEC_PER_MSEC)),
+                       dispatch_get_main_queue(), ^{
+            [self performPaste];
+
+            if (completion) {
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(100 * NSEC_PER_MSEC)),
+                               dispatch_get_main_queue(), ^{
+                    completion();
+                });
+            }
+        });
+    });
+}
+
+- (void)performUndo {
+    CGEventSourceRef source = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
+    if (!source) {
+        NSLog(@"[Koe] Failed to create event source for undo");
+        return;
+    }
+
+    // Key code for 'Z' is 6 (kVK_ANSI_Z)
+    CGEventRef cmdDown = CGEventCreateKeyboardEvent(source, (CGKeyCode)kVK_ANSI_Z, true);
+    CGEventRef cmdUp = CGEventCreateKeyboardEvent(source, (CGKeyCode)kVK_ANSI_Z, false);
+
+    CGEventSetFlags(cmdDown, kCGEventFlagMaskCommand);
+    CGEventSetFlags(cmdUp, kCGEventFlagMaskCommand);
+
+    CGEventPost(kCGHIDEventTap, cmdDown);
+    CGEventPost(kCGHIDEventTap, cmdUp);
+
+    CFRelease(cmdDown);
+    CFRelease(cmdUp);
+    CFRelease(source);
+
+    NSLog(@"[Koe] Cmd+Z simulated");
+}
+
 @end

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -24,6 +24,7 @@ static NSToolbarItemIdentifier const kToolbarLLM = @"llm";
 static NSToolbarItemIdentifier const kToolbarHotkey = @"hotkey";
 static NSToolbarItemIdentifier const kToolbarDictionary = @"dictionary";
 static NSToolbarItemIdentifier const kToolbarSystemPrompt = @"system_prompt";
+static NSToolbarItemIdentifier const kToolbarTemplates = @"templates";
 static NSToolbarItemIdentifier const kToolbarAbout = @"about";
 
 // ─── Config helpers (backed by sp_config_get / sp_config_set) ───────
@@ -187,6 +188,12 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 // System Prompt
 @property (nonatomic, strong) NSTextView *systemPromptTextView;
 
+// Templates
+@property (nonatomic, strong) NSMutableArray<NSMutableDictionary *> *templatesData;
+@property (nonatomic, strong) NSTableView *templatesTableView;
+@property (nonatomic, strong) NSTextView *templatePromptTextView;
+@property (nonatomic, assign) NSInteger selectedTemplateIndex;
+
 @end
 
 @implementation SPSetupWizardWindowController {
@@ -231,15 +238,15 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 }
 
 - (NSArray<NSToolbarItemIdentifier> *)toolbarAllowedItemIdentifiers:(NSToolbar *)toolbar {
-    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarAbout];
+    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarTemplates, kToolbarAbout];
 }
 
 - (NSArray<NSToolbarItemIdentifier> *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar {
-    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarAbout];
+    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarTemplates, kToolbarAbout];
 }
 
 - (NSArray<NSToolbarItemIdentifier> *)toolbarSelectableItemIdentifiers:(NSToolbar *)toolbar {
-    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarAbout];
+    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarTemplates, kToolbarAbout];
 }
 
 - (NSToolbarItem *)toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSToolbarItemIdentifier)itemIdentifier willBeInsertedIntoToolbar:(BOOL)flag {
@@ -262,6 +269,9 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     } else if ([itemIdentifier isEqualToString:kToolbarSystemPrompt]) {
         item.label = @"Prompt";
         item.image = [NSImage imageWithSystemSymbolName:@"text.bubble" accessibilityDescription:@"System Prompt"];
+    } else if ([itemIdentifier isEqualToString:kToolbarTemplates]) {
+        item.label = @"Templates";
+        item.image = [NSImage imageWithSystemSymbolName:@"sparkles" accessibilityDescription:@"Templates"];
     } else if ([itemIdentifier isEqualToString:kToolbarAbout]) {
         item.label = @"About";
         item.image = [NSImage imageWithSystemSymbolName:@"info.circle" accessibilityDescription:@"About"];
@@ -295,6 +305,8 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
         paneView = [self buildDictionaryPane];
     } else if ([identifier isEqualToString:kToolbarSystemPrompt]) {
         paneView = [self buildSystemPromptPane];
+    } else if ([identifier isEqualToString:kToolbarTemplates]) {
+        paneView = [self buildTemplatesPane];
     } else if ([identifier isEqualToString:kToolbarAbout]) {
         paneView = [self buildAboutPane];
     }
@@ -906,6 +918,194 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     [self addButtonsToPane:pane atY:16 width:paneWidth];
 
     return pane;
+}
+
+// ─── Templates Pane ────────────────────────────────────────────────
+
+- (NSView *)buildTemplatesPane {
+    CGFloat paneWidth = 600;
+    CGFloat contentHeight = 480;
+    NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+
+    CGFloat y = contentHeight - 48;
+
+    // Description
+    NSTextField *desc = [self descriptionLabel:@"Add prompt templates to rewrite voice input in different styles (translate, tweet, etc.). After default correction, these appear as buttons above the overlay."];
+    desc.frame = NSMakeRect(24, y - 10, paneWidth - 48, 36);
+    [pane addSubview:desc];
+    y -= 52;
+
+    // Template list (left side: table + buttons, right side: prompt editor)
+    CGFloat listW = 200;
+    CGFloat listH = 240;
+
+    // Table view in scroll view
+    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(24, y - listH, listW, listH)];
+    scrollView.hasVerticalScroller = YES;
+    scrollView.borderType = NSBezelBorder;
+
+    self.templatesTableView = [[NSTableView alloc] initWithFrame:scrollView.bounds];
+    NSTableColumn *col = [[NSTableColumn alloc] initWithIdentifier:@"name"];
+    col.title = @"Template";
+    col.width = listW - 20;
+    [self.templatesTableView addTableColumn:col];
+    self.templatesTableView.headerView = nil;
+    self.templatesTableView.delegate = (id)self;
+    self.templatesTableView.dataSource = (id)self;
+    self.templatesTableView.target = self;
+    self.templatesTableView.action = @selector(templateTableClicked:);
+    scrollView.documentView = self.templatesTableView;
+    [pane addSubview:scrollView];
+
+    // Add / Remove buttons
+    CGFloat btnY = y - listH - 30;
+    NSButton *addBtn = [NSButton buttonWithTitle:@"+" target:self action:@selector(addTemplate:)];
+    addBtn.frame = NSMakeRect(24, btnY, 30, 24);
+    addBtn.bezelStyle = NSBezelStyleSmallSquare;
+    [pane addSubview:addBtn];
+
+    NSButton *removeBtn = [NSButton buttonWithTitle:@"−" target:self action:@selector(removeTemplate:)];
+    removeBtn.frame = NSMakeRect(56, btnY, 30, 24);
+    removeBtn.bezelStyle = NSBezelStyleSmallSquare;
+    [pane addSubview:removeBtn];
+
+    // Right side: prompt editor
+    CGFloat editorX = 24 + listW + 16;
+    CGFloat editorW = paneWidth - editorX - 24;
+
+    NSTextField *nameLabel = [self formLabel:@"Name" frame:NSMakeRect(editorX, y - 2, 50, 20)];
+    nameLabel.alignment = NSTextAlignmentLeft;
+    [pane addSubview:nameLabel];
+
+    NSTextField *nameField = [self formTextField:NSMakeRect(editorX + 55, y - 2, editorW - 55, 24) placeholder:@"Template name"];
+    nameField.tag = 1001;
+    [pane addSubview:nameField];
+
+    CGFloat promptY = y - 36;
+    NSTextField *promptLabel = [self formLabel:@"Prompt" frame:NSMakeRect(editorX, promptY, 50, 20)];
+    promptLabel.alignment = NSTextAlignmentLeft;
+    [pane addSubview:promptLabel];
+
+    NSScrollView *promptScroll = [[NSScrollView alloc] initWithFrame:NSMakeRect(editorX, promptY - listH + 20, editorW, listH - 20)];
+    promptScroll.hasVerticalScroller = YES;
+    promptScroll.borderType = NSBezelBorder;
+
+    self.templatePromptTextView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, editorW - 16, listH - 24)];
+    self.templatePromptTextView.minSize = NSMakeSize(0, listH - 24);
+    self.templatePromptTextView.maxSize = NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX);
+    self.templatePromptTextView.verticallyResizable = YES;
+    self.templatePromptTextView.horizontallyResizable = NO;
+    self.templatePromptTextView.textContainer.containerSize = NSMakeSize(editorW - 16, CGFLOAT_MAX);
+    self.templatePromptTextView.textContainer.widthTracksTextView = YES;
+    self.templatePromptTextView.font = [NSFont systemFontOfSize:12];
+    self.templatePromptTextView.allowsUndo = YES;
+    promptScroll.documentView = self.templatePromptTextView;
+    [pane addSubview:promptScroll];
+
+    // Save / Cancel buttons
+    [self addButtonsToPane:pane atY:16 width:paneWidth];
+
+    return pane;
+}
+
+#pragma mark - Templates Table Data Source & Delegate
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView {
+    if (tableView == self.templatesTableView) {
+        return (NSInteger)self.templatesData.count;
+    }
+    return 0;
+}
+
+- (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row {
+    if (tableView != self.templatesTableView) return nil;
+
+    NSTextField *cell = [tableView makeViewWithIdentifier:@"TemplateCell" owner:self];
+    if (!cell) {
+        cell = [NSTextField labelWithString:@""];
+        cell.identifier = @"TemplateCell";
+        cell.lineBreakMode = NSLineBreakByTruncatingTail;
+    }
+    if (row < (NSInteger)self.templatesData.count) {
+        NSDictionary *tmpl = self.templatesData[row];
+        NSNumber *shortcut = tmpl[@"shortcut"];
+        NSString *name = tmpl[@"name"] ?: @"Untitled";
+        cell.stringValue = [NSString stringWithFormat:@"%@  %@", shortcut, name];
+    }
+    return cell;
+}
+
+- (void)templateTableClicked:(id)sender {
+    [self saveCurrentTemplateEdits];
+    NSInteger row = self.templatesTableView.selectedRow;
+    self.selectedTemplateIndex = row;
+    [self loadTemplateAtIndex:row];
+}
+
+- (void)loadTemplateAtIndex:(NSInteger)index {
+    NSTextField *nameField = [self.templatesTableView.superview.superview viewWithTag:1001];
+    // Find the name field by walking pane subviews
+    NSView *pane = self.templatesTableView.superview.superview.superview;
+    for (NSView *sub in pane.subviews) {
+        if (sub.tag == 1001 && [sub isKindOfClass:[NSTextField class]]) {
+            nameField = (NSTextField *)sub;
+            break;
+        }
+    }
+
+    if (index >= 0 && index < (NSInteger)self.templatesData.count) {
+        NSDictionary *tmpl = self.templatesData[index];
+        if (nameField) nameField.stringValue = tmpl[@"name"] ?: @"";
+        self.templatePromptTextView.string = tmpl[@"system_prompt"] ?: @"";
+    } else {
+        if (nameField) nameField.stringValue = @"";
+        self.templatePromptTextView.string = @"";
+    }
+}
+
+- (void)saveCurrentTemplateEdits {
+    NSInteger idx = self.selectedTemplateIndex;
+    if (idx < 0 || idx >= (NSInteger)self.templatesData.count) return;
+
+    NSView *pane = self.templatesTableView.superview.superview.superview;
+    NSTextField *nameField = nil;
+    for (NSView *sub in pane.subviews) {
+        if (sub.tag == 1001 && [sub isKindOfClass:[NSTextField class]]) {
+            nameField = (NSTextField *)sub;
+            break;
+        }
+    }
+
+    NSMutableDictionary *tmpl = self.templatesData[idx];
+    if (nameField) tmpl[@"name"] = nameField.stringValue;
+    tmpl[@"system_prompt"] = self.templatePromptTextView.string ?: @"";
+    [self.templatesTableView reloadData];
+}
+
+- (void)addTemplate:(id)sender {
+    [self saveCurrentTemplateEdits];
+    NSInteger nextShortcut = (NSInteger)self.templatesData.count + 1;
+    if (nextShortcut > 9) nextShortcut = 9;
+    NSMutableDictionary *newTemplate = [NSMutableDictionary dictionaryWithDictionary:@{
+        @"name": @"New Template",
+        @"shortcut": @(nextShortcut),
+        @"system_prompt": @"",
+    }];
+    [self.templatesData addObject:newTemplate];
+    [self.templatesTableView reloadData];
+    NSInteger newRow = (NSInteger)self.templatesData.count - 1;
+    [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:newRow] byExtendingSelection:NO];
+    self.selectedTemplateIndex = newRow;
+    [self loadTemplateAtIndex:newRow];
+}
+
+- (void)removeTemplate:(id)sender {
+    NSInteger row = self.templatesTableView.selectedRow;
+    if (row < 0 || row >= (NSInteger)self.templatesData.count) return;
+    [self.templatesData removeObjectAtIndex:row];
+    [self.templatesTableView reloadData];
+    self.selectedTemplateIndex = -1;
+    [self loadTemplateAtIndex:-1];
 }
 
 - (NSView *)buildAboutPane {
@@ -1769,6 +1969,21 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         NSString *promptPath = [dir stringByAppendingPathComponent:kSystemPromptFile];
         NSString *promptContent = [NSString stringWithContentsOfFile:promptPath encoding:NSUTF8StringEncoding error:nil] ?: @"";
         [self.systemPromptTextView setString:promptContent];
+    } else if ([identifier isEqualToString:kToolbarTemplates]) {
+        NSArray *templates = [self.rustBridge promptTemplates];
+        self.templatesData = [NSMutableArray array];
+        for (NSDictionary *t in templates) {
+            [self.templatesData addObject:[t mutableCopy]];
+        }
+        self.selectedTemplateIndex = -1;
+        [self.templatesTableView reloadData];
+        if (self.templatesData.count > 0) {
+            [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+            self.selectedTemplateIndex = 0;
+            [self loadTemplateAtIndex:0];
+        } else {
+            [self loadTemplateAtIndex:-1];
+        }
     }
 }
 
@@ -1926,6 +2141,12 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
             [self showAlert:@"Failed to save system_prompt.txt" info:error.localizedDescription];
             return;
         }
+    }
+
+    // Save prompt templates
+    if (self.templatesData) {
+        [self saveCurrentTemplateEdits];
+        [self.rustBridge setPromptTemplates:self.templatesData];
     }
 
     NSLog(@"[Koe] Settings saved");

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1,6 +1,7 @@
 #import "SPSetupWizardWindowController.h"
 #import "SPRustBridge.h"
 #import <Cocoa/Cocoa.h>
+#import <Carbon/Carbon.h>
 #import <Speech/Speech.h>
 
 // Apple Speech asset management FFI (KoeAppleSpeech Swift package)
@@ -17,6 +18,8 @@ extern uint8_t *koe_apple_speech_supported_locales(uint32_t *outLen);
 static NSString *const kConfigDir = @".koe";
 static NSString *const kDictionaryFile = @"dictionary.txt";
 static NSString *const kSystemPromptFile = @"system_prompt.txt";
+static NSString *const kTemplateEditablePromptKey = @"__editable_prompt";
+static NSString *const kTemplateOriginalPromptKey = @"__original_prompt";
 
 // Toolbar item identifiers
 static NSToolbarItemIdentifier const kToolbarASR = @"asr";
@@ -54,7 +57,83 @@ static BOOL isNumericKeycode(NSString *value) {
     return [scanner scanInt:&intValue] && [scanner isAtEnd];
 }
 
-static NSString *normalizedHotkeyValue(NSString *value) {
+static NSString *displayCharacterForKeycode(NSInteger keycode) {
+    TISInputSourceRef inputSource = TISCopyCurrentKeyboardLayoutInputSource();
+    if (!inputSource) return nil;
+
+    CFDataRef layoutData = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData);
+    if (!layoutData) {
+        CFRelease(inputSource);
+        return nil;
+    }
+
+    const UCKeyboardLayout *keyboardLayout = (const UCKeyboardLayout *)CFDataGetBytePtr(layoutData);
+    if (!keyboardLayout) {
+        CFRelease(inputSource);
+        return nil;
+    }
+
+    UInt32 deadKeyState = 0;
+    UniChar chars[4];
+    UniCharCount length = 0;
+    OSStatus status = UCKeyTranslate(keyboardLayout,
+                                     (UInt16)keycode,
+                                     kUCKeyActionDisplay,
+                                     0,
+                                     LMGetKbdType(),
+                                     kUCKeyTranslateNoDeadKeysBit,
+                                     &deadKeyState,
+                                     sizeof(chars) / sizeof(chars[0]),
+                                     &length,
+                                     chars);
+    CFRelease(inputSource);
+
+    if (status != noErr || length == 0) return nil;
+
+    NSString *result = [[NSString stringWithCharacters:chars length:(NSUInteger)length]
+        stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (result.length == 0) return nil;
+    return result.uppercaseString;
+}
+
+static NSString *displayNameForKeycodeValue(NSString *value) {
+    NSInteger keycode = value.integerValue;
+    switch (keycode) {
+        case 122: return @"F1";
+        case 120: return @"F2";
+        case 99:  return @"F3";
+        case 118: return @"F4";
+        case 96:  return @"F5";
+        case 97:  return @"F6";
+        case 98:  return @"F7";
+        case 100: return @"F8";
+        case 101: return @"F9";
+        case 109: return @"F10";
+        case 103: return @"F11";
+        case 111: return @"F12";
+        case 49:  return @"Space";
+        case 53:  return @"Escape";
+        case 48:  return @"Tab";
+        case 57:  return @"Caps Lock";
+        case 36:  return @"Return";
+        case 51:  return @"Delete";
+        case 117: return @"Forward Delete";
+        case 115: return @"Home";
+        case 119: return @"End";
+        case 116: return @"Page Up";
+        case 121: return @"Page Down";
+        case 123: return @"Left Arrow";
+        case 124: return @"Right Arrow";
+        case 125: return @"Down Arrow";
+        case 126: return @"Up Arrow";
+        default: {
+            NSString *displayCharacter = displayCharacterForKeycode(keycode);
+            return displayCharacter.length > 0 ? displayCharacter : [NSString stringWithFormat:@"Key %ld", (long)keycode];
+        }
+    }
+}
+
+static NSSet<NSString *> *presetHotkeyValues(void) {
     static NSSet<NSString *> *validValues;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -68,58 +147,169 @@ static NSString *normalizedHotkeyValue(NSString *value) {
             @"right_control",
         ]];
     });
-    if ([validValues containsObject:value]) return value;
-    if (isNumericKeycode(value)) return value;
+    return validValues;
+}
+
+static NSArray<NSString *> *comboModifierOrder(void) {
+    return @[@"command", @"option", @"control", @"shift", @"fn"];
+}
+
+static NSDictionary<NSString *, NSString *> *comboModifierDisplayNames(void) {
+    static NSDictionary<NSString *, NSString *> *displayNames;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        displayNames = @{
+            @"command": @"Command",
+            @"option": @"Option",
+            @"control": @"Control",
+            @"shift": @"Shift",
+            @"fn": @"Fn",
+        };
+    });
+    return displayNames;
+}
+
+static NSString *normalizedHotkeyComboValue(NSString *value) {
+    if (![value containsString:@"+"]) return nil;
+
+    NSMutableOrderedSet<NSString *> *modifiers = [NSMutableOrderedSet orderedSet];
+    NSString *keyToken = nil;
+
+    for (NSString *rawPart in [value componentsSeparatedByString:@"+"]) {
+        NSString *part = [[rawPart stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+        if (part.length == 0) return nil;
+
+        NSString *normalizedModifier = nil;
+        if ([part isEqualToString:@"cmd"] || [part isEqualToString:@"command"]) {
+            normalizedModifier = @"command";
+        } else if ([part isEqualToString:@"alt"] || [part isEqualToString:@"option"]) {
+            normalizedModifier = @"option";
+        } else if ([part isEqualToString:@"ctrl"] || [part isEqualToString:@"control"]) {
+            normalizedModifier = @"control";
+        } else if ([part isEqualToString:@"shift"]) {
+            normalizedModifier = @"shift";
+        } else if ([part isEqualToString:@"fn"] || [part isEqualToString:@"function"] || [part isEqualToString:@"globe"]) {
+            normalizedModifier = @"fn";
+        }
+
+        if (normalizedModifier) {
+            [modifiers addObject:normalizedModifier];
+            continue;
+        }
+
+        if (keyToken != nil || !isNumericKeycode(part)) {
+            return nil;
+        }
+        keyToken = [NSString stringWithFormat:@"%ld", (long)part.integerValue];
+    }
+
+    if (modifiers.count == 0 || keyToken.length == 0) return nil;
+
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    for (NSString *modifier in comboModifierOrder()) {
+        if ([modifiers containsObject:modifier]) {
+            [parts addObject:modifier];
+        }
+    }
+    [parts addObject:keyToken];
+    return [parts componentsJoinedByString:@"+"];
+}
+
+static NSString *normalizedHotkeyValue(NSString *value) {
+    NSString *trimmedValue = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if ([presetHotkeyValues() containsObject:trimmedValue]) return trimmedValue;
+    if (isNumericKeycode(trimmedValue)) {
+        return [NSString stringWithFormat:@"%ld", (long)trimmedValue.integerValue];
+    }
+    NSString *normalizedCombo = normalizedHotkeyComboValue(trimmedValue);
+    if (normalizedCombo.length > 0) return normalizedCombo;
     return @"fn";
 }
 
-static NSString *displayNameForCustomKeycode(NSString *value) {
-    int keycode = value.intValue;
-    switch (keycode) {
-        case 122: return @"F1 (Keycode 122)";
-        case 120: return @"F2 (Keycode 120)";
-        case 99:  return @"F3 (Keycode 99)";
-        case 118: return @"F4 (Keycode 118)";
-        case 96:  return @"F5 (Keycode 96)";
-        case 97:  return @"F6 (Keycode 97)";
-        case 98:  return @"F7 (Keycode 98)";
-        case 100: return @"F8 (Keycode 100)";
-        case 101: return @"F9 (Keycode 101)";
-        case 109: return @"F10 (Keycode 109)";
-        case 103: return @"F11 (Keycode 103)";
-        case 111: return @"F12 (Keycode 111)";
-        case 49:  return @"Space (Keycode 49)";
-        case 53:  return @"Escape (Keycode 53)";
-        case 48:  return @"Tab (Keycode 48)";
-        case 57:  return @"CapsLock (Keycode 57)";
-        default:  return [NSString stringWithFormat:@"Keycode %d", keycode];
+static NSString *displayNameForHotkeyValue(NSString *value) {
+    NSString *normalizedValue = normalizedHotkeyValue(value);
+    if ([normalizedValue isEqualToString:@"left_option"]) return @"Left Option (⌥)";
+    if ([normalizedValue isEqualToString:@"right_option"]) return @"Right Option (⌥)";
+    if ([normalizedValue isEqualToString:@"left_command"]) return @"Left Command (⌘)";
+    if ([normalizedValue isEqualToString:@"right_command"]) return @"Right Command (⌘)";
+    if ([normalizedValue isEqualToString:@"left_control"]) return @"Left Control (⌃)";
+    if ([normalizedValue isEqualToString:@"right_control"]) return @"Right Control (⌃)";
+    if ([normalizedValue isEqualToString:@"fn"]) return @"Fn (Globe)";
+    NSString *normalizedCombo = normalizedHotkeyComboValue(normalizedValue);
+    if (normalizedCombo.length > 0) {
+        NSMutableArray<NSString *> *parts = [NSMutableArray array];
+        NSArray<NSString *> *tokens = [normalizedCombo componentsSeparatedByString:@"+"];
+        NSDictionary<NSString *, NSString *> *displayNames = comboModifierDisplayNames();
+        for (NSInteger idx = 0; idx < (NSInteger)tokens.count; idx++) {
+            NSString *token = tokens[idx];
+            if (idx == (NSInteger)tokens.count - 1) {
+                [parts addObject:displayNameForKeycodeValue(token)];
+            } else {
+                [parts addObject:displayNames[token] ?: token.capitalizedString];
+            }
+        }
+        return [parts componentsJoinedByString:@" + "];
     }
+    if (isNumericKeycode(normalizedValue)) return displayNameForKeycodeValue(normalizedValue);
+    return normalizedValue;
 }
 
-/// If the value is a numeric keycode, add a custom item to the popup and select it.
-static void ensureCustomKeycodeInPopup(NSPopUpButton *popup, NSString *value) {
-    if (!isNumericKeycode(value)) return;
-    NSString *title = displayNameForCustomKeycode(value);
-    [popup addItemWithTitle:title];
-    [popup lastItem].representedObject = value;
+static BOOL hotkeyValueUsesCustomPopupItem(NSString *value) {
+    NSString *normalizedValue = normalizedHotkeyValue(value);
+    return isNumericKeycode(normalizedValue) || normalizedHotkeyComboValue(normalizedValue).length > 0;
+}
+
+/// If the value is a custom hotkey (recorded combo or raw keycode), add a
+/// custom popup item and select it.
+static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
+    NSString *normalizedValue = normalizedHotkeyValue(value);
+    if (!hotkeyValueUsesCustomPopupItem(normalizedValue)) return;
+
+    NSMutableArray<NSMenuItem *> *itemsToRemove = [NSMutableArray array];
+    for (NSMenuItem *item in popup.itemArray) {
+        NSString *representedObject = [item.representedObject isKindOfClass:[NSString class]] ? item.representedObject : nil;
+        if (representedObject.length > 0 &&
+            ![presetHotkeyValues() containsObject:representedObject] &&
+            ![representedObject isEqualToString:normalizedValue]) {
+            [itemsToRemove addObject:item];
+        }
+        if ([representedObject isEqualToString:normalizedValue]) {
+            [popup selectItem:item];
+            return;
+        }
+    }
+
+    for (NSMenuItem *item in itemsToRemove) {
+        [popup.menu removeItem:item];
+    }
+
+    [popup addItemWithTitle:displayNameForHotkeyValue(normalizedValue)];
+    [popup lastItem].representedObject = normalizedValue;
     [popup selectItem:[popup lastItem]];
 }
 
-static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
-    if (isNumericKeycode(triggerKey)) return @"left_option";
-    NSString *normalizedTrigger = normalizedHotkeyValue(triggerKey);
-    if ([normalizedTrigger isEqualToString:@"fn"]) return @"left_option";
-    if ([normalizedTrigger isEqualToString:@"left_option"]) return @"right_option";
-    if ([normalizedTrigger isEqualToString:@"right_option"]) return @"left_command";
-    if ([normalizedTrigger isEqualToString:@"left_command"]) return @"right_command";
-    if ([normalizedTrigger isEqualToString:@"right_command"]) return @"left_control";
-    if ([normalizedTrigger isEqualToString:@"left_control"]) return @"right_control";
-    return @"fn";
+@interface SPTemplateRowView : NSTableRowView
+@end
+
+@implementation SPTemplateRowView
+
+- (void)drawSelectionInRect:(NSRect)dirtyRect {
+    if (!self.isSelected) return;
+
+    NSRect selectionRect = NSInsetRect(self.bounds, 2.0, 2.0);
+    NSBezierPath *selectionPath = [NSBezierPath bezierPathWithRoundedRect:selectionRect xRadius:8.0 yRadius:8.0];
+    [[NSColor colorWithRed:0.231 green:0.431 blue:0.902 alpha:0.08] setFill];
+    [selectionPath fill];
 }
+
+- (void)drawSeparatorInRect:(NSRect)dirtyRect {
+}
+
+@end
 
 // ─── Window Controller ──────────────────────────────────────────────
 
-@interface SPSetupWizardWindowController () <NSToolbarDelegate>
+@interface SPSetupWizardWindowController () <NSToolbarDelegate, NSTableViewDelegate, NSTableViewDataSource, NSTextFieldDelegate, NSTextViewDelegate>
 
 // Current pane
 @property (nonatomic, copy) NSString *currentPaneIdentifier;
@@ -152,7 +342,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 @property (nonatomic, strong) NSPopUpButton *appleSpeechLocalePopup;
 
 // LLM fields
-@property (nonatomic, strong) NSButton *llmEnabledCheckbox;
+@property (nonatomic, strong) NSSwitch *llmEnabledCheckbox;
 @property (nonatomic, strong) NSPopUpButton *llmProviderPopup;
 @property (nonatomic, strong) NSTextField *llmBaseUrlField;
 @property (nonatomic, strong) NSTextField *llmApiKeyField;
@@ -175,7 +365,10 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 
 // Hotkey
 @property (nonatomic, strong) NSPopUpButton *hotkeyPopup;
-@property (nonatomic, strong) NSPopUpButton *cancelHotkeyPopup;
+@property (nonatomic, strong) NSButton *recordTriggerHotkeyButton;
+@property (nonatomic, strong) NSButton *resetTriggerHotkeyButton;
+@property (nonatomic, strong) id hotkeyRecordingMonitor;
+@property (nonatomic, copy) NSString *recordingHotkeyTarget;
 // Trigger mode
 @property (nonatomic, strong) NSPopUpButton *triggerModePopup;
 @property (nonatomic, strong) NSSwitch *startSoundCheckbox;
@@ -191,10 +384,15 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 // Templates
 @property (nonatomic, strong) NSMutableArray<NSMutableDictionary *> *templatesData;
 @property (nonatomic, strong) NSTableView *templatesTableView;
+@property (nonatomic, strong) NSSwitch *templatesEnabledSwitch;
+@property (nonatomic, strong) NSSegmentedControl *templatePrimaryActionsControl;
+@property (nonatomic, strong) NSSegmentedControl *templateReorderActionsControl;
 @property (nonatomic, strong) NSTextField *templateNameField;
+@property (nonatomic, strong) NSSwitch *templateItemEnabledSwitch;
 @property (nonatomic, strong) NSTextView *templatePromptTextView;
 @property (nonatomic, assign) NSInteger selectedTemplateIndex;
 @property (nonatomic, assign) BOOL suppressTemplateSync;
+@property (nonatomic, assign) BOOL templateEditorDirty;
 
 @end
 
@@ -295,6 +493,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     if ([self.currentPaneIdentifier isEqualToString:kToolbarTemplates]) {
         [self saveCurrentTemplateEdits];
     }
+    [self endHotkeyRecording];
 
     self.currentPaneIdentifier = identifier;
 
@@ -358,18 +557,28 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     CGFloat fieldX = labelW + 24;
     CGFloat fieldW = paneWidth - fieldX - 32;
     CGFloat rowH = 32;
+    CGFloat contentX = 24.0;
+    CGFloat contentW = paneWidth - 48.0;
 
     // Calculate content height
     CGFloat contentHeight = 260;
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+    [self applySettingsPaneBackgroundToView:pane];
 
-    CGFloat y = contentHeight - 48;
+    CGFloat y = contentHeight - 30.0;
 
     // Description
-    NSTextField *desc = [self descriptionLabel:@"Choose the ASR provider used for transcription."];
-    desc.frame = NSMakeRect(24, y - 10, paneWidth - 48, 36);
-    [pane addSubview:desc];
-    y -= 52;
+    NSTextField *desc = [self addSettingsDescriptionText:@"Choose the ASR provider used for transcription."
+                                                  toPane:pane
+                                                   topY:y
+                                                      x:contentX
+                                                  width:contentW];
+
+    NSTextField *sectionTitle = [self sectionTitleLabel:@"Connection"
+                                                  frame:NSMakeRect(contentX, floor(NSMinY(desc.frame) - 36.0), contentW, 20)];
+    [pane addSubview:sectionTitle];
+    y = NSMinY(sectionTitle.frame) - 32.0;
+    CGFloat formStartY = y;
 
     // Provider
     [pane addSubview:[self formLabel:@"Provider" frame:NSMakeRect(16, y, labelW, 22)]];
@@ -499,7 +708,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     y -= rowH;
 
     // Access Key (Doubao) — fixed at row 2 (same as Qwen API Key)
-    CGFloat accessKeyY = contentHeight - 48 - 52 - rowH - rowH;
+    CGFloat accessKeyY = formStartY - rowH - rowH;
     CGFloat eyeW = 28;
     CGFloat secFieldW = fieldW - eyeW - 4;
 
@@ -518,7 +727,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     [pane addSubview:accessKeyLabel];
 
     // Qwen API Key — fixed at row 1 (same position as App Key)
-    CGFloat qwenY = contentHeight - 48 - 52 - rowH;
+    CGFloat qwenY = formStartY - rowH;
     self.asrQwenApiKeySecureField = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(fieldX, qwenY, secFieldW, 22)];
     self.asrQwenApiKeySecureField.placeholderString = @"DashScope API Key (sk-xxx)";
     self.asrQwenApiKeySecureField.font = [NSFont systemFontOfSize:13];
@@ -555,25 +764,35 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     CGFloat fieldX = labelW + 24;
     CGFloat fieldW = paneWidth - fieldX - 32;
     CGFloat rowH = 32;
+    CGFloat contentX = 24.0;
+    CGFloat contentW = paneWidth - 48.0;
 
     CGFloat contentHeight = 540;
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+    [self applySettingsPaneBackgroundToView:pane];
 
-    CGFloat y = contentHeight - 48;
+    CGFloat y = contentHeight - 30.0;
 
     // Description
-    NSTextField *desc = [self descriptionLabel:@"Configure LLM for post-correction. When disabled, raw ASR output is used directly."];
-    desc.frame = NSMakeRect(24, y - 10, paneWidth - 48, 36);
-    [pane addSubview:desc];
-    y -= 52;
+    NSTextField *desc = [self addSettingsDescriptionText:@"Configure LLM for post-correction. When disabled, raw ASR output is used directly."
+                                                  toPane:pane
+                                                   topY:y
+                                                      x:contentX
+                                                  width:contentW];
+    y = NSMinY(desc.frame) - 16.0;
 
     // Enabled toggle
-    self.llmEnabledCheckbox = [NSButton checkboxWithTitle:@"Enable LLM Correction"
-                                                   target:self
-                                                   action:@selector(llmEnabledToggled:)];
-    self.llmEnabledCheckbox.frame = NSMakeRect(fieldX, y, 300, 22);
-    [pane addSubview:self.llmEnabledCheckbox];
-    y -= rowH + 8;
+    self.llmEnabledCheckbox = [self settingsSwitchWithAction:@selector(llmEnabledToggled:)];
+    NSView *llmEnabledCard = [self settingsToggleCardWithFrame:NSMakeRect(contentX, y - 48.0, contentW, 48.0)
+                                                         title:@"LLM Correction"
+                                                        toggle:self.llmEnabledCheckbox];
+    [pane addSubview:llmEnabledCard];
+    y = NSMinY(llmEnabledCard.frame) - 24.0;
+
+    NSTextField *sectionTitle = [self sectionTitleLabel:@"Connection"
+                                                  frame:NSMakeRect(contentX, floor(y - 20.0), contentW, 20.0)];
+    [pane addSubview:sectionTitle];
+    y = NSMinY(sectionTitle.frame) - 32.0;
 
     // Provider
     [pane addSubview:[self formLabel:@"Provider" frame:NSMakeRect(16, y, labelW, 22)]];
@@ -588,6 +807,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     [self.llmProviderPopup setAction:@selector(llmProviderChanged:)];
     [pane addSubview:self.llmProviderPopup];
     y -= rowH;
+    CGFloat providerDetailStartY = y;
 
     // --- OpenAI fields (tag 2001-2006 for show/hide) ---
 
@@ -668,7 +888,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     [pane addSubview:self.llmTestResultLabel];
 
     // --- MLX fields (tag 2010-2012 for show/hide, initially hidden) ---
-    CGFloat mlxY = contentHeight - 48 - 52 - rowH - 8 - rowH;  // same Y as Base URL row
+    CGFloat mlxY = providerDetailStartY;  // same Y as Base URL row
 
     // MLX Model popup + Download button
     NSTextField *llmModelLabel = [self formLabel:@"Model" frame:NSMakeRect(16, mlxY, labelW, 22)];
@@ -755,23 +975,18 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     CGFloat topPad = 24.0;
 
     // ── Trigger Key ──
-    self.hotkeyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
-    [self.hotkeyPopup addItemsWithTitles:@[
-        @"Fn (Globe)",
-        @"Left Option (\u2325)",
-        @"Right Option (\u2325)",
-        @"Left Command (\u2318)",
-        @"Right Command (\u2318)",
-        @"Left Control (\u2303)",
-        @"Right Control (\u2303)",
-    ]];
-    [self.hotkeyPopup itemAtIndex:0].representedObject = @"fn";
-    [self.hotkeyPopup itemAtIndex:1].representedObject = @"left_option";
-    [self.hotkeyPopup itemAtIndex:2].representedObject = @"right_option";
-    [self.hotkeyPopup itemAtIndex:3].representedObject = @"left_command";
-    [self.hotkeyPopup itemAtIndex:4].representedObject = @"right_command";
-    [self.hotkeyPopup itemAtIndex:5].representedObject = @"left_control";
-    [self.hotkeyPopup itemAtIndex:6].representedObject = @"right_control";
+    self.hotkeyPopup = [self hotkeyPresetPopup];
+    self.hotkeyPopup.target = self;
+    self.hotkeyPopup.action = @selector(triggerHotkeyChanged:);
+    self.recordTriggerHotkeyButton = [NSButton buttonWithTitle:@"Record" target:self action:@selector(recordTriggerHotkey:)];
+    self.recordTriggerHotkeyButton.bezelStyle = NSBezelStyleRounded;
+    self.recordTriggerHotkeyButton.frame = NSMakeRect(0, 0, 70, 28);
+    self.resetTriggerHotkeyButton = [NSButton buttonWithTitle:@"Reset" target:self action:@selector(resetTriggerHotkey:)];
+    self.resetTriggerHotkeyButton.bezelStyle = NSBezelStyleRounded;
+    self.resetTriggerHotkeyButton.frame = NSMakeRect(0, 0, 58, 28);
+    NSView *triggerShortcutControl = [self hotkeyPickerControlWithPopup:self.hotkeyPopup
+                                                           recordButton:self.recordTriggerHotkeyButton
+                                                            resetButton:self.resetTriggerHotkeyButton];
 
     // ── Trigger Mode ──
     self.triggerModePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
@@ -782,36 +997,16 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     [self.triggerModePopup itemAtIndex:0].representedObject = @"hold";
     [self.triggerModePopup itemAtIndex:1].representedObject = @"toggle";
 
-    // ── Cancel Key ──
-    self.cancelHotkeyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
-    [self.cancelHotkeyPopup addItemsWithTitles:@[
-        @"Fn (Globe)",
-        @"Left Option (\u2325)",
-        @"Right Option (\u2325)",
-        @"Left Command (\u2318)",
-        @"Right Command (\u2318)",
-        @"Left Control (\u2303)",
-        @"Right Control (\u2303)",
-    ]];
-    [self.cancelHotkeyPopup itemAtIndex:0].representedObject = @"fn";
-    [self.cancelHotkeyPopup itemAtIndex:1].representedObject = @"left_option";
-    [self.cancelHotkeyPopup itemAtIndex:2].representedObject = @"right_option";
-    [self.cancelHotkeyPopup itemAtIndex:3].representedObject = @"left_command";
-    [self.cancelHotkeyPopup itemAtIndex:4].representedObject = @"right_command";
-    [self.cancelHotkeyPopup itemAtIndex:5].representedObject = @"left_control";
-    [self.cancelHotkeyPopup itemAtIndex:6].representedObject = @"right_control";
-
     // ── Trigger card ──
     NSView *triggerCard = [self cardWithTitle:@"Trigger" rows:@[
-        [self cardRowWithLabel:@"Trigger Key" control:self.hotkeyPopup],
+        [self cardRowWithLabel:@"Trigger Shortcut" control:triggerShortcutControl],
         [self cardRowWithLabel:@"Trigger Mode" control:self.triggerModePopup],
-        [self cardRowWithLabel:@"Cancel Key" control:self.cancelHotkeyPopup],
     ] width:cardWidth];
 
     // ── Feedback Sounds ──
-    self.startSoundCheckbox = [[NSSwitch alloc] initWithFrame:NSMakeRect(0, 0, 38, 22)];
-    self.stopSoundCheckbox = [[NSSwitch alloc] initWithFrame:NSMakeRect(0, 0, 38, 22)];
-    self.errorSoundCheckbox = [[NSSwitch alloc] initWithFrame:NSMakeRect(0, 0, 38, 22)];
+    self.startSoundCheckbox = [self settingsSwitchWithAction:NULL];
+    self.stopSoundCheckbox = [self settingsSwitchWithAction:NULL];
+    self.errorSoundCheckbox = [self settingsSwitchWithAction:NULL];
 
     NSView *feedbackCard = [self cardWithTitle:@"Feedback Sounds" rows:@[
         [self cardRowWithLabel:@"Recording starts" control:self.startSoundCheckbox],
@@ -825,8 +1020,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     CGFloat contentHeight = topPad + triggerH + cardSpacing + feedbackH + 56;
 
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
-    pane.wantsLayer = YES;
-    pane.layer.backgroundColor = [NSColor colorWithRed:0.961 green:0.961 blue:0.969 alpha:1.0].CGColor;
+    [self applySettingsPaneBackgroundToView:pane];
 
     CGFloat y = contentHeight - topPad;
 
@@ -848,39 +1042,240 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     return pane;
 }
 
+- (NSPopUpButton *)hotkeyPresetPopup {
+    NSPopUpButton *popup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 168, 26) pullsDown:NO];
+    NSArray<NSString *> *titles = @[
+        @"Fn (Globe)",
+        @"Left Option (\u2325)",
+        @"Right Option (\u2325)",
+        @"Left Command (\u2318)",
+        @"Right Command (\u2318)",
+        @"Left Control (\u2303)",
+        @"Right Control (\u2303)",
+    ];
+    NSArray<NSString *> *values = @[
+        @"fn",
+        @"left_option",
+        @"right_option",
+        @"left_command",
+        @"right_command",
+        @"left_control",
+        @"right_control",
+    ];
+    [popup addItemsWithTitles:titles];
+    for (NSInteger idx = 0; idx < (NSInteger)values.count; idx++) {
+        [popup itemAtIndex:idx].representedObject = values[idx];
+    }
+    return popup;
+}
+
+- (NSView *)hotkeyPickerControlWithPopup:(NSPopUpButton *)popup
+                            recordButton:(NSButton *)button
+                             resetButton:(NSButton *)resetButton {
+    CGFloat spacing = 6.0;
+    CGFloat width = popup.frame.size.width + spacing + button.frame.size.width + spacing + resetButton.frame.size.width;
+    CGFloat height = MAX(popup.frame.size.height, button.frame.size.height);
+    NSView *container = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, height)];
+
+    popup.frame = NSMakeRect(0, floor((height - popup.frame.size.height) / 2.0), popup.frame.size.width, popup.frame.size.height);
+    button.frame = NSMakeRect(CGRectGetMaxX(popup.frame) + spacing,
+                              floor((height - button.frame.size.height) / 2.0),
+                              button.frame.size.width,
+                              button.frame.size.height);
+    resetButton.frame = NSMakeRect(CGRectGetMaxX(button.frame) + spacing,
+                                   floor((height - resetButton.frame.size.height) / 2.0),
+                                   resetButton.frame.size.width,
+                                   resetButton.frame.size.height);
+    [container addSubview:popup];
+    [container addSubview:button];
+    [container addSubview:resetButton];
+    return container;
+}
+
+- (void)setRuntimeHotkeyMonitoringSuspended:(BOOL)suspended {
+    id appDelegate = NSApp.delegate;
+    if ([appDelegate respondsToSelector:@selector(hotkeyMonitor)]) {
+        id monitor = [appDelegate valueForKey:@"hotkeyMonitor"];
+        if ([monitor respondsToSelector:@selector(setSuspended:)]) {
+            [monitor setSuspended:suspended];
+        }
+    }
+}
+
+- (void)selectHotkeyValue:(NSString *)value inPopup:(NSPopUpButton *)popup {
+    NSString *normalizedValue = normalizedHotkeyValue(value);
+    if (hotkeyValueUsesCustomPopupItem(normalizedValue)) {
+        ensureCustomHotkeyInPopup(popup, normalizedValue);
+        return;
+    }
+
+    NSMutableArray<NSMenuItem *> *itemsToRemove = [NSMutableArray array];
+    for (NSMenuItem *item in popup.itemArray) {
+        NSString *representedObject = [item.representedObject isKindOfClass:[NSString class]] ? item.representedObject : nil;
+        if (representedObject.length > 0 && ![presetHotkeyValues() containsObject:representedObject]) {
+            [itemsToRemove addObject:item];
+        }
+    }
+    for (NSMenuItem *item in itemsToRemove) {
+        [popup.menu removeItem:item];
+    }
+
+    for (NSMenuItem *item in popup.itemArray) {
+        if ([[item.representedObject description] isEqualToString:normalizedValue]) {
+            [popup selectItem:item];
+            return;
+        }
+    }
+
+    [popup selectItemAtIndex:0];
+}
+
+- (void)triggerHotkeyChanged:(id)sender {
+}
+
+- (void)updateHotkeyRecordingButtons {
+    BOOL recordingTrigger = [self.recordingHotkeyTarget isEqualToString:@"trigger"];
+
+    self.recordTriggerHotkeyButton.enabled = YES;
+    self.resetTriggerHotkeyButton.enabled = !recordingTrigger;
+    [self.recordTriggerHotkeyButton setTitle:(recordingTrigger ? @"Press..." : @"Record")];
+}
+
+- (NSString *)recordedHotkeyValueFromEvent:(NSEvent *)event {
+    NSInteger keyCode = event.keyCode;
+    switch (keyCode) {
+        case 54:
+        case 55:
+        case 56:
+        case 57:
+        case 58:
+        case 59:
+        case 60:
+        case 61:
+        case 62:
+        case 63:
+            return nil;
+        default:
+            break;
+    }
+
+    NSUInteger flags = event.modifierFlags & (NSEventModifierFlagCommand |
+                                              NSEventModifierFlagOption |
+                                              NSEventModifierFlagControl |
+                                              NSEventModifierFlagShift |
+                                              NSEventModifierFlagFunction);
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    if ((flags & NSEventModifierFlagCommand) != 0) [parts addObject:@"command"];
+    if ((flags & NSEventModifierFlagOption) != 0) [parts addObject:@"option"];
+    if ((flags & NSEventModifierFlagControl) != 0) [parts addObject:@"control"];
+    if ((flags & NSEventModifierFlagShift) != 0) [parts addObject:@"shift"];
+    if ((flags & NSEventModifierFlagFunction) != 0) [parts addObject:@"fn"];
+    [parts addObject:[NSString stringWithFormat:@"%ld", (long)keyCode]];
+    return normalizedHotkeyValue([parts componentsJoinedByString:@"+"]);
+}
+
+- (void)endHotkeyRecording {
+    if (self.hotkeyRecordingMonitor) {
+        [NSEvent removeMonitor:self.hotkeyRecordingMonitor];
+        self.hotkeyRecordingMonitor = nil;
+    }
+    self.recordingHotkeyTarget = nil;
+    [self setRuntimeHotkeyMonitoringSuspended:NO];
+    [self updateHotkeyRecordingButtons];
+}
+
+- (void)beginHotkeyRecordingForTarget:(NSString *)target popup:(NSPopUpButton *)popup {
+    [self endHotkeyRecording];
+
+    self.recordingHotkeyTarget = target;
+    [self setRuntimeHotkeyMonitoringSuspended:YES];
+    [self updateHotkeyRecordingButtons];
+
+    __weak typeof(self) weakSelf = self;
+    self.hotkeyRecordingMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:(NSEventMaskKeyDown | NSEventMaskFlagsChanged)
+                                                                        handler:^NSEvent *(NSEvent *event) {
+        if (![weakSelf.recordingHotkeyTarget isEqualToString:target]) {
+            return event;
+        }
+
+        if (event.type == NSEventTypeKeyDown && event.keyCode == 53) {
+            [weakSelf endHotkeyRecording];
+            return nil;
+        }
+
+        if (event.type != NSEventTypeKeyDown || [event isARepeat]) {
+            return nil;
+        }
+
+        NSString *recordedValue = [weakSelf recordedHotkeyValueFromEvent:event];
+        if (recordedValue.length == 0) {
+            return nil;
+        }
+
+        [weakSelf selectHotkeyValue:recordedValue inPopup:popup];
+        [weakSelf endHotkeyRecording];
+        return nil;
+    }];
+}
+
+- (void)recordTriggerHotkey:(id)sender {
+    [self beginHotkeyRecordingForTarget:@"trigger" popup:self.hotkeyPopup];
+}
+
+- (void)resetTriggerHotkey:(id)sender {
+    [self endHotkeyRecording];
+    [self selectHotkeyValue:@"fn" inPopup:self.hotkeyPopup];
+}
+
 - (NSView *)buildDictionaryPane {
     CGFloat paneWidth = 600;
     CGFloat contentHeight = 440;
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+    [self applySettingsPaneBackgroundToView:pane];
+    CGFloat contentX = 24.0;
+    CGFloat contentW = paneWidth - 48.0;
 
-    CGFloat y = contentHeight - 48;
+    CGFloat y = contentHeight - 30.0;
 
     // Description
-    NSTextField *desc = [self descriptionLabel:@"User dictionary \u2014 one term per line. These terms are prioritized during LLM correction. Lines starting with # are comments."];
-    desc.frame = NSMakeRect(24, y - 10, paneWidth - 48, 36);
-    [pane addSubview:desc];
-    y -= 44;
+    NSTextField *desc = [self addSettingsDescriptionText:@"User dictionary \u2014 one term per line. These terms are prioritized during LLM correction. Lines starting with # are comments."
+                                                  toPane:pane
+                                                   topY:y
+                                                      x:contentX
+                                                  width:contentW];
+
+    NSTextField *sectionTitle = [self sectionTitleLabel:@"Dictionary"
+                                                  frame:NSMakeRect(contentX, floor(NSMinY(desc.frame) - 36.0), contentW, 20)];
+    [pane addSubview:sectionTitle];
 
     // Text editor
-    CGFloat editorHeight = y - 56;
-    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(24, 56, paneWidth - 48, editorHeight)];
+    CGFloat editorCardY = 56.0;
+    CGFloat editorTopY = NSMinY(sectionTitle.frame) - 12.0;
+    CGFloat editorHeight = editorTopY - editorCardY;
+    NSView *editorCard = [self surfaceCardViewWithFrame:NSMakeRect(contentX, editorCardY, contentW, editorHeight)];
+    [pane addSubview:editorCard];
+
+    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(12, 12, contentW - 24, editorHeight - 24)];
     scrollView.hasVerticalScroller = YES;
     scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-    scrollView.borderType = NSBezelBorder;
+    scrollView.borderType = NSNoBorder;
+    scrollView.drawsBackground = NO;
+    scrollView.scrollerStyle = NSScrollerStyleOverlay;
 
-    self.dictionaryTextView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth - 54, editorHeight)];
-    self.dictionaryTextView.minSize = NSMakeSize(0, editorHeight);
+    self.dictionaryTextView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, contentW - 24, editorHeight - 24)];
+    self.dictionaryTextView.minSize = NSMakeSize(0, editorHeight - 24);
     self.dictionaryTextView.maxSize = NSMakeSize(FLT_MAX, FLT_MAX);
     self.dictionaryTextView.verticallyResizable = YES;
     self.dictionaryTextView.horizontallyResizable = NO;
     self.dictionaryTextView.autoresizingMask = NSViewWidthSizable;
-    self.dictionaryTextView.textContainer.containerSize = NSMakeSize(paneWidth - 54, FLT_MAX);
+    self.dictionaryTextView.textContainer.containerSize = NSMakeSize(contentW - 24, FLT_MAX);
     self.dictionaryTextView.textContainer.widthTracksTextView = YES;
+    self.dictionaryTextView.textContainerInset = NSMakeSize(8, 10);
     self.dictionaryTextView.font = [NSFont monospacedSystemFontOfSize:12 weight:NSFontWeightRegular];
     self.dictionaryTextView.allowsUndo = YES;
 
     scrollView.documentView = self.dictionaryTextView;
-    [pane addSubview:scrollView];
+    [editorCard addSubview:scrollView];
 
     // Save / Cancel buttons
     [self addButtonsToPane:pane atY:16 width:paneWidth];
@@ -892,35 +1287,51 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     CGFloat paneWidth = 600;
     CGFloat contentHeight = 440;
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+    [self applySettingsPaneBackgroundToView:pane];
+    CGFloat contentX = 24.0;
+    CGFloat contentW = paneWidth - 48.0;
 
-    CGFloat y = contentHeight - 48;
+    CGFloat y = contentHeight - 30.0;
 
     // Description
-    NSTextField *desc = [self descriptionLabel:@"System prompt sent to the LLM for text correction. Edit to customize behavior."];
-    desc.frame = NSMakeRect(24, y - 10, paneWidth - 48, 36);
-    [pane addSubview:desc];
-    y -= 44;
+    NSTextField *desc = [self addSettingsDescriptionText:@"System prompt sent to the LLM for text correction. Edit to customize behavior."
+                                                  toPane:pane
+                                                   topY:y
+                                                      x:contentX
+                                                  width:contentW];
+
+    NSTextField *sectionTitle = [self sectionTitleLabel:@"System Prompt"
+                                                  frame:NSMakeRect(contentX, floor(NSMinY(desc.frame) - 36.0), contentW, 20)];
+    [pane addSubview:sectionTitle];
 
     // Text editor
-    CGFloat editorHeight = y - 56;
-    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(24, 56, paneWidth - 48, editorHeight)];
+    CGFloat editorCardY = 56.0;
+    CGFloat editorTopY = NSMinY(sectionTitle.frame) - 12.0;
+    CGFloat editorHeight = editorTopY - editorCardY;
+    NSView *editorCard = [self surfaceCardViewWithFrame:NSMakeRect(contentX, editorCardY, contentW, editorHeight)];
+    [pane addSubview:editorCard];
+
+    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(12, 12, contentW - 24, editorHeight - 24)];
     scrollView.hasVerticalScroller = YES;
     scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-    scrollView.borderType = NSBezelBorder;
+    scrollView.borderType = NSNoBorder;
+    scrollView.drawsBackground = NO;
+    scrollView.scrollerStyle = NSScrollerStyleOverlay;
 
-    self.systemPromptTextView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth - 54, editorHeight)];
-    self.systemPromptTextView.minSize = NSMakeSize(0, editorHeight);
+    self.systemPromptTextView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, contentW - 24, editorHeight - 24)];
+    self.systemPromptTextView.minSize = NSMakeSize(0, editorHeight - 24);
     self.systemPromptTextView.maxSize = NSMakeSize(FLT_MAX, FLT_MAX);
     self.systemPromptTextView.verticallyResizable = YES;
     self.systemPromptTextView.horizontallyResizable = NO;
     self.systemPromptTextView.autoresizingMask = NSViewWidthSizable;
-    self.systemPromptTextView.textContainer.containerSize = NSMakeSize(paneWidth - 54, FLT_MAX);
+    self.systemPromptTextView.textContainer.containerSize = NSMakeSize(contentW - 24, FLT_MAX);
     self.systemPromptTextView.textContainer.widthTracksTextView = YES;
+    self.systemPromptTextView.textContainerInset = NSMakeSize(8, 10);
     self.systemPromptTextView.font = [NSFont monospacedSystemFontOfSize:12 weight:NSFontWeightRegular];
     self.systemPromptTextView.allowsUndo = YES;
 
     scrollView.documentView = self.systemPromptTextView;
-    [pane addSubview:scrollView];
+    [editorCard addSubview:scrollView];
 
     // Save / Cancel buttons
     [self addButtonsToPane:pane atY:16 width:paneWidth];
@@ -932,80 +1343,160 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 
 - (NSView *)buildTemplatesPane {
     CGFloat paneWidth = 600;
-    CGFloat contentHeight = 480;
+    CGFloat contentHeight = 568;
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+    [self applySettingsPaneBackgroundToView:pane];
 
-    CGFloat y = contentHeight - 48;
+    CGFloat contentX = 24.0;
+    CGFloat contentW = paneWidth - 48.0;
+    CGFloat y = contentHeight - 30.0;
 
-    // Description
-    NSTextField *desc = [self descriptionLabel:@"Add prompt templates to rewrite voice input in different styles (translate, tweet, etc.). After default correction, these appear as buttons above the overlay."];
-    desc.frame = NSMakeRect(24, y - 10, paneWidth - 48, 36);
-    [pane addSubview:desc];
-    y -= 52;
+    NSTextField *desc = [self addSettingsDescriptionText:@"Manage overlay templates. Reorder them, control visibility, and edit each prompt here."
+                                                  toPane:pane
+                                                   topY:y
+                                                      x:contentX
+                                                  width:contentW];
+    y = NSMinY(desc.frame) - 16.0;
 
-    // Template list (left side: table + buttons, right side: prompt editor)
-    CGFloat listW = 200;
-    CGFloat listH = 240;
+    self.templatesEnabledSwitch = [self settingsSwitchWithAction:NULL];
+    NSView *visibilityCard = [self settingsToggleCardWithFrame:NSMakeRect(contentX, y - 48, contentW, 48)
+                                                         title:@"Show template buttons in overlay"
+                                                        toggle:self.templatesEnabledSwitch];
+    [pane addSubview:visibilityCard];
 
-    // Table view in scroll view
-    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(24, y - listH, listW, listH)];
+    CGFloat sectionTitleY = NSMinY(visibilityCard.frame) - 44.0;
+    CGFloat mainCardY = 60.0;
+    CGFloat mainCardH = sectionTitleY - mainCardY - 12.0;
+    CGFloat listW = 214.0;
+    CGFloat cardGap = 16.0;
+    CGFloat editorW = contentW - listW - cardGap;
+    CGFloat editorX = contentX + listW + cardGap;
+
+    NSTextField *listTitle = [self sectionTitleLabel:@"Template Library"
+                                               frame:NSMakeRect(contentX, sectionTitleY, listW, 20)];
+    [pane addSubview:listTitle];
+
+    NSTextField *editorTitle = [self sectionTitleLabel:@"Template Editor"
+                                                 frame:NSMakeRect(editorX, sectionTitleY, editorW, 20)];
+    [pane addSubview:editorTitle];
+
+    NSView *listCard = [self surfaceCardViewWithFrame:NSMakeRect(contentX, mainCardY, listW, mainCardH)];
+    [pane addSubview:listCard];
+
+    NSView *editorCard = [self surfaceCardViewWithFrame:NSMakeRect(editorX, mainCardY, editorW, mainCardH)];
+    [pane addSubview:editorCard];
+
+    CGFloat headerH = 34.0;
+    CGFloat footerH = 34.0;
+
+    NSTextField *libraryCaption = [NSTextField labelWithString:@"Templates"];
+    libraryCaption.font = [NSFont systemFontOfSize:14 weight:NSFontWeightSemibold];
+    libraryCaption.textColor = [NSColor colorWithRed:0.114 green:0.114 blue:0.122 alpha:1.0];
+    libraryCaption.frame = NSMakeRect(14, mainCardH - headerH + 9, 120, 18);
+    [listCard addSubview:libraryCaption];
+
+    NSView *headerSeparator = [[NSView alloc] initWithFrame:NSMakeRect(0, mainCardH - headerH, listW, 1)];
+    headerSeparator.wantsLayer = YES;
+    headerSeparator.layer.backgroundColor = [NSColor colorWithRed:0.898 green:0.898 blue:0.918 alpha:1.0].CGColor;
+    [listCard addSubview:headerSeparator];
+
+    NSView *footerSeparator = [[NSView alloc] initWithFrame:NSMakeRect(0, footerH, listW, 1)];
+    footerSeparator.wantsLayer = YES;
+    footerSeparator.layer.backgroundColor = [NSColor colorWithRed:0.898 green:0.898 blue:0.918 alpha:1.0].CGColor;
+    [listCard addSubview:footerSeparator];
+
+    self.templatePrimaryActionsControl = [self templateActionSegmentedControlWithSymbols:@[@"plus", @"minus"]
+                                                                                toolTips:@[@"Add template", @"Remove selected template"]
+                                                                                  action:@selector(handleTemplatePrimaryActions:)];
+    self.templatePrimaryActionsControl.frame = NSMakeRect(12, 5, 50, 24);
+    [listCard addSubview:self.templatePrimaryActionsControl];
+
+    self.templateReorderActionsControl = [self templateActionSegmentedControlWithSymbols:@[@"arrow.up", @"arrow.down"]
+                                                                                 toolTips:@[@"Move selected template up", @"Move selected template down"]
+                                                                                   action:@selector(handleTemplateReorderActions:)];
+    self.templateReorderActionsControl.frame = NSMakeRect(listW - 12 - 50, 5, 50, 24);
+    [listCard addSubview:self.templateReorderActionsControl];
+
+    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(10, footerH + 10, listW - 20, mainCardH - headerH - footerH - 20)];
     scrollView.hasVerticalScroller = YES;
-    scrollView.borderType = NSBezelBorder;
+    scrollView.autohidesScrollers = YES;
+    scrollView.borderType = NSNoBorder;
+    scrollView.drawsBackground = NO;
+    scrollView.wantsLayer = YES;
+    scrollView.layer.cornerRadius = 8.0;
+    scrollView.layer.borderWidth = 1.0;
+    scrollView.layer.borderColor = [NSColor colorWithRed:0.922 green:0.929 blue:0.945 alpha:1.0].CGColor;
+    scrollView.scrollerStyle = NSScrollerStyleOverlay;
+    [listCard addSubview:scrollView];
 
     self.templatesTableView = [[NSTableView alloc] initWithFrame:scrollView.bounds];
     NSTableColumn *col = [[NSTableColumn alloc] initWithIdentifier:@"name"];
     col.title = @"Template";
-    col.width = listW - 20;
+    col.width = scrollView.bounds.size.width;
+    col.resizingMask = NSTableColumnAutoresizingMask;
     [self.templatesTableView addTableColumn:col];
     self.templatesTableView.headerView = nil;
+    self.templatesTableView.rowHeight = 34.0;
+    self.templatesTableView.intercellSpacing = NSMakeSize(0, 0);
+    self.templatesTableView.backgroundColor = [NSColor clearColor];
+    self.templatesTableView.selectionHighlightStyle = NSTableViewSelectionHighlightStyleRegular;
+    self.templatesTableView.focusRingType = NSFocusRingTypeNone;
+    self.templatesTableView.columnAutoresizingStyle = NSTableViewFirstColumnOnlyAutoresizingStyle;
     self.templatesTableView.delegate = (id)self;
     self.templatesTableView.dataSource = (id)self;
     scrollView.documentView = self.templatesTableView;
-    [pane addSubview:scrollView];
 
-    // Add / Remove buttons
-    CGFloat btnY = y - listH - 30;
-    NSButton *addBtn = [NSButton buttonWithTitle:@"+" target:self action:@selector(addTemplate:)];
-    addBtn.frame = NSMakeRect(24, btnY, 30, 24);
-    addBtn.bezelStyle = NSBezelStyleSmallSquare;
-    [pane addSubview:addBtn];
+    NSTextField *nameLabel = [self sectionTitleLabel:@"Name" frame:NSMakeRect(16, mainCardH - 34, editorW - 32, 18)];
+    [editorCard addSubview:nameLabel];
 
-    NSButton *removeBtn = [NSButton buttonWithTitle:@"−" target:self action:@selector(removeTemplate:)];
-    removeBtn.frame = NSMakeRect(56, btnY, 30, 24);
-    removeBtn.bezelStyle = NSBezelStyleSmallSquare;
-    [pane addSubview:removeBtn];
+    self.templateNameField = [self formTextField:NSMakeRect(16, mainCardH - 64, editorW - 32, 24) placeholder:@"Template name"];
+    self.templateNameField.delegate = self;
+    [editorCard addSubview:self.templateNameField];
 
-    // Right side: prompt editor
-    CGFloat editorX = 24 + listW + 16;
-    CGFloat editorW = paneWidth - editorX - 24;
+    self.templateItemEnabledSwitch = [self settingsSwitchWithAction:@selector(toggleSelectedTemplateEnabled:)
+                                                        controlSize:NSControlSizeSmall];
+    CGFloat templateItemToggleW = self.templateItemEnabledSwitch.frame.size.width;
+    CGFloat templateItemToggleH = self.templateItemEnabledSwitch.frame.size.height;
+    CGFloat templateVisibilityCenterY = mainCardH - 86.0;
 
-    NSTextField *nameLabel = [self formLabel:@"Name" frame:NSMakeRect(editorX, y - 2, 50, 20)];
-    nameLabel.alignment = NSTextAlignmentLeft;
-    [pane addSubview:nameLabel];
+    NSTextField *templateVisibilityLabel = [self settingsRowLabelWithString:@"Visible in overlay"];
+    templateVisibilityLabel.frame = NSMakeRect(16,
+                                               floor(templateVisibilityCenterY - 10.0),
+                                               editorW - templateItemToggleW - 44.0,
+                                               20);
+    [editorCard addSubview:templateVisibilityLabel];
 
-    self.templateNameField = [self formTextField:NSMakeRect(editorX + 55, y - 2, editorW - 55, 24) placeholder:@"Template name"];
-    [pane addSubview:self.templateNameField];
+    self.templateItemEnabledSwitch.frame = NSMakeRect(editorW - 16 - templateItemToggleW,
+                                                      floor(templateVisibilityCenterY - (templateItemToggleH / 2.0)),
+                                                      templateItemToggleW,
+                                                      templateItemToggleH);
+    [editorCard addSubview:self.templateItemEnabledSwitch];
 
-    CGFloat promptY = y - 36;
-    NSTextField *promptLabel = [self formLabel:@"Prompt" frame:NSMakeRect(editorX, promptY, 50, 20)];
-    promptLabel.alignment = NSTextAlignmentLeft;
-    [pane addSubview:promptLabel];
+    NSTextField *promptLabel = [self sectionTitleLabel:@"Prompt" frame:NSMakeRect(16, mainCardH - 124, editorW - 32, 18)];
+    [editorCard addSubview:promptLabel];
 
-    NSScrollView *promptScroll = [[NSScrollView alloc] initWithFrame:NSMakeRect(editorX, promptY - listH + 20, editorW, listH - 20)];
+    NSScrollView *promptScroll = [[NSScrollView alloc] initWithFrame:NSMakeRect(16, 16, editorW - 32, mainCardH - 146)];
     promptScroll.hasVerticalScroller = YES;
-    promptScroll.borderType = NSBezelBorder;
+    promptScroll.borderType = NSNoBorder;
+    promptScroll.drawsBackground = NO;
+    promptScroll.wantsLayer = YES;
+    promptScroll.layer.cornerRadius = 8.0;
+    promptScroll.layer.borderWidth = 1.0;
+    promptScroll.layer.borderColor = [NSColor colorWithRed:0.922 green:0.929 blue:0.945 alpha:1.0].CGColor;
 
-    self.templatePromptTextView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, editorW - 16, listH - 24)];
-    self.templatePromptTextView.minSize = NSMakeSize(0, listH - 24);
+    self.templatePromptTextView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, editorW - 48, mainCardH - 146)];
+    self.templatePromptTextView.minSize = NSMakeSize(0, mainCardH - 146);
     self.templatePromptTextView.maxSize = NSMakeSize(CGFLOAT_MAX, CGFLOAT_MAX);
     self.templatePromptTextView.verticallyResizable = YES;
     self.templatePromptTextView.horizontallyResizable = NO;
-    self.templatePromptTextView.textContainer.containerSize = NSMakeSize(editorW - 16, CGFLOAT_MAX);
+    self.templatePromptTextView.textContainerInset = NSMakeSize(8, 10);
+    self.templatePromptTextView.textContainer.containerSize = NSMakeSize(editorW - 48, CGFLOAT_MAX);
     self.templatePromptTextView.textContainer.widthTracksTextView = YES;
-    self.templatePromptTextView.font = [NSFont systemFontOfSize:12];
+    self.templatePromptTextView.font = [NSFont monospacedSystemFontOfSize:12 weight:NSFontWeightRegular];
     self.templatePromptTextView.allowsUndo = YES;
+    self.templatePromptTextView.delegate = self;
     promptScroll.documentView = self.templatePromptTextView;
-    [pane addSubview:promptScroll];
+    [editorCard addSubview:promptScroll];
 
     // Save / Cancel buttons
     [self addButtonsToPane:pane atY:16 width:paneWidth];
@@ -1025,19 +1516,90 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 - (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row {
     if (tableView != self.templatesTableView) return nil;
 
-    NSTextField *cell = [tableView makeViewWithIdentifier:@"TemplateCell" owner:self];
+    NSTableCellView *cell = [tableView makeViewWithIdentifier:@"TemplateCell" owner:self];
     if (!cell) {
-        cell = [NSTextField labelWithString:@""];
+        cell = [[NSTableCellView alloc] initWithFrame:NSMakeRect(0, 0, tableColumn.width, tableView.rowHeight)];
         cell.identifier = @"TemplateCell";
-        cell.lineBreakMode = NSLineBreakByTruncatingTail;
+        cell.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+
+        NSTextField *titleLabel = [NSTextField labelWithString:@""];
+        titleLabel.identifier = @"TemplateTitleLabel";
+        titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+        titleLabel.alignment = NSTextAlignmentLeft;
+        titleLabel.font = [NSFont systemFontOfSize:13 weight:NSFontWeightMedium];
+        titleLabel.textColor = [NSColor colorWithRed:0.114 green:0.114 blue:0.122 alpha:1.0];
+        titleLabel.autoresizingMask = NSViewWidthSizable;
+        titleLabel.frame = NSMakeRect(12, 7, tableColumn.width - 24, 20);
+        cell.textField = titleLabel;
+        [cell addSubview:titleLabel];
     }
+
     if (row < (NSInteger)self.templatesData.count) {
         NSDictionary *tmpl = self.templatesData[row];
-        NSNumber *shortcut = tmpl[@"shortcut"];
         NSString *name = tmpl[@"name"] ?: @"Untitled";
-        cell.stringValue = [NSString stringWithFormat:@"%@  %@", shortcut, name];
+        BOOL enabled = [self isTemplateEnabled:tmpl];
+
+        NSTextField *titleLabel = nil;
+        for (NSView *subview in cell.subviews) {
+            if ([subview.identifier isEqualToString:@"TemplateTitleLabel"]) {
+                titleLabel = (NSTextField *)subview;
+            }
+        }
+
+        titleLabel.stringValue = name;
+        titleLabel.frame = NSMakeRect(12, 7, tableColumn.width - 24, 20);
+        titleLabel.textColor = enabled ? [NSColor colorWithRed:0.114 green:0.114 blue:0.122 alpha:1.0] : [NSColor secondaryLabelColor];
+        titleLabel.alphaValue = enabled ? 1.0 : 0.6;
     }
     return cell;
+}
+
+- (NSTableRowView *)tableView:(NSTableView *)tableView rowViewForRow:(NSInteger)row {
+    if (tableView != self.templatesTableView) return nil;
+    return [[SPTemplateRowView alloc] initWithFrame:NSMakeRect(0, 0, tableView.bounds.size.width, tableView.rowHeight)];
+}
+
+- (NSString *)resolvedPromptTextForTemplate:(NSDictionary *)templateData {
+    id inlinePrompt = templateData[@"system_prompt"];
+    if ([inlinePrompt isKindOfClass:[NSString class]]) {
+        NSString *inlineText = (NSString *)inlinePrompt;
+        if (inlineText.length > 0) {
+            return inlineText;
+        }
+    }
+
+    id promptPath = templateData[@"system_prompt_path"];
+    if ([promptPath isKindOfClass:[NSString class]] && [promptPath length] > 0) {
+        NSString *path = (NSString *)promptPath;
+        NSString *resolvedPath = path.isAbsolutePath ? path : [configDirPath() stringByAppendingPathComponent:path];
+        NSString *filePrompt = [NSString stringWithContentsOfFile:resolvedPath
+                                                        encoding:NSUTF8StringEncoding
+                                                           error:nil];
+        if ([filePrompt isKindOfClass:[NSString class]]) {
+            return filePrompt;
+        }
+    }
+
+    return @"";
+}
+
+- (NSString *)editablePromptTextForTemplate:(NSMutableDictionary *)templateData {
+    id editablePrompt = templateData[kTemplateEditablePromptKey];
+    if ([editablePrompt isKindOfClass:[NSString class]]) {
+        return editablePrompt ?: @"";
+    }
+
+    NSString *resolvedPrompt = [self resolvedPromptTextForTemplate:templateData];
+    templateData[kTemplateEditablePromptKey] = resolvedPrompt ?: @"";
+    if (![templateData[kTemplateOriginalPromptKey] isKindOfClass:[NSString class]]) {
+        templateData[kTemplateOriginalPromptKey] = resolvedPrompt ?: @"";
+    }
+    return resolvedPrompt ?: @"";
+}
+
+- (BOOL)isTemplateEnabled:(NSDictionary *)templateData {
+    id enabledValue = templateData[@"enabled"];
+    return ![enabledValue isKindOfClass:[NSNumber class]] || [enabledValue boolValue];
 }
 
 // ─── Template List: selection only loads, NEVER saves back automatically ───
@@ -1062,79 +1624,274 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 
     self.selectedTemplateIndex = newRow;
     [self loadEditorFromIndex:newRow];
+    [self updateTemplateActionButtons];
 }
 
 /// Write current editor fields into templatesData[index]. Safe to call with -1.
 - (void)flushEditorToIndex:(NSInteger)index {
     if (index < 0 || index >= (NSInteger)self.templatesData.count) return;
     if (!self.templateNameField) return;
-    self.templatesData[index][@"name"] = self.templateNameField.stringValue ?: @"";
-    self.templatesData[index][@"system_prompt"] = self.templatePromptTextView.string ?: @"";
+    if (!self.templateEditorDirty) return;
+
+    NSMutableDictionary *templateData = self.templatesData[index];
+    NSString *editedPrompt = self.templatePromptTextView.string ?: @"";
+
+    templateData[@"name"] = self.templateNameField.stringValue ?: @"";
+    templateData[kTemplateEditablePromptKey] = editedPrompt;
+
+    NSString *originalPrompt = [templateData[kTemplateOriginalPromptKey] isKindOfClass:[NSString class]]
+        ? templateData[kTemplateOriginalPromptKey]
+        : [self resolvedPromptTextForTemplate:templateData];
+    NSString *inlinePrompt = [templateData[@"system_prompt"] isKindOfClass:[NSString class]]
+        ? templateData[@"system_prompt"]
+        : nil;
+    NSString *promptPath = [templateData[@"system_prompt_path"] isKindOfClass:[NSString class]]
+        ? templateData[@"system_prompt_path"]
+        : nil;
+
+    BOOL preservePromptPath = (inlinePrompt.length == 0
+                               && promptPath.length > 0
+                               && [editedPrompt isEqualToString:(originalPrompt ?: @"")]);
+    if (preservePromptPath) {
+        [templateData removeObjectForKey:@"system_prompt"];
+        return;
+    }
+
+    templateData[@"system_prompt"] = editedPrompt;
+    [templateData removeObjectForKey:@"system_prompt_path"];
+    templateData[kTemplateOriginalPromptKey] = editedPrompt;
+    self.templateEditorDirty = NO;
 }
 
 /// Load templatesData[index] into the editor fields. -1 clears everything.
 - (void)loadEditorFromIndex:(NSInteger)index {
+    BOOL previousSuppress = self.suppressTemplateSync;
+    self.suppressTemplateSync = YES;
+
     if (index >= 0 && index < (NSInteger)self.templatesData.count) {
-        NSDictionary *tmpl = self.templatesData[index];
+        NSMutableDictionary *tmpl = self.templatesData[index];
         self.templateNameField.stringValue = tmpl[@"name"] ?: @"";
-        id val = tmpl[@"system_prompt"];
-        self.templatePromptTextView.string = ([val isKindOfClass:[NSString class]]) ? val : @"";
+        self.templateItemEnabledSwitch.state = [self isTemplateEnabled:tmpl] ? NSControlStateValueOn : NSControlStateValueOff;
+        self.templatePromptTextView.string = [self editablePromptTextForTemplate:tmpl];
         self.templateNameField.enabled = YES;
+        self.templateItemEnabledSwitch.enabled = YES;
         self.templatePromptTextView.editable = YES;
     } else {
         self.templateNameField.stringValue = @"";
+        self.templateItemEnabledSwitch.state = NSControlStateValueOff;
         self.templatePromptTextView.string = @"";
         self.templateNameField.enabled = NO;
+        self.templateItemEnabledSwitch.enabled = NO;
         self.templatePromptTextView.editable = NO;
     }
+
+    self.templateEditorDirty = NO;
+    self.suppressTemplateSync = previousSuppress;
+}
+
+- (void)controlTextDidChange:(NSNotification *)notification {
+    if (self.suppressTemplateSync) return;
+    if (notification.object != self.templateNameField) return;
+    if (self.selectedTemplateIndex < 0 || self.selectedTemplateIndex >= (NSInteger)self.templatesData.count) return;
+
+    self.templateEditorDirty = YES;
+    self.templatesData[self.selectedTemplateIndex][@"name"] = self.templateNameField.stringValue ?: @"";
+
+    NSIndexSet *rows = [NSIndexSet indexSetWithIndex:(NSUInteger)self.selectedTemplateIndex];
+    NSIndexSet *columns = [NSIndexSet indexSetWithIndex:0];
+    [self.templatesTableView reloadDataForRowIndexes:rows columnIndexes:columns];
+}
+
+- (void)textDidChange:(NSNotification *)notification {
+    if (self.suppressTemplateSync) return;
+    if (notification.object != self.templatePromptTextView) return;
+
+    self.templateEditorDirty = YES;
+}
+
+- (void)toggleSelectedTemplateEnabled:(id)sender {
+    if (self.selectedTemplateIndex < 0 || self.selectedTemplateIndex >= (NSInteger)self.templatesData.count) return;
+
+    self.templatesData[self.selectedTemplateIndex][@"enabled"] = @(self.templateItemEnabledSwitch.state == NSControlStateValueOn);
+    NSIndexSet *rows = [NSIndexSet indexSetWithIndex:(NSUInteger)self.selectedTemplateIndex];
+    NSIndexSet *columns = [NSIndexSet indexSetWithIndex:0];
+    [self.templatesTableView reloadDataForRowIndexes:rows columnIndexes:columns];
 }
 
 /// Flush editor, then reload table (used by Save button & tab switch).
 - (void)saveCurrentTemplateEdits {
     [self flushEditorToIndex:self.selectedTemplateIndex];
+    [self reindexTemplateShortcuts];
 }
 
-- (void)addTemplate:(id)sender {
-    // Flush current editor first
-    [self flushEditorToIndex:self.selectedTemplateIndex];
+- (void)updateTemplateActionButtons {
+    BOOL canAdd = self.templatesData.count < 9;
+    BOOL hasSelection = self.templatesTableView.selectedRow >= 0;
+    BOOL canMoveUp = hasSelection && self.templatesTableView.selectedRow > 0;
+    BOOL canMoveDown = hasSelection && self.templatesTableView.selectedRow < (NSInteger)self.templatesData.count - 1;
 
-    NSInteger nextShortcut = (NSInteger)self.templatesData.count + 1;
-    if (nextShortcut > 9) nextShortcut = 9;
-    [self.templatesData addObject:[NSMutableDictionary dictionaryWithDictionary:@{
-        @"name": @"New Template",
-        @"shortcut": @(nextShortcut),
-        @"system_prompt": @"",
-    }]];
+    [self.templatePrimaryActionsControl setEnabled:canAdd forSegment:0];
+    [self.templatePrimaryActionsControl setEnabled:hasSelection forSegment:1];
+    [self.templateReorderActionsControl setEnabled:canMoveUp forSegment:0];
+    [self.templateReorderActionsControl setEnabled:canMoveDown forSegment:1];
+}
 
-    NSInteger newRow = (NSInteger)self.templatesData.count - 1;
-    self.selectedTemplateIndex = newRow;
+- (void)reindexTemplateShortcuts {
+    [self.templatesData enumerateObjectsUsingBlock:^(NSMutableDictionary *templateData, NSUInteger idx, BOOL *stop) {
+        templateData[@"shortcut"] = @((NSInteger)idx + 1);
+        if (![templateData[@"enabled"] isKindOfClass:[NSNumber class]]) {
+            templateData[@"enabled"] = @YES;
+        }
+    }];
+}
+
+- (void)reloadTemplateTableSelectingRow:(NSInteger)row {
+    NSInteger selectedRow = (row >= 0 && row < (NSInteger)self.templatesData.count) ? row : -1;
+    self.selectedTemplateIndex = selectedRow;
 
     self.suppressTemplateSync = YES;
     [self.templatesTableView reloadData];
-    [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:newRow] byExtendingSelection:NO];
+    if (selectedRow >= 0) {
+        [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:(NSUInteger)selectedRow] byExtendingSelection:NO];
+    } else {
+        [self.templatesTableView deselectAll:nil];
+    }
     self.suppressTemplateSync = NO;
 
-    [self loadEditorFromIndex:newRow];
+    [self loadEditorFromIndex:selectedRow];
+    [self updateTemplateActionButtons];
+}
+
+- (NSArray<NSDictionary *> *)serializedTemplatesData {
+    [self reindexTemplateShortcuts];
+    NSMutableArray<NSDictionary *> *serialized = [NSMutableArray arrayWithCapacity:self.templatesData.count];
+
+    for (NSDictionary *templateData in self.templatesData) {
+        NSMutableDictionary *result = [NSMutableDictionary dictionary];
+        result[@"name"] = [templateData[@"name"] isKindOfClass:[NSString class]] ? templateData[@"name"] : @"";
+        result[@"enabled"] = @([self isTemplateEnabled:templateData]);
+        result[@"shortcut"] = [templateData[@"shortcut"] isKindOfClass:[NSNumber class]] ? templateData[@"shortcut"] : @0;
+
+        NSString *systemPrompt = [templateData[@"system_prompt"] isKindOfClass:[NSString class]] ? templateData[@"system_prompt"] : nil;
+        NSString *systemPromptPath = [templateData[@"system_prompt_path"] isKindOfClass:[NSString class]] ? templateData[@"system_prompt_path"] : nil;
+        if (systemPrompt != nil) {
+            result[@"system_prompt"] = systemPrompt;
+        }
+        if (systemPromptPath.length > 0) {
+            result[@"system_prompt_path"] = systemPromptPath;
+        }
+
+        [serialized addObject:result];
+    }
+
+    return serialized;
+}
+
+- (BOOL)validateTemplatesDataWithMessage:(NSString **)message {
+    if (self.templatesData.count > 9) {
+        if (message) *message = @"You can add up to 9 prompt templates.";
+        return NO;
+    }
+
+    NSMutableSet<NSNumber *> *used = [NSMutableSet set];
+    for (NSDictionary *tmpl in self.templatesData) {
+        NSNumber *shortcut = [tmpl[@"shortcut"] isKindOfClass:[NSNumber class]] ? tmpl[@"shortcut"] : nil;
+        NSInteger value = shortcut.integerValue;
+        if (!shortcut || value < 1 || value > 9) {
+            if (message) *message = @"Each prompt template needs a shortcut between 1 and 9.";
+            return NO;
+        }
+        if ([used containsObject:@(value)]) {
+            if (message) *message = @"Each prompt template shortcut must be unique.";
+            return NO;
+        }
+        [used addObject:@(value)];
+    }
+
+    return YES;
+}
+
+- (void)addTemplate:(id)sender {
+    if (self.templatesData.count >= 9) {
+        [self showAlert:@"Template limit reached"
+                   info:@"You can add up to 9 prompt templates because the overlay only supports number keys 1-9."];
+        return;
+    }
+
+    [self flushEditorToIndex:self.selectedTemplateIndex];
+    [self.templatesData addObject:[NSMutableDictionary dictionaryWithDictionary:@{
+        @"name": @"New Template",
+        @"enabled": @YES,
+        @"shortcut": @((NSInteger)self.templatesData.count + 1),
+        @"system_prompt": @"",
+        kTemplateEditablePromptKey: @"",
+        kTemplateOriginalPromptKey: @"",
+    }]];
+
+    NSInteger newRow = (NSInteger)self.templatesData.count - 1;
+    [self reindexTemplateShortcuts];
+    [self reloadTemplateTableSelectingRow:newRow];
+}
+
+- (void)handleTemplatePrimaryActions:(NSSegmentedControl *)sender {
+    NSInteger segment = sender.selectedSegment;
+    if (segment == 0) {
+        [self addTemplate:sender];
+    } else if (segment == 1) {
+        [self removeTemplate:sender];
+    }
+}
+
+- (void)handleTemplateReorderActions:(NSSegmentedControl *)sender {
+    NSInteger segment = sender.selectedSegment;
+    if (segment == 0) {
+        [self moveTemplateUp:sender];
+    } else if (segment == 1) {
+        [self moveTemplateDown:sender];
+    }
 }
 
 - (void)removeTemplate:(id)sender {
     NSInteger row = self.templatesTableView.selectedRow;
     if (row < 0 || row >= (NSInteger)self.templatesData.count) return;
+
+    [self flushEditorToIndex:self.selectedTemplateIndex];
     [self.templatesData removeObjectAtIndex:row];
+    [self reindexTemplateShortcuts];
 
-    self.selectedTemplateIndex = -1;
+    NSInteger nextSelection = MIN(row, (NSInteger)self.templatesData.count - 1);
+    [self reloadTemplateTableSelectingRow:nextSelection];
+}
 
-    self.suppressTemplateSync = YES;
-    [self.templatesTableView reloadData];
-    self.suppressTemplateSync = NO;
+- (void)moveTemplateUp:(id)sender {
+    NSInteger row = self.templatesTableView.selectedRow;
+    if (row <= 0 || row >= (NSInteger)self.templatesData.count) return;
 
-    [self loadEditorFromIndex:-1];
+    [self flushEditorToIndex:self.selectedTemplateIndex];
+    NSMutableDictionary *templateData = self.templatesData[row];
+    [self.templatesData removeObjectAtIndex:row];
+    [self.templatesData insertObject:templateData atIndex:row - 1];
+    [self reindexTemplateShortcuts];
+    [self reloadTemplateTableSelectingRow:row - 1];
+}
+
+- (void)moveTemplateDown:(id)sender {
+    NSInteger row = self.templatesTableView.selectedRow;
+    if (row < 0 || row >= (NSInteger)self.templatesData.count - 1) return;
+
+    [self flushEditorToIndex:self.selectedTemplateIndex];
+    NSMutableDictionary *templateData = self.templatesData[row];
+    [self.templatesData removeObjectAtIndex:row];
+    [self.templatesData insertObject:templateData atIndex:row + 1];
+    [self reindexTemplateShortcuts];
+    [self reloadTemplateTableSelectingRow:row + 1];
 }
 
 - (NSView *)buildAboutPane {
     CGFloat paneWidth = 600;
     CGFloat contentHeight = 300;
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+    [self applySettingsPaneBackgroundToView:pane];
 
     CGFloat y = contentHeight - 48;
 
@@ -1240,6 +1997,141 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     return label;
 }
 
+- (CGFloat)fittingHeightForWrappingLabel:(NSTextField *)label width:(CGFloat)width {
+    NSTextFieldCell *cell = (NSTextFieldCell *)label.cell;
+    NSSize measuredSize = [cell cellSizeForBounds:NSMakeRect(0, 0, width, CGFLOAT_MAX)];
+    return ceil(MAX(18.0, measuredSize.height));
+}
+
+- (NSTextField *)addSettingsDescriptionText:(NSString *)text
+                                     toPane:(NSView *)pane
+                                      topY:(CGFloat)topY
+                                         x:(CGFloat)x
+                                     width:(CGFloat)width {
+    NSTextField *label = [self descriptionLabel:text];
+    CGFloat height = [self fittingHeightForWrappingLabel:label width:width];
+    label.frame = NSMakeRect(x, floor(topY - height), width, height);
+    [pane addSubview:label];
+    return label;
+}
+
+- (NSTextField *)settingsRowLabelWithString:(NSString *)text {
+    NSTextField *label = [NSTextField labelWithString:text];
+    label.font = [NSFont systemFontOfSize:13 weight:NSFontWeightRegular];
+    label.textColor = [NSColor colorWithRed:0.114 green:0.114 blue:0.122 alpha:1.0];
+    label.lineBreakMode = NSLineBreakByTruncatingTail;
+    return label;
+}
+
+- (NSSwitch *)settingsSwitchWithAction:(SEL)action {
+    return [self settingsSwitchWithAction:action controlSize:NSControlSizeRegular];
+}
+
+- (NSSwitch *)settingsSwitchWithAction:(SEL)action controlSize:(NSControlSize)controlSize {
+    NSSwitch *toggle = [[NSSwitch alloc] initWithFrame:NSZeroRect];
+    toggle.controlSize = controlSize;
+    toggle.target = self;
+    toggle.action = action;
+    [toggle sizeToFit];
+    return toggle;
+}
+
+- (void)enumerateSubviewsRecursivelyInView:(NSView *)view usingBlock:(void (^)(NSView *subview))block {
+    for (NSView *subview in view.subviews) {
+        block(subview);
+        [self enumerateSubviewsRecursivelyInView:subview usingBlock:block];
+    }
+}
+
+- (void)setHidden:(BOOL)hidden forViewsMatchingTags:(NSIndexSet *)tags inView:(NSView *)view {
+    [self enumerateSubviewsRecursivelyInView:view usingBlock:^(NSView *subview) {
+        if ([tags containsIndex:(NSUInteger)subview.tag]) {
+            subview.hidden = hidden;
+        }
+    }];
+}
+
+- (void)setHidden:(BOOL)hidden forViewsWithTagInRange:(NSRange)range inView:(NSView *)view {
+    [self enumerateSubviewsRecursivelyInView:view usingBlock:^(NSView *subview) {
+        if (NSLocationInRange((NSUInteger)subview.tag, range)) {
+            subview.hidden = hidden;
+        }
+    }];
+}
+
+- (void)applySettingsPaneBackgroundToView:(NSView *)pane {
+    pane.wantsLayer = YES;
+    pane.layer.backgroundColor = [NSColor colorWithRed:0.961 green:0.961 blue:0.969 alpha:1.0].CGColor;
+}
+
+- (NSTextField *)sectionTitleLabel:(NSString *)title frame:(NSRect)frame {
+    NSTextField *label = [NSTextField labelWithString:title.uppercaseString];
+    label.frame = frame;
+    label.font = [NSFont systemFontOfSize:12 weight:NSFontWeightSemibold];
+    label.textColor = [NSColor colorWithRed:0.525 green:0.525 blue:0.557 alpha:1.0];
+    return label;
+}
+
+- (NSView *)surfaceCardViewWithFrame:(NSRect)frame {
+    NSView *card = [[NSView alloc] initWithFrame:frame];
+    card.wantsLayer = YES;
+    card.layer.backgroundColor = [NSColor whiteColor].CGColor;
+    card.layer.cornerRadius = 12.0;
+    card.layer.borderWidth = 1.0;
+    card.layer.borderColor = [NSColor colorWithRed:0.898 green:0.898 blue:0.918 alpha:1.0].CGColor;
+    return card;
+}
+
+- (NSView *)settingsToggleCardWithFrame:(NSRect)frame title:(NSString *)title toggle:(NSSwitch *)toggle {
+    NSView *card = [self surfaceCardViewWithFrame:frame];
+    CGFloat toggleW = toggle.frame.size.width;
+    CGFloat toggleH = toggle.frame.size.height;
+    if (toggleW <= 0.0 || toggleH <= 0.0) {
+        [toggle sizeToFit];
+        toggleW = toggle.frame.size.width;
+        toggleH = toggle.frame.size.height;
+    }
+
+    NSTextField *label = [self settingsRowLabelWithString:title];
+    label.frame = NSMakeRect(14.0,
+                             floor((frame.size.height - 20.0) / 2.0),
+                             MAX(80.0, frame.size.width - toggleW - 40.0),
+                             20.0);
+    [card addSubview:label];
+
+    toggle.frame = NSMakeRect(frame.size.width - 14.0 - toggleW,
+                              floor((frame.size.height - toggleH) / 2.0),
+                              toggleW,
+                              toggleH);
+    [card addSubview:toggle];
+
+    return card;
+}
+
+- (NSSegmentedControl *)templateActionSegmentedControlWithSymbols:(NSArray<NSString *> *)symbolNames
+                                                         toolTips:(NSArray<NSString *> *)toolTips
+                                                           action:(SEL)action {
+    NSSegmentedControl *control = [[NSSegmentedControl alloc] initWithFrame:NSMakeRect(0, 0, 50, 24)];
+    control.segmentCount = symbolNames.count;
+    control.segmentStyle = NSSegmentStyleTexturedRounded;
+    control.trackingMode = NSSegmentSwitchTrackingMomentary;
+    control.controlSize = NSControlSizeSmall;
+    control.target = self;
+    control.action = action;
+
+    for (NSInteger idx = 0; idx < (NSInteger)symbolNames.count; idx++) {
+        NSString *symbolName = symbolNames[idx];
+        NSString *toolTip = idx < (NSInteger)toolTips.count ? toolTips[idx] : @"";
+        NSImage *image = [NSImage imageWithSystemSymbolName:symbolName accessibilityDescription:toolTip];
+        image.size = NSMakeSize(12, 12);
+        [control setImage:image forSegment:idx];
+        [control setWidth:24 forSegment:idx];
+        [[control cell] setToolTip:toolTip forSegment:idx];
+    }
+
+    return control;
+}
+
 // ─── Card Layout Helpers ───────────────────────────────────────────
 
 - (NSView *)cardWithTitle:(NSString *)title rows:(NSArray<NSView *> *)rows width:(CGFloat)width {
@@ -1260,10 +2152,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
         [container addSubview:titleLabel];
     }
 
-    NSView *card = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, cardHeight)];
-    card.wantsLayer = YES;
-    card.layer.backgroundColor = [NSColor whiteColor].CGColor;
-    card.layer.cornerRadius = 12.0;
+    NSView *card = [self surfaceCardViewWithFrame:NSMakeRect(0, 0, width, cardHeight)];
     [container addSubview:card];
 
     for (NSUInteger i = 0; i < rows.count; i++) {
@@ -1376,33 +2265,27 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     BOOL isModelBasedLocal = !isDoubaoIme && !isDoubao && !isQwen && !isAppleSpeech;
 
     // Show/hide Doubao fields
-    for (NSView *view in self.currentPaneView.subviews) {
-        if (view.tag == 1001 || view.tag == 1002) { // App Key and Access Key labels
-            view.hidden = !isDoubao;
-        }
-    }
+    [self setHidden:!isDoubao
+ forViewsMatchingTags:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1001, 2)]
+             inView:self.currentPaneView];
     self.asrAppKeyField.hidden = !isDoubao;
     self.asrAccessKeyField.hidden = YES; // Always start hidden (secure mode)
     self.asrAccessKeySecureField.hidden = !isDoubao;
     self.asrAccessKeyToggle.hidden = !isDoubao;
 
     // Show/hide Qwen fields
-    for (NSView *view in self.currentPaneView.subviews) {
-        if (view.tag == 1003) { // Qwen API Key label
-            view.hidden = !isQwen;
-        }
-    }
+    [self setHidden:!isQwen
+ forViewsMatchingTags:[NSIndexSet indexSetWithIndex:1003]
+             inView:self.currentPaneView];
     self.asrQwenApiKeyField.hidden = YES; // Always start hidden (secure mode)
     self.asrQwenApiKeySecureField.hidden = !isQwen;
     self.asrQwenApiKeyToggle.hidden = !isQwen;
 
     // Show/hide Apple Speech locale popup and asset status
     self.appleSpeechLocalePopup.hidden = !isAppleSpeech;
-    for (NSView *view in self.currentPaneView.subviews) {
-        if (view.tag == 1005) { // Locale label
-            view.hidden = !isAppleSpeech;
-        }
-    }
+    [self setHidden:!isAppleSpeech
+ forViewsMatchingTags:[NSIndexSet indexSetWithIndex:1005]
+             inView:self.currentPaneView];
 
     // Show/hide local model popup, status, and download button
     self.localModelPopup.hidden = !isModelBasedLocal;
@@ -1428,11 +2311,9 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
         self.modelProgressSizeLabel.hidden = YES;
         [self updateModelStatusLabel];
     }
-    for (NSView *view in self.currentPaneView.subviews) {
-        if (view.tag == 1004) { // Model label
-            view.hidden = !isModelBasedLocal;
-        }
-    }
+    [self setHidden:!isModelBasedLocal
+ forViewsMatchingTags:[NSIndexSet indexSetWithIndex:1004]
+             inView:self.currentPaneView];
     if (isModelBasedLocal) {
         [self populateLocalModelPopup:selectedProvider mode:@"asr"];
         [self updateModelStatusLabel];
@@ -1939,36 +2820,9 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         [self updateLlmFieldsEnabled];
     } else if ([identifier isEqualToString:kToolbarHotkey]) {
         NSString *triggerKeyRaw = configGet(@"hotkey.trigger_key");
-        NSString *cancelKeyRaw = configGet(@"hotkey.cancel_key");
-
         NSString *triggerKey = normalizedHotkeyValue(triggerKeyRaw);
-        NSString *cancelKey = normalizedHotkeyValue(cancelKeyRaw);
 
-        // Reset cancel key to default if it's empty or matches trigger key
-        if (cancelKey.length == 0 || [cancelKey isEqualToString:triggerKey]) {
-            cancelKey = defaultCancelKeyForTrigger(triggerKey);
-        }
-
-        if (isNumericKeycode(triggerKey)) {
-            ensureCustomKeycodeInPopup(self.hotkeyPopup, triggerKey);
-        } else {
-            for (NSInteger i = 0; i < self.hotkeyPopup.numberOfItems; i++) {
-                if ([[self.hotkeyPopup itemAtIndex:i].representedObject isEqualToString:triggerKey]) {
-                    [self.hotkeyPopup selectItemAtIndex:i];
-                    break;
-                }
-            }
-        }
-        if (isNumericKeycode(cancelKey)) {
-            ensureCustomKeycodeInPopup(self.cancelHotkeyPopup, cancelKey);
-        } else {
-            for (NSInteger i = 0; i < self.cancelHotkeyPopup.numberOfItems; i++) {
-                if ([[self.cancelHotkeyPopup itemAtIndex:i].representedObject isEqualToString:cancelKey]) {
-                    [self.cancelHotkeyPopup selectItemAtIndex:i];
-                    break;
-                }
-            }
-        }
+        [self selectHotkeyValue:triggerKey inPopup:self.hotkeyPopup];
 
         // Load trigger mode
         NSString *triggerMode = configGet(@"hotkey.trigger_mode");
@@ -1993,27 +2847,29 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         NSString *promptContent = [NSString stringWithContentsOfFile:promptPath encoding:NSUTF8StringEncoding error:nil] ?: @"";
         [self.systemPromptTextView setString:promptContent];
     } else if ([identifier isEqualToString:kToolbarTemplates]) {
+        NSString *templatesEnabled = configGet(@"llm.prompt_templates_enabled");
+        self.templatesEnabledSwitch.state = [templatesEnabled isEqualToString:@"true"] ? NSControlStateValueOn : NSControlStateValueOff;
+
         NSArray *templates = [self.rustBridge promptTemplates];
         self.templatesData = [NSMutableArray array];
         for (NSDictionary *t in templates) {
-            [self.templatesData addObject:[t mutableCopy]];
+            NSMutableDictionary *templateData = [t mutableCopy] ?: [NSMutableDictionary dictionary];
+            if (![templateData[@"enabled"] isKindOfClass:[NSNumber class]]) {
+                templateData[@"enabled"] = @YES;
+            }
+            NSString *resolvedPrompt = [self resolvedPromptTextForTemplate:templateData];
+            templateData[kTemplateEditablePromptKey] = resolvedPrompt ?: @"";
+            templateData[kTemplateOriginalPromptKey] = resolvedPrompt ?: @"";
+            [self.templatesData addObject:templateData];
         }
-        self.suppressTemplateSync = YES;
-        self.selectedTemplateIndex = -1;
-        [self.templatesTableView reloadData];
-        if (self.templatesData.count > 0) {
-            self.selectedTemplateIndex = 0;
-            [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
-            self.suppressTemplateSync = NO;
-            [self loadEditorFromIndex:0];
-        } else {
-            self.suppressTemplateSync = NO;
-            [self loadEditorFromIndex:-1];
-        }
+        [self reindexTemplateShortcuts];
+        [self reloadTemplateTableSelectingRow:(self.templatesData.count > 0 ? 0 : -1)];
     }
 }
 
 - (void)saveConfig:(id)sender {
+    [self endHotkeyRecording];
+
     // Warn if a local provider is selected but assets/models are not installed
     if (self.asrProviderPopup) {
         NSString *provider = self.asrProviderPopup.selectedItem.representedObject ?: @"doubaoime";
@@ -2118,19 +2974,12 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
     // Update hotkey
     if (self.hotkeyPopup) {
-        NSString *selectedTriggerHotkey = self.hotkeyPopup.selectedItem.representedObject ?: @"fn";
-        NSString *selectedCancelHotkey = self.cancelHotkeyPopup.selectedItem.representedObject ?: defaultCancelKeyForTrigger(selectedTriggerHotkey);
-        if ([selectedTriggerHotkey isEqualToString:selectedCancelHotkey]) {
-            [self showAlert:@"Trigger and Cancel keys must be different"
-                       info:@"Choose two different keys for starting and cancelling voice input."];
-            return;
-        }
+        NSString *selectedTriggerHotkey = normalizedHotkeyValue(self.hotkeyPopup.selectedItem.representedObject ?: @"fn");
         saveOk &= configSet(@"hotkey.trigger_key", selectedTriggerHotkey);
-        saveOk &= configSet(@"hotkey.cancel_key", selectedCancelHotkey);
 
         // Save trigger mode
         NSString *triggerModeValue = [self.triggerModePopup selectedItem].representedObject ?: @"hold";
-        configSet(@"hotkey.trigger_mode", triggerModeValue);
+        saveOk &= configSet(@"hotkey.trigger_mode", triggerModeValue);
     }
     if (self.startSoundCheckbox) {
         NSString *startSound = (self.startSoundCheckbox.state == NSControlStateValueOn) ? @"true" : @"false";
@@ -2140,10 +2989,31 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         saveOk &= configSet(@"feedback.stop_sound", stopSound);
         saveOk &= configSet(@"feedback.error_sound", errorSound);
     }
+    if (self.templatesEnabledSwitch) {
+        NSString *templatesEnabled = (self.templatesEnabledSwitch.state == NSControlStateValueOn) ? @"true" : @"false";
+        saveOk &= configSet(@"llm.prompt_templates_enabled", templatesEnabled);
+    }
 
     if (!saveOk) {
         [self showAlert:@"Some settings failed to save"
                    info:@"Check that ~/.koe/config.yaml is writable and try again."];
+        return;
+    }
+
+    // Save prompt templates
+    if (self.templatesData) {
+        [self saveCurrentTemplateEdits];
+        NSString *templateError = nil;
+        if (![self validateTemplatesDataWithMessage:&templateError]) {
+            [self showAlert:@"Invalid prompt templates"
+                       info:templateError ?: @"Check your templates and try again."];
+            return;
+        }
+        if (![self.rustBridge setPromptTemplates:[self serializedTemplatesData]]) {
+            [self showAlert:@"Failed to save prompt templates"
+                       info:@"Check your prompt templates and ~/.koe/config.yaml, then try again."];
+            return;
+        }
     }
 
     // Write dictionary.txt
@@ -2169,12 +3039,6 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         }
     }
 
-    // Save prompt templates
-    if (self.templatesData) {
-        [self saveCurrentTemplateEdits];
-        [self.rustBridge setPromptTemplates:self.templatesData];
-    }
-
     NSLog(@"[Koe] Settings saved");
 
     // Notify delegate to reload
@@ -2186,6 +3050,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 }
 
 - (void)cancelSetup:(id)sender {
+    [self endHotkeyRecording];
     [self.window close];
 }
 
@@ -2202,11 +3067,9 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     BOOL isMlx = [provider isEqualToString:@"mlx"];
 
     // Toggle OpenAI fields (tag 2001-2006)
-    for (NSView *view in self.currentPaneView.subviews) {
-        if (view.tag >= 2001 && view.tag <= 2006) {
-            view.hidden = !isOpenAI;
-        }
-    }
+    [self setHidden:!isOpenAI
+ forViewsWithTagInRange:NSMakeRange(2001, 6)
+             inView:self.currentPaneView];
     // Eye toggle doesn't use tag for show/hide (tag is used for 0/1 state)
     self.llmApiKeyToggle.hidden = !isOpenAI;
     // Preserve API key visibility state when showing OpenAI fields
@@ -2224,11 +3087,9 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     self.llmTestButton.enabled = enabled;
 
     // Toggle MLX fields (tag 2010-2012)
-    for (NSView *view in self.currentPaneView.subviews) {
-        if (view.tag >= 2010 && view.tag <= 2012) {
-            view.hidden = !isMlx;
-        }
-    }
+    [self setHidden:!isMlx
+ forViewsWithTagInRange:NSMakeRange(2010, 3)
+             inView:self.currentPaneView];
     if (isMlx) {
         self.llmLocalModelPopup.enabled = enabled;
         self.llmModelDownloadButton.enabled = enabled;

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1042,10 +1042,12 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 }
 
 - (void)templateTableClicked:(id)sender {
-    // Save the currently displayed template back to data before switching
+    NSInteger row = self.templatesTableView.selectedRow;
+    if (row == self.selectedTemplateIndex) return; // same row, nothing to do
+
+    // Save edits from current template before switching
     [self syncCurrentTemplateToData];
 
-    NSInteger row = self.templatesTableView.selectedRow;
     self.selectedTemplateIndex = row;
     [self loadTemplateAtIndex:row];
 }
@@ -1054,9 +1056,9 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 - (void)syncCurrentTemplateToData {
     NSInteger idx = self.selectedTemplateIndex;
     if (idx < 0 || idx >= (NSInteger)self.templatesData.count) return;
-    NSMutableDictionary *tmpl = self.templatesData[idx];
-    tmpl[@"name"] = self.templateNameField.stringValue ?: @"";
-    tmpl[@"system_prompt"] = self.templatePromptTextView.string ?: @"";
+    if (!self.templateNameField || !self.templatePromptTextView) return;
+    self.templatesData[idx][@"name"] = self.templateNameField.stringValue ?: @"";
+    self.templatesData[idx][@"system_prompt"] = self.templatePromptTextView.string ?: @"";
 }
 
 - (void)loadTemplateAtIndex:(NSInteger)index {

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -960,8 +960,6 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     self.templatesTableView.headerView = nil;
     self.templatesTableView.delegate = (id)self;
     self.templatesTableView.dataSource = (id)self;
-    self.templatesTableView.target = self;
-    self.templatesTableView.action = @selector(templateTableClicked:);
     scrollView.documentView = self.templatesTableView;
     [pane addSubview:scrollView];
 
@@ -1042,7 +1040,8 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     return cell;
 }
 
-- (void)templateTableClicked:(id)sender {
+- (void)tableViewSelectionDidChange:(NSNotification *)notification {
+    if (notification.object != self.templatesTableView) return;
     if (self.suppressTemplateSync) return;
 
     NSInteger row = self.templatesTableView.selectedRow;

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -191,6 +191,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 // Templates
 @property (nonatomic, strong) NSMutableArray<NSMutableDictionary *> *templatesData;
 @property (nonatomic, strong) NSTableView *templatesTableView;
+@property (nonatomic, strong) NSTextField *templateNameField;
 @property (nonatomic, strong) NSTextView *templatePromptTextView;
 @property (nonatomic, assign) NSInteger selectedTemplateIndex;
 
@@ -288,6 +289,12 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 
 - (void)switchToPane:(NSString *)identifier {
     if ([self.currentPaneIdentifier isEqualToString:identifier]) return;
+
+    // Save template edits before switching away
+    if ([self.currentPaneIdentifier isEqualToString:kToolbarTemplates]) {
+        [self saveCurrentTemplateEdits];
+    }
+
     self.currentPaneIdentifier = identifier;
 
     // Remove old pane
@@ -977,9 +984,8 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     nameLabel.alignment = NSTextAlignmentLeft;
     [pane addSubview:nameLabel];
 
-    NSTextField *nameField = [self formTextField:NSMakeRect(editorX + 55, y - 2, editorW - 55, 24) placeholder:@"Template name"];
-    nameField.tag = 1001;
-    [pane addSubview:nameField];
+    self.templateNameField = [self formTextField:NSMakeRect(editorX + 55, y - 2, editorW - 55, 24) placeholder:@"Template name"];
+    [pane addSubview:self.templateNameField];
 
     CGFloat promptY = y - 36;
     NSTextField *promptLabel = [self formLabel:@"Prompt" frame:NSMakeRect(editorX, promptY, 50, 20)];
@@ -1043,23 +1049,17 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 }
 
 - (void)loadTemplateAtIndex:(NSInteger)index {
-    NSTextField *nameField = [self.templatesTableView.superview.superview viewWithTag:1001];
-    // Find the name field by walking pane subviews
-    NSView *pane = self.templatesTableView.superview.superview.superview;
-    for (NSView *sub in pane.subviews) {
-        if (sub.tag == 1001 && [sub isKindOfClass:[NSTextField class]]) {
-            nameField = (NSTextField *)sub;
-            break;
-        }
-    }
-
     if (index >= 0 && index < (NSInteger)self.templatesData.count) {
         NSDictionary *tmpl = self.templatesData[index];
-        if (nameField) nameField.stringValue = tmpl[@"name"] ?: @"";
+        self.templateNameField.stringValue = tmpl[@"name"] ?: @"";
         self.templatePromptTextView.string = tmpl[@"system_prompt"] ?: @"";
+        self.templateNameField.enabled = YES;
+        self.templatePromptTextView.editable = YES;
     } else {
-        if (nameField) nameField.stringValue = @"";
+        self.templateNameField.stringValue = @"";
         self.templatePromptTextView.string = @"";
+        self.templateNameField.enabled = NO;
+        self.templatePromptTextView.editable = NO;
     }
 }
 
@@ -1067,17 +1067,8 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     NSInteger idx = self.selectedTemplateIndex;
     if (idx < 0 || idx >= (NSInteger)self.templatesData.count) return;
 
-    NSView *pane = self.templatesTableView.superview.superview.superview;
-    NSTextField *nameField = nil;
-    for (NSView *sub in pane.subviews) {
-        if (sub.tag == 1001 && [sub isKindOfClass:[NSTextField class]]) {
-            nameField = (NSTextField *)sub;
-            break;
-        }
-    }
-
     NSMutableDictionary *tmpl = self.templatesData[idx];
-    if (nameField) tmpl[@"name"] = nameField.stringValue;
+    tmpl[@"name"] = self.templateNameField.stringValue ?: @"";
     tmpl[@"system_prompt"] = self.templatePromptTextView.string ?: @"";
     [self.templatesTableView reloadData];
 }

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1042,17 +1042,35 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 }
 
 - (void)templateTableClicked:(id)sender {
-    [self saveCurrentTemplateEdits];
+    // Save the currently displayed template back to data before switching
+    [self syncCurrentTemplateToData];
+
     NSInteger row = self.templatesTableView.selectedRow;
     self.selectedTemplateIndex = row;
     [self loadTemplateAtIndex:row];
 }
 
+/// Write the name/prompt fields back into templatesData for the current selection.
+- (void)syncCurrentTemplateToData {
+    NSInteger idx = self.selectedTemplateIndex;
+    if (idx < 0 || idx >= (NSInteger)self.templatesData.count) return;
+    NSMutableDictionary *tmpl = self.templatesData[idx];
+    tmpl[@"name"] = self.templateNameField.stringValue ?: @"";
+    tmpl[@"system_prompt"] = self.templatePromptTextView.string ?: @"";
+}
+
 - (void)loadTemplateAtIndex:(NSInteger)index {
     if (index >= 0 && index < (NSInteger)self.templatesData.count) {
         NSDictionary *tmpl = self.templatesData[index];
+        NSLog(@"[Koe] Loading template %ld: name=%@ prompt_len=%lu prompt_class=%@",
+              (long)index,
+              tmpl[@"name"],
+              (unsigned long)[tmpl[@"system_prompt"] length],
+              NSStringFromClass([tmpl[@"system_prompt"] class]));
         self.templateNameField.stringValue = tmpl[@"name"] ?: @"";
-        self.templatePromptTextView.string = tmpl[@"system_prompt"] ?: @"";
+        id promptVal = tmpl[@"system_prompt"];
+        NSString *promptStr = ([promptVal isKindOfClass:[NSString class]]) ? promptVal : @"";
+        self.templatePromptTextView.string = promptStr;
         self.templateNameField.enabled = YES;
         self.templatePromptTextView.editable = YES;
     } else {
@@ -1064,12 +1082,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 }
 
 - (void)saveCurrentTemplateEdits {
-    NSInteger idx = self.selectedTemplateIndex;
-    if (idx < 0 || idx >= (NSInteger)self.templatesData.count) return;
-
-    NSMutableDictionary *tmpl = self.templatesData[idx];
-    tmpl[@"name"] = self.templateNameField.stringValue ?: @"";
-    tmpl[@"system_prompt"] = self.templatePromptTextView.string ?: @"";
+    [self syncCurrentTemplateToData];
     [self.templatesTableView reloadData];
 }
 

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -24,6 +24,7 @@ static NSToolbarItemIdentifier const kToolbarLLM = @"llm";
 static NSToolbarItemIdentifier const kToolbarHotkey = @"hotkey";
 static NSToolbarItemIdentifier const kToolbarDictionary = @"dictionary";
 static NSToolbarItemIdentifier const kToolbarSystemPrompt = @"system_prompt";
+static NSToolbarItemIdentifier const kToolbarAbout = @"about";
 
 // ─── Config helpers (backed by sp_config_get / sp_config_set) ───────
 #import "koe_core.h"
@@ -174,9 +175,11 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 // Hotkey
 @property (nonatomic, strong) NSPopUpButton *hotkeyPopup;
 @property (nonatomic, strong) NSPopUpButton *cancelHotkeyPopup;
-@property (nonatomic, strong) NSButton *startSoundCheckbox;
-@property (nonatomic, strong) NSButton *stopSoundCheckbox;
-@property (nonatomic, strong) NSButton *errorSoundCheckbox;
+// Trigger mode
+@property (nonatomic, strong) NSPopUpButton *triggerModePopup;
+@property (nonatomic, strong) NSSwitch *startSoundCheckbox;
+@property (nonatomic, strong) NSSwitch *stopSoundCheckbox;
+@property (nonatomic, strong) NSSwitch *errorSoundCheckbox;
 
 // Dictionary
 @property (nonatomic, strong) NSTextView *dictionaryTextView;
@@ -228,15 +231,15 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 }
 
 - (NSArray<NSToolbarItemIdentifier> *)toolbarAllowedItemIdentifiers:(NSToolbar *)toolbar {
-    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt];
+    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarAbout];
 }
 
 - (NSArray<NSToolbarItemIdentifier> *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar {
-    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt];
+    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarAbout];
 }
 
 - (NSArray<NSToolbarItemIdentifier> *)toolbarSelectableItemIdentifiers:(NSToolbar *)toolbar {
-    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt];
+    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarAbout];
 }
 
 - (NSToolbarItem *)toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSToolbarItemIdentifier)itemIdentifier willBeInsertedIntoToolbar:(BOOL)flag {
@@ -259,6 +262,9 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     } else if ([itemIdentifier isEqualToString:kToolbarSystemPrompt]) {
         item.label = @"Prompt";
         item.image = [NSImage imageWithSystemSymbolName:@"text.bubble" accessibilityDescription:@"System Prompt"];
+    } else if ([itemIdentifier isEqualToString:kToolbarAbout]) {
+        item.label = @"About";
+        item.image = [NSImage imageWithSystemSymbolName:@"info.circle" accessibilityDescription:@"About"];
     }
 
     return item;
@@ -289,6 +295,8 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
         paneView = [self buildDictionaryPane];
     } else if ([identifier isEqualToString:kToolbarSystemPrompt]) {
         paneView = [self buildSystemPromptPane];
+    } else if ([identifier isEqualToString:kToolbarAbout]) {
+        paneView = [self buildAboutPane];
     }
 
     if (!paneView) return;
@@ -722,25 +730,12 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 
 - (NSView *)buildHotkeyPane {
     CGFloat paneWidth = 600;
-    CGFloat labelW = 130;
-    CGFloat fieldX = labelW + 24;
-    CGFloat rowH = 32;
+    CGFloat cardWidth = paneWidth - 48;
+    CGFloat cardSpacing = 16.0;
+    CGFloat topPad = 24.0;
 
-    CGFloat contentHeight = 360;
-    NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
-
-    CGFloat y = contentHeight - 48;
-
-    // Description
-    NSTextField *desc = [self descriptionLabel:@"Choose a trigger key for voice input and a separate cancel key to abort the current session."];
-    desc.frame = NSMakeRect(24, y - 10, paneWidth - 48, 36);
-    [pane addSubview:desc];
-    y -= 52;
-
-    // Trigger Key
-    [pane addSubview:[self formLabel:@"Trigger Key" frame:NSMakeRect(16, y, labelW, 22)]];
-
-    self.hotkeyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, 220, 26) pullsDown:NO];
+    // ── Trigger Key ──
+    self.hotkeyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
     [self.hotkeyPopup addItemsWithTitles:@[
         @"Fn (Globe)",
         @"Left Option (\u2325)",
@@ -757,13 +752,18 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     [self.hotkeyPopup itemAtIndex:4].representedObject = @"right_command";
     [self.hotkeyPopup itemAtIndex:5].representedObject = @"left_control";
     [self.hotkeyPopup itemAtIndex:6].representedObject = @"right_control";
-    [pane addSubview:self.hotkeyPopup];
-    y -= rowH + 16;
 
-    // Cancel Key
-    [pane addSubview:[self formLabel:@"Cancel Key" frame:NSMakeRect(16, y, labelW, 22)]];
+    // ── Trigger Mode ──
+    self.triggerModePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
+    [self.triggerModePopup addItemsWithTitles:@[
+        @"Hold (Press & Hold)",
+        @"Toggle (Tap to Start/Stop)",
+    ]];
+    [self.triggerModePopup itemAtIndex:0].representedObject = @"hold";
+    [self.triggerModePopup itemAtIndex:1].representedObject = @"toggle";
 
-    self.cancelHotkeyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, 220, 26) pullsDown:NO];
+    // ── Cancel Key ──
+    self.cancelHotkeyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
     [self.cancelHotkeyPopup addItemsWithTitles:@[
         @"Fn (Globe)",
         @"Left Option (\u2325)",
@@ -780,45 +780,50 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     [self.cancelHotkeyPopup itemAtIndex:4].representedObject = @"right_command";
     [self.cancelHotkeyPopup itemAtIndex:5].representedObject = @"left_control";
     [self.cancelHotkeyPopup itemAtIndex:6].representedObject = @"right_control";
-    [pane addSubview:self.cancelHotkeyPopup];
-    y -= rowH + 8;
 
-    NSTextField *hotkeyHint = [self descriptionLabel:@"Trigger Key and Cancel Key must be different."];
-    hotkeyHint.frame = NSMakeRect(fieldX, y + 2, paneWidth - fieldX - 32, 24);
-    [pane addSubview:hotkeyHint];
-    y -= 30;
+    // ── Trigger card ──
+    NSView *triggerCard = [self cardWithTitle:@"Trigger" rows:@[
+        [self cardRowWithLabel:@"Trigger Key" control:self.hotkeyPopup],
+        [self cardRowWithLabel:@"Trigger Mode" control:self.triggerModePopup],
+        [self cardRowWithLabel:@"Cancel Key" control:self.cancelHotkeyPopup],
+    ] width:cardWidth];
 
-    // Feedback sounds
-    [pane addSubview:[self formLabel:@"Feedback Sounds" frame:NSMakeRect(16, y, labelW, 22)]];
+    // ── Feedback Sounds ──
+    self.startSoundCheckbox = [[NSSwitch alloc] initWithFrame:NSMakeRect(0, 0, 38, 22)];
+    self.stopSoundCheckbox = [[NSSwitch alloc] initWithFrame:NSMakeRect(0, 0, 38, 22)];
+    self.errorSoundCheckbox = [[NSSwitch alloc] initWithFrame:NSMakeRect(0, 0, 38, 22)];
 
-    self.startSoundCheckbox = [NSButton checkboxWithTitle:@"Play a sound when recording starts"
-                                                   target:nil
-                                                   action:nil];
-    self.startSoundCheckbox.frame = NSMakeRect(fieldX, y - 4, 300, 22);
-    [pane addSubview:self.startSoundCheckbox];
-    y -= 28;
+    NSView *feedbackCard = [self cardWithTitle:@"Feedback Sounds" rows:@[
+        [self cardRowWithLabel:@"Recording starts" control:self.startSoundCheckbox],
+        [self cardRowWithLabel:@"Recording stops" control:self.stopSoundCheckbox],
+        [self cardRowWithLabel:@"Error occurs" control:self.errorSoundCheckbox],
+    ] width:cardWidth];
 
-    self.stopSoundCheckbox = [NSButton checkboxWithTitle:@"Play a sound when recording stops"
-                                                  target:nil
-                                                  action:nil];
-    self.stopSoundCheckbox.frame = NSMakeRect(fieldX, y - 4, 300, 22);
-    [pane addSubview:self.stopSoundCheckbox];
-    y -= 28;
+    // ── Layout ──
+    CGFloat triggerH = triggerCard.frame.size.height;
+    CGFloat feedbackH = feedbackCard.frame.size.height;
+    CGFloat contentHeight = topPad + triggerH + cardSpacing + feedbackH + 56;
 
-    self.errorSoundCheckbox = [NSButton checkboxWithTitle:@"Play a sound when an error occurs"
-                                                   target:nil
-                                                   action:nil];
-    self.errorSoundCheckbox.frame = NSMakeRect(fieldX, y - 4, 300, 22);
-    [pane addSubview:self.errorSoundCheckbox];
-    y -= 32;
+    NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+    pane.wantsLayer = YES;
+    pane.layer.backgroundColor = [NSColor colorWithRed:0.961 green:0.961 blue:0.969 alpha:1.0].CGColor;
 
-    NSTextField *feedbackHint = [self descriptionLabel:@"These toggle the built-in cue sounds for start, stop, and error events."];
-    feedbackHint.frame = NSMakeRect(fieldX, y - 2, paneWidth - fieldX - 32, 24);
-    [pane addSubview:feedbackHint];
-    y -= 34;
+    CGFloat y = contentHeight - topPad;
 
-    // Save / Cancel buttons
-    [self addButtonsToPane:pane atY:y width:paneWidth];
+    y -= triggerH;
+    triggerCard.frame = NSMakeRect(24, y, cardWidth, triggerH);
+    [pane addSubview:triggerCard];
+    // Fix control positions — the card's child (index 1) is the white card view
+    NSView *triggerCardBody = triggerCard.subviews.count > 1 ? triggerCard.subviews[1] : triggerCard.subviews[0];
+    [self layoutCardRowControls:triggerCardBody width:cardWidth];
+
+    y -= cardSpacing + feedbackH;
+    feedbackCard.frame = NSMakeRect(24, y, cardWidth, feedbackH);
+    [pane addSubview:feedbackCard];
+    NSView *feedbackCardBody = feedbackCard.subviews.count > 1 ? feedbackCard.subviews[1] : feedbackCard.subviews[0];
+    [self layoutCardRowControls:feedbackCardBody width:cardWidth];
+
+    [self addButtonsToPane:pane atY:16 width:paneWidth];
 
     return pane;
 }
@@ -903,6 +908,72 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     return pane;
 }
 
+- (NSView *)buildAboutPane {
+    CGFloat paneWidth = 600;
+    CGFloat contentHeight = 300;
+    NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+
+    CGFloat y = contentHeight - 48;
+
+    // App name
+    NSTextField *appName = [NSTextField labelWithString:@"Koe (\u58f0)"];
+    appName.font = [NSFont systemFontOfSize:28 weight:NSFontWeightBold];
+    appName.alignment = NSTextAlignmentCenter;
+    appName.frame = NSMakeRect(24, y - 4, paneWidth - 48, 36);
+    [pane addSubview:appName];
+    y -= 44;
+
+    // Version
+    NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"dev";
+    NSString *build = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"] ?: @"0";
+    NSTextField *versionLabel = [self descriptionLabel:[NSString stringWithFormat:@"Version %@ (%@)", version, build]];
+    versionLabel.alignment = NSTextAlignmentCenter;
+    versionLabel.frame = NSMakeRect(24, y, paneWidth - 48, 20);
+    [pane addSubview:versionLabel];
+    y -= 32;
+
+    // Description
+    NSTextField *desc = [self descriptionLabel:@"A background-first macOS voice input tool.\nPress a hotkey, speak, and the corrected text is pasted into whatever app you\u2019re using."];
+    desc.alignment = NSTextAlignmentCenter;
+    desc.frame = NSMakeRect(60, y - 10, paneWidth - 120, 40);
+    [pane addSubview:desc];
+    y -= 60;
+
+    // GitHub button
+    NSButton *githubButton = [NSButton buttonWithTitle:@"GitHub Repository" target:self action:@selector(openGitHub:)];
+    githubButton.bezelStyle = NSBezelStyleRounded;
+    githubButton.image = [NSImage imageWithSystemSymbolName:@"arrow.up.right" accessibilityDescription:nil];
+    githubButton.imagePosition = NSImageTrailing;
+    githubButton.frame = NSMakeRect((paneWidth - 180) / 2.0, y, 180, 32);
+    [pane addSubview:githubButton];
+    y -= 40;
+
+    // Documentation link
+    NSButton *docsButton = [NSButton buttonWithTitle:@"Documentation" target:self action:@selector(openDocs:)];
+    docsButton.bezelStyle = NSBezelStyleRounded;
+    docsButton.image = [NSImage imageWithSystemSymbolName:@"arrow.up.right" accessibilityDescription:nil];
+    docsButton.imagePosition = NSImageTrailing;
+    docsButton.frame = NSMakeRect((paneWidth - 180) / 2.0, y, 180, 32);
+    [pane addSubview:docsButton];
+    y -= 48;
+
+    // License
+    NSTextField *license = [self descriptionLabel:@"MIT License \u00b7 Made with Rust + Objective-C"];
+    license.alignment = NSTextAlignmentCenter;
+    license.frame = NSMakeRect(24, y, paneWidth - 48, 20);
+    [pane addSubview:license];
+
+    return pane;
+}
+
+- (void)openGitHub:(id)sender {
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://github.com/missuo/koe"]];
+}
+
+- (void)openDocs:(id)sender {
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://github.com/missuo/koe/blob/main/README.md"]];
+}
+
 // ─── Shared button bar ──────────────────────────────────────────────
 
 - (void)addButtonsToPane:(NSView *)pane atY:(CGFloat)y width:(CGFloat)paneWidth {
@@ -944,6 +1015,85 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     label.font = [NSFont systemFontOfSize:12];
     label.textColor = [NSColor secondaryLabelColor];
     return label;
+}
+
+// ─── Card Layout Helpers ───────────────────────────────────────────
+
+- (NSView *)cardWithTitle:(NSString *)title rows:(NSArray<NSView *> *)rows width:(CGFloat)width {
+    CGFloat rowHeight = 44.0;
+    CGFloat cardPad = 16.0;
+
+    CGFloat cardHeight = rows.count * rowHeight;
+    CGFloat titleHeight = title.length > 0 ? 28.0 : 0.0;
+    CGFloat totalHeight = titleHeight + cardHeight;
+
+    NSView *container = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, totalHeight)];
+
+    if (title.length > 0) {
+        NSTextField *titleLabel = [NSTextField labelWithString:title.uppercaseString];
+        titleLabel.font = [NSFont systemFontOfSize:12 weight:NSFontWeightSemibold];
+        titleLabel.textColor = [NSColor colorWithRed:0.525 green:0.525 blue:0.557 alpha:1.0];
+        titleLabel.frame = NSMakeRect(cardPad, cardHeight, width - 2 * cardPad, 20);
+        [container addSubview:titleLabel];
+    }
+
+    NSView *card = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, cardHeight)];
+    card.wantsLayer = YES;
+    card.layer.backgroundColor = [NSColor whiteColor].CGColor;
+    card.layer.cornerRadius = 12.0;
+    [container addSubview:card];
+
+    for (NSUInteger i = 0; i < rows.count; i++) {
+        NSView *row = rows[i];
+        CGFloat rowY = cardHeight - (i + 1) * rowHeight;
+        row.frame = NSMakeRect(0, rowY, width, rowHeight);
+        [card addSubview:row];
+
+        if (i < rows.count - 1) {
+            NSView *sep = [[NSView alloc] initWithFrame:NSMakeRect(cardPad, rowY, width - cardPad, 1)];
+            sep.wantsLayer = YES;
+            sep.layer.backgroundColor = [NSColor colorWithRed:0.898 green:0.898 blue:0.918 alpha:1.0].CGColor;
+            [card addSubview:sep];
+        }
+    }
+
+    return container;
+}
+
+- (NSView *)cardRowWithLabel:(NSString *)label control:(NSView *)control {
+    CGFloat rowHeight = 44.0;
+    CGFloat pad = 16.0;
+    NSView *row = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 100, rowHeight)];
+
+    NSTextField *lbl = [NSTextField labelWithString:label];
+    lbl.font = [NSFont systemFontOfSize:13 weight:NSFontWeightRegular];
+    lbl.textColor = [NSColor colorWithRed:0.114 green:0.114 blue:0.122 alpha:1.0];
+    lbl.frame = NSMakeRect(pad, (rowHeight - 20) / 2.0, 200, 20);
+    [row addSubview:lbl];
+
+    CGFloat controlW = control.frame.size.width;
+    CGFloat controlH = control.frame.size.height;
+    // Will be repositioned when parent sets the row's frame width
+    control.frame = NSMakeRect(0, (rowHeight - controlH) / 2.0, controlW, controlH);
+    control.autoresizingMask = NSViewMinXMargin;
+    [row addSubview:control];
+
+    return row;
+}
+
+- (void)layoutCardRowControls:(NSView *)card width:(CGFloat)width {
+    CGFloat pad = 16.0;
+    for (NSView *row in card.subviews) {
+        for (NSView *sub in row.subviews) {
+            if (sub.autoresizingMask & NSViewMinXMargin) {
+                CGFloat controlW = sub.frame.size.width;
+                CGFloat controlH = sub.frame.size.height;
+                sub.frame = NSMakeRect(width - pad - controlW,
+                                       (row.frame.size.height - controlH) / 2.0,
+                                       controlW, controlH);
+            }
+        }
+    }
 }
 
 - (NSButton *)eyeButtonWithFrame:(NSRect)frame action:(SEL)action {
@@ -1597,6 +1747,14 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
             }
         }
 
+        // Load trigger mode
+        NSString *triggerMode = configGet(@"hotkey.trigger_mode");
+        if ([triggerMode isEqualToString:@"toggle"]) {
+            [self.triggerModePopup selectItemAtIndex:1];
+        } else {
+            [self.triggerModePopup selectItemAtIndex:0];
+        }
+
         NSString *startSound = configGet(@"feedback.start_sound");
         NSString *stopSound = configGet(@"feedback.stop_sound");
         NSString *errorSound = configGet(@"feedback.error_sound");
@@ -1728,6 +1886,10 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         }
         saveOk &= configSet(@"hotkey.trigger_key", selectedTriggerHotkey);
         saveOk &= configSet(@"hotkey.cancel_key", selectedCancelHotkey);
+
+        // Save trigger mode
+        NSString *triggerModeValue = [self.triggerModePopup selectedItem].representedObject ?: @"hold";
+        configSet(@"hotkey.trigger_mode", triggerModeValue);
     }
     if (self.startSoundCheckbox) {
         NSString *startSound = (self.startSoundCheckbox.state == NSControlStateValueOn) ? @"true" : @"false";

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -194,6 +194,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 @property (nonatomic, strong) NSTextField *templateNameField;
 @property (nonatomic, strong) NSTextView *templatePromptTextView;
 @property (nonatomic, assign) NSInteger selectedTemplateIndex;
+@property (nonatomic, assign) BOOL suppressTemplateSync;
 
 @end
 
@@ -1042,8 +1043,10 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 }
 
 - (void)templateTableClicked:(id)sender {
+    if (self.suppressTemplateSync) return;
+
     NSInteger row = self.templatesTableView.selectedRow;
-    if (row == self.selectedTemplateIndex) return; // same row, nothing to do
+    if (row == self.selectedTemplateIndex) return;
 
     // Save edits from current template before switching
     [self syncCurrentTemplateToData];
@@ -1059,6 +1062,17 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     if (!self.templateNameField || !self.templatePromptTextView) return;
     self.templatesData[idx][@"name"] = self.templateNameField.stringValue ?: @"";
     self.templatesData[idx][@"system_prompt"] = self.templatePromptTextView.string ?: @"";
+}
+
+/// Reload table without triggering sync callbacks.
+- (void)reloadTemplatesTablePreservingSelection {
+    self.suppressTemplateSync = YES;
+    [self.templatesTableView reloadData];
+    if (self.selectedTemplateIndex >= 0 && self.selectedTemplateIndex < (NSInteger)self.templatesData.count) {
+        [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:self.selectedTemplateIndex]
+                             byExtendingSelection:NO];
+    }
+    self.suppressTemplateSync = NO;
 }
 
 - (void)loadTemplateAtIndex:(NSInteger)index {
@@ -1085,11 +1099,11 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 
 - (void)saveCurrentTemplateEdits {
     [self syncCurrentTemplateToData];
-    [self.templatesTableView reloadData];
+    [self reloadTemplatesTablePreservingSelection];
 }
 
 - (void)addTemplate:(id)sender {
-    [self saveCurrentTemplateEdits];
+    [self syncCurrentTemplateToData];
     NSInteger nextShortcut = (NSInteger)self.templatesData.count + 1;
     if (nextShortcut > 9) nextShortcut = 9;
     NSMutableDictionary *newTemplate = [NSMutableDictionary dictionaryWithDictionary:@{
@@ -1098,10 +1112,12 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
         @"system_prompt": @"",
     }];
     [self.templatesData addObject:newTemplate];
-    [self.templatesTableView reloadData];
     NSInteger newRow = (NSInteger)self.templatesData.count - 1;
-    [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:newRow] byExtendingSelection:NO];
     self.selectedTemplateIndex = newRow;
+    self.suppressTemplateSync = YES;
+    [self.templatesTableView reloadData];
+    [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:newRow] byExtendingSelection:NO];
+    self.suppressTemplateSync = NO;
     [self loadTemplateAtIndex:newRow];
 }
 
@@ -1109,8 +1125,10 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     NSInteger row = self.templatesTableView.selectedRow;
     if (row < 0 || row >= (NSInteger)self.templatesData.count) return;
     [self.templatesData removeObjectAtIndex:row];
-    [self.templatesTableView reloadData];
     self.selectedTemplateIndex = -1;
+    self.suppressTemplateSync = YES;
+    [self.templatesTableView reloadData];
+    self.suppressTemplateSync = NO;
     [self loadTemplateAtIndex:-1];
 }
 
@@ -1981,13 +1999,16 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         for (NSDictionary *t in templates) {
             [self.templatesData addObject:[t mutableCopy]];
         }
+        self.suppressTemplateSync = YES;
         self.selectedTemplateIndex = -1;
         [self.templatesTableView reloadData];
         if (self.templatesData.count > 0) {
-            [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
             self.selectedTemplateIndex = 0;
+            [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+            self.suppressTemplateSync = NO;
             [self loadTemplateAtIndex:0];
         } else {
+            self.suppressTemplateSync = NO;
             [self loadTemplateAtIndex:-1];
         }
     }

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1040,52 +1040,45 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     return cell;
 }
 
+// ─── Template List: selection only loads, NEVER saves back automatically ───
+//
+// Design: templatesData is the source of truth. The editor fields are just
+// a view into one entry. We sync editor→data ONLY on explicit actions:
+// (1) user clicks Save button  (2) user clicks + to add  (3) switching tabs
+//
+// tableViewSelectionDidChange just loads the new row into the editor.
+// It first writes back the editor content for the OLD row, which is safe
+// because selectedTemplateIndex still points to the old row at that moment.
+
 - (void)tableViewSelectionDidChange:(NSNotification *)notification {
     if (notification.object != self.templatesTableView) return;
     if (self.suppressTemplateSync) return;
 
-    NSInteger row = self.templatesTableView.selectedRow;
-    if (row == self.selectedTemplateIndex) return;
+    NSInteger newRow = self.templatesTableView.selectedRow;
+    if (newRow == self.selectedTemplateIndex) return;
 
-    // Save edits from current template before switching
-    [self syncCurrentTemplateToData];
+    // Write editor content back to the OLD row before loading the new one
+    [self flushEditorToIndex:self.selectedTemplateIndex];
 
-    self.selectedTemplateIndex = row;
-    [self loadTemplateAtIndex:row];
+    self.selectedTemplateIndex = newRow;
+    [self loadEditorFromIndex:newRow];
 }
 
-/// Write the name/prompt fields back into templatesData for the current selection.
-- (void)syncCurrentTemplateToData {
-    NSInteger idx = self.selectedTemplateIndex;
-    if (idx < 0 || idx >= (NSInteger)self.templatesData.count) return;
-    if (!self.templateNameField || !self.templatePromptTextView) return;
-    self.templatesData[idx][@"name"] = self.templateNameField.stringValue ?: @"";
-    self.templatesData[idx][@"system_prompt"] = self.templatePromptTextView.string ?: @"";
+/// Write current editor fields into templatesData[index]. Safe to call with -1.
+- (void)flushEditorToIndex:(NSInteger)index {
+    if (index < 0 || index >= (NSInteger)self.templatesData.count) return;
+    if (!self.templateNameField) return;
+    self.templatesData[index][@"name"] = self.templateNameField.stringValue ?: @"";
+    self.templatesData[index][@"system_prompt"] = self.templatePromptTextView.string ?: @"";
 }
 
-/// Reload table without triggering sync callbacks.
-- (void)reloadTemplatesTablePreservingSelection {
-    self.suppressTemplateSync = YES;
-    [self.templatesTableView reloadData];
-    if (self.selectedTemplateIndex >= 0 && self.selectedTemplateIndex < (NSInteger)self.templatesData.count) {
-        [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:self.selectedTemplateIndex]
-                             byExtendingSelection:NO];
-    }
-    self.suppressTemplateSync = NO;
-}
-
-- (void)loadTemplateAtIndex:(NSInteger)index {
+/// Load templatesData[index] into the editor fields. -1 clears everything.
+- (void)loadEditorFromIndex:(NSInteger)index {
     if (index >= 0 && index < (NSInteger)self.templatesData.count) {
         NSDictionary *tmpl = self.templatesData[index];
-        NSLog(@"[Koe] Loading template %ld: name=%@ prompt_len=%lu prompt_class=%@",
-              (long)index,
-              tmpl[@"name"],
-              (unsigned long)[tmpl[@"system_prompt"] length],
-              NSStringFromClass([tmpl[@"system_prompt"] class]));
         self.templateNameField.stringValue = tmpl[@"name"] ?: @"";
-        id promptVal = tmpl[@"system_prompt"];
-        NSString *promptStr = ([promptVal isKindOfClass:[NSString class]]) ? promptVal : @"";
-        self.templatePromptTextView.string = promptStr;
+        id val = tmpl[@"system_prompt"];
+        self.templatePromptTextView.string = ([val isKindOfClass:[NSString class]]) ? val : @"";
         self.templateNameField.enabled = YES;
         self.templatePromptTextView.editable = YES;
     } else {
@@ -1096,39 +1089,46 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     }
 }
 
+/// Flush editor, then reload table (used by Save button & tab switch).
 - (void)saveCurrentTemplateEdits {
-    [self syncCurrentTemplateToData];
-    [self reloadTemplatesTablePreservingSelection];
+    [self flushEditorToIndex:self.selectedTemplateIndex];
 }
 
 - (void)addTemplate:(id)sender {
-    [self syncCurrentTemplateToData];
+    // Flush current editor first
+    [self flushEditorToIndex:self.selectedTemplateIndex];
+
     NSInteger nextShortcut = (NSInteger)self.templatesData.count + 1;
     if (nextShortcut > 9) nextShortcut = 9;
-    NSMutableDictionary *newTemplate = [NSMutableDictionary dictionaryWithDictionary:@{
+    [self.templatesData addObject:[NSMutableDictionary dictionaryWithDictionary:@{
         @"name": @"New Template",
         @"shortcut": @(nextShortcut),
         @"system_prompt": @"",
-    }];
-    [self.templatesData addObject:newTemplate];
+    }]];
+
     NSInteger newRow = (NSInteger)self.templatesData.count - 1;
     self.selectedTemplateIndex = newRow;
+
     self.suppressTemplateSync = YES;
     [self.templatesTableView reloadData];
     [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:newRow] byExtendingSelection:NO];
     self.suppressTemplateSync = NO;
-    [self loadTemplateAtIndex:newRow];
+
+    [self loadEditorFromIndex:newRow];
 }
 
 - (void)removeTemplate:(id)sender {
     NSInteger row = self.templatesTableView.selectedRow;
     if (row < 0 || row >= (NSInteger)self.templatesData.count) return;
     [self.templatesData removeObjectAtIndex:row];
+
     self.selectedTemplateIndex = -1;
+
     self.suppressTemplateSync = YES;
     [self.templatesTableView reloadData];
     self.suppressTemplateSync = NO;
-    [self loadTemplateAtIndex:-1];
+
+    [self loadEditorFromIndex:-1];
 }
 
 - (NSView *)buildAboutPane {
@@ -2005,10 +2005,10 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
             self.selectedTemplateIndex = 0;
             [self.templatesTableView selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
             self.suppressTemplateSync = NO;
-            [self loadTemplateAtIndex:0];
+            [self loadEditorFromIndex:0];
         } else {
             self.suppressTemplateSync = NO;
-            [self loadTemplateAtIndex:-1];
+            [self loadEditorFromIndex:-1];
         }
     }
 }

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1,4 +1,5 @@
 #import "SPSetupWizardWindowController.h"
+#import "SPOverlayPanel.h"
 #import "SPRustBridge.h"
 #import <Cocoa/Cocoa.h>
 #import <Carbon/Carbon.h>
@@ -20,10 +21,23 @@ static NSString *const kDictionaryFile = @"dictionary.txt";
 static NSString *const kSystemPromptFile = @"system_prompt.txt";
 static NSString *const kTemplateEditablePromptKey = @"__editable_prompt";
 static NSString *const kTemplateOriginalPromptKey = @"__original_prompt";
+static NSString *const kOverlayFontFamilyDefault = @"system";
+static NSString *const kOverlayFontFamilySystemLabel = @"System Default";
+static const NSInteger kOverlayFontSizeDefault = 13;
+static const NSInteger kOverlayFontSizeMin = 12;
+static const NSInteger kOverlayFontSizeMax = 28;
+static const NSInteger kOverlayBottomMarginDefault = 10;
+static const NSInteger kOverlayBottomMarginMax = 180;
+static const BOOL kOverlayLimitVisibleLinesDefault = YES;
+static const NSInteger kOverlayMaxVisibleLinesDefault = 3;
+static const NSInteger kOverlayMaxVisibleLinesMin = 3;
+static const NSInteger kOverlayMaxVisibleLinesMax = 5;
+static NSString *const kOverlayPreviewSampleText = @"今天下午三点我们先开评审会，然后把设计方案、PR 评论和接口联调一起过一遍；如果我这段话持续很久，也希望底部实时字幕保持稳定，不要遮住文字边缘，同时完整保留整段转写内容。";
 
 // Toolbar item identifiers
 static NSToolbarItemIdentifier const kToolbarASR = @"asr";
 static NSToolbarItemIdentifier const kToolbarLLM = @"llm";
+static NSToolbarItemIdentifier const kToolbarOverlay = @"overlay";
 static NSToolbarItemIdentifier const kToolbarHotkey = @"hotkey";
 static NSToolbarItemIdentifier const kToolbarDictionary = @"dictionary";
 static NSToolbarItemIdentifier const kToolbarSystemPrompt = @"system_prompt";
@@ -48,6 +62,84 @@ static NSString *configGet(NSString *keyPath) {
 
 static BOOL configSet(NSString *keyPath, NSString *value) {
     return sp_config_set(keyPath.UTF8String, (value ?: @"").UTF8String) == 0;
+}
+
+static NSInteger clampedOverlayFontSizeValue(NSInteger value) {
+    return MAX(kOverlayFontSizeMin, MIN(kOverlayFontSizeMax, value));
+}
+
+static NSInteger clampedOverlayBottomMarginValue(NSInteger value) {
+    return MAX(0, MIN(kOverlayBottomMarginMax, value));
+}
+
+static NSInteger clampedOverlayMaxVisibleLinesValue(NSInteger value) {
+    return MAX(kOverlayMaxVisibleLinesMin, MIN(kOverlayMaxVisibleLinesMax, value));
+}
+
+static BOOL overlayLimitVisibleLinesEnabledValue(NSString *value) {
+    NSString *normalized = [[[value ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString] copy];
+    if (normalized.length == 0) {
+        return kOverlayLimitVisibleLinesDefault;
+    }
+
+    if ([normalized isEqualToString:@"1"] ||
+        [normalized isEqualToString:@"true"] ||
+        [normalized isEqualToString:@"yes"] ||
+        [normalized isEqualToString:@"on"]) {
+        return YES;
+    }
+
+    if ([normalized isEqualToString:@"0"] ||
+        [normalized isEqualToString:@"false"] ||
+        [normalized isEqualToString:@"no"] ||
+        [normalized isEqualToString:@"off"]) {
+        return NO;
+    }
+
+    return kOverlayLimitVisibleLinesDefault;
+}
+
+static NSString *normalizedOverlayFontFamilyValue(NSString *value) {
+    NSString *normalized = [[value ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+    if (normalized.length == 0) {
+        return kOverlayFontFamilyDefault;
+    }
+    return normalized;
+}
+
+static BOOL overlayUsesSystemFontFamily(NSString *value) {
+    return [normalizedOverlayFontFamilyValue(value) caseInsensitiveCompare:kOverlayFontFamilyDefault] == NSOrderedSame;
+}
+
+static NSFont *overlayFontForFamily(NSString *fontFamily, CGFloat fontSize) {
+    CGFloat clampedFontSize = clampedOverlayFontSizeValue(lround(fontSize));
+    NSString *normalized = normalizedOverlayFontFamilyValue(fontFamily);
+
+    if (overlayUsesSystemFontFamily(normalized)) {
+        return [NSFont systemFontOfSize:clampedFontSize weight:NSFontWeightMedium];
+    }
+
+    NSFont *font = [NSFont fontWithName:normalized size:clampedFontSize];
+    if (font) {
+        return font;
+    }
+
+    NSFontManager *fontManager = [NSFontManager sharedFontManager];
+    font = [fontManager fontWithFamily:normalized traits:0 weight:5 size:clampedFontSize];
+    if (font) {
+        return font;
+    }
+
+    for (NSArray *member in [fontManager availableMembersOfFontFamily:normalized]) {
+        if (member.count == 0) continue;
+        NSString *memberName = member[0];
+        font = [NSFont fontWithName:memberName size:clampedFontSize];
+        if (font) {
+            return font;
+        }
+    }
+
+    return [NSFont systemFontOfSize:clampedFontSize weight:NSFontWeightMedium];
 }
 
 static BOOL isNumericKeycode(NSString *value) {
@@ -309,7 +401,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 
 // ─── Window Controller ──────────────────────────────────────────────
 
-@interface SPSetupWizardWindowController () <NSToolbarDelegate, NSTableViewDelegate, NSTableViewDataSource, NSTextFieldDelegate, NSTextViewDelegate>
+@interface SPSetupWizardWindowController () <NSToolbarDelegate, NSTableViewDelegate, NSTableViewDataSource, NSTextFieldDelegate, NSTextViewDelegate, NSWindowDelegate>
 
 // Current pane
 @property (nonatomic, copy) NSString *currentPaneIdentifier;
@@ -375,6 +467,16 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 @property (nonatomic, strong) NSSwitch *stopSoundCheckbox;
 @property (nonatomic, strong) NSSwitch *errorSoundCheckbox;
 
+// Overlay
+@property (nonatomic, strong) NSPopUpButton *overlayFontFamilyPopup;
+@property (nonatomic, copy) NSArray<NSString *> *overlayAvailableFontFamilies;
+@property (nonatomic, strong) NSSlider *overlayFontSizeSlider;
+@property (nonatomic, strong) NSTextField *overlayFontSizeValueLabel;
+@property (nonatomic, strong) NSSlider *overlayBottomMarginSlider;
+@property (nonatomic, strong) NSTextField *overlayBottomMarginValueLabel;
+@property (nonatomic, strong) NSSwitch *overlayLimitVisibleLinesSwitch;
+@property (nonatomic, strong) NSPopUpButton *overlayMaxVisibleLinesPopup;
+
 // Dictionary
 @property (nonatomic, strong) NSTextView *dictionaryTextView;
 
@@ -412,6 +514,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     self = [super initWithWindow:window];
     if (self) {
         _verifyQueue = dispatch_queue_create("koe.model.verify", DISPATCH_QUEUE_SERIAL);
+        window.delegate = self;
         [self setupToolbar];
     }
     return self;
@@ -427,6 +530,11 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     [NSApp activateIgnoringOtherApps:YES];
 }
 
+- (void)windowWillClose:(NSNotification *)notification {
+    [self endHotkeyRecording];
+    [self hideRuntimeOverlayPreview];
+}
+
 // ─── Toolbar ────────────────────────────────────────────────────────
 
 - (void)setupToolbar {
@@ -438,15 +546,15 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 }
 
 - (NSArray<NSToolbarItemIdentifier> *)toolbarAllowedItemIdentifiers:(NSToolbar *)toolbar {
-    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarTemplates, kToolbarAbout];
+    return @[kToolbarASR, kToolbarLLM, kToolbarOverlay, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarTemplates, kToolbarAbout];
 }
 
 - (NSArray<NSToolbarItemIdentifier> *)toolbarDefaultItemIdentifiers:(NSToolbar *)toolbar {
-    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarTemplates, kToolbarAbout];
+    return @[kToolbarASR, kToolbarLLM, kToolbarOverlay, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarTemplates, kToolbarAbout];
 }
 
 - (NSArray<NSToolbarItemIdentifier> *)toolbarSelectableItemIdentifiers:(NSToolbar *)toolbar {
-    return @[kToolbarASR, kToolbarLLM, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarTemplates, kToolbarAbout];
+    return @[kToolbarASR, kToolbarLLM, kToolbarOverlay, kToolbarHotkey, kToolbarDictionary, kToolbarSystemPrompt, kToolbarTemplates, kToolbarAbout];
 }
 
 - (NSToolbarItem *)toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSToolbarItemIdentifier)itemIdentifier willBeInsertedIntoToolbar:(BOOL)flag {
@@ -460,6 +568,9 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     } else if ([itemIdentifier isEqualToString:kToolbarLLM]) {
         item.label = @"LLM";
         item.image = [NSImage imageWithSystemSymbolName:@"cpu" accessibilityDescription:@"LLM"];
+    } else if ([itemIdentifier isEqualToString:kToolbarOverlay]) {
+        item.label = @"Overlay";
+        item.image = [NSImage imageWithSystemSymbolName:@"captions.bubble" accessibilityDescription:@"Overlay"];
     } else if ([itemIdentifier isEqualToString:kToolbarHotkey]) {
         item.label = @"Controls";
         item.image = [NSImage imageWithSystemSymbolName:@"slider.horizontal.3" accessibilityDescription:@"Controls"];
@@ -492,6 +603,8 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     // Save template edits before switching away
     if ([self.currentPaneIdentifier isEqualToString:kToolbarTemplates]) {
         [self saveCurrentTemplateEdits];
+    } else if ([self.currentPaneIdentifier isEqualToString:kToolbarOverlay]) {
+        [self hideRuntimeOverlayPreview];
     }
     [self endHotkeyRecording];
 
@@ -506,6 +619,8 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
         paneView = [self buildAsrPane];
     } else if ([identifier isEqualToString:kToolbarLLM]) {
         paneView = [self buildLlmPane];
+    } else if ([identifier isEqualToString:kToolbarOverlay]) {
+        paneView = [self buildOverlayPane];
     } else if ([identifier isEqualToString:kToolbarHotkey]) {
         paneView = [self buildHotkeyPane];
     } else if ([identifier isEqualToString:kToolbarDictionary]) {
@@ -968,6 +1083,145 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     return pane;
 }
 
+- (NSView *)buildOverlayPane {
+    CGFloat paneWidth = 600.0;
+    CGFloat contentX = 24.0;
+    CGFloat contentW = paneWidth - 48.0;
+    NSString *descriptionText = @"Adjust the bottom live transcript overlay. Choose a system font, tune text size, set the bottom distance, and decide whether long live text stays capped to a few lines or expands fully. Every change is previewed directly in the real desktop overlay position.";
+
+    self.overlayFontFamilyPopup = [self overlayFontFamilyPopupControl];
+
+    self.overlayFontSizeSlider = [self overlaySliderWithMin:kOverlayFontSizeMin
+                                                        max:kOverlayFontSizeMax
+                                                     action:@selector(overlayControlChanged:)];
+    self.overlayFontSizeValueLabel = [self overlayValueLabel];
+    NSView *fontSliderControl = [self sliderControlWithSlider:self.overlayFontSizeSlider
+                                                   valueLabel:self.overlayFontSizeValueLabel
+                                                        width:290.0];
+
+    self.overlayBottomMarginSlider = [self overlaySliderWithMin:0
+                                                            max:kOverlayBottomMarginMax
+                                                         action:@selector(overlayControlChanged:)];
+    self.overlayBottomMarginValueLabel = [self overlayValueLabel];
+    NSView *bottomSliderControl = [self sliderControlWithSlider:self.overlayBottomMarginSlider
+                                                     valueLabel:self.overlayBottomMarginValueLabel
+                                                          width:290.0];
+
+    self.overlayLimitVisibleLinesSwitch = [self settingsSwitchWithAction:@selector(overlayControlChanged:)];
+    self.overlayMaxVisibleLinesPopup = [self overlayMaxVisibleLinesPopupControl];
+
+    NSButton *resetButton = [NSButton buttonWithTitle:@"Reset to Default"
+                                               target:self
+                                               action:@selector(resetOverlaySettings:)];
+    resetButton.bezelStyle = NSBezelStyleRounded;
+    resetButton.frame = NSMakeRect(0, 0, 126.0, 28.0);
+
+    NSView *controlsCard = [self cardWithTitle:@"Overlay"
+                                          rows:@[
+        [self cardRowWithLabel:@"Font" control:self.overlayFontFamilyPopup],
+        [self cardRowWithLabel:@"Text Size" control:fontSliderControl],
+        [self cardRowWithLabel:@"Distance from Bottom" control:bottomSliderControl],
+        [self cardRowWithLabel:@"Limit Visible Lines" control:self.overlayLimitVisibleLinesSwitch],
+        [self cardRowWithLabel:@"Max Visible Lines" control:self.overlayMaxVisibleLinesPopup],
+        [self cardRowWithLabel:@"Defaults" control:resetButton],
+    ]
+                                         width:contentW];
+    CGFloat descriptionHeight = [self fittingHeightForWrappingLabel:[self descriptionLabel:descriptionText] width:contentW];
+    CGFloat paneHeight = 30.0 + descriptionHeight + 18.0 + 20.0 + 12.0 + controlsCard.frame.size.height + 60.0;
+
+    NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, paneHeight)];
+    [self applySettingsPaneBackgroundToView:pane];
+
+    CGFloat y = paneHeight - 30.0;
+    NSTextField *desc = [self addSettingsDescriptionText:descriptionText
+                                                  toPane:pane
+                                                   topY:y
+                                                      x:contentX
+                                                  width:contentW];
+    y = NSMinY(desc.frame) - 18.0;
+
+    CGFloat controlsTitleY = y - 20.0;
+    NSTextField *controlsTitle = [self sectionTitleLabel:@"Style Controls"
+                                                   frame:NSMakeRect(contentX, controlsTitleY, contentW, 20.0)];
+    [pane addSubview:controlsTitle];
+    controlsCard.frame = NSMakeRect(contentX,
+                                    NSMinY(controlsTitle.frame) - 12.0 - controlsCard.frame.size.height,
+                                    contentW,
+                                    controlsCard.frame.size.height);
+    [pane addSubview:controlsCard];
+    NSView *controlsCardBody = controlsCard.subviews.count > 1 ? controlsCard.subviews[1] : controlsCard.subviews[0];
+    [self layoutCardRowControls:controlsCardBody width:contentW];
+    [self updateOverlayLineLimitControlsEnabled];
+
+    [self addButtonsToPane:pane atY:16 width:paneWidth];
+
+    return pane;
+}
+
+- (void)updateOverlayControlValueLabels {
+    self.overlayFontSizeValueLabel.stringValue = [NSString stringWithFormat:@"%ld pt", (long)clampedOverlayFontSizeValue(lround(self.overlayFontSizeSlider.doubleValue))];
+    self.overlayBottomMarginValueLabel.stringValue = [NSString stringWithFormat:@"%ld pt", (long)clampedOverlayBottomMarginValue(lround(self.overlayBottomMarginSlider.doubleValue))];
+}
+
+- (SPOverlayPanel *)runtimeOverlayPanel {
+    id appDelegate = NSApp.delegate;
+    if (!appDelegate) {
+        return nil;
+    }
+
+    id overlayPanel = nil;
+    @try {
+        overlayPanel = [appDelegate valueForKey:@"overlayPanel"];
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+
+    if (![overlayPanel isKindOfClass:[SPOverlayPanel class]]) {
+        return nil;
+    }
+    return (SPOverlayPanel *)overlayPanel;
+}
+
+- (void)showRuntimeOverlayPreview {
+    SPOverlayPanel *overlayPanel = [self runtimeOverlayPanel];
+    if (!overlayPanel) return;
+
+    NSInteger fontSize = clampedOverlayFontSizeValue(lround(self.overlayFontSizeSlider.doubleValue));
+    NSInteger bottomMargin = clampedOverlayBottomMarginValue(lround(self.overlayBottomMarginSlider.doubleValue));
+    NSString *fontFamily = [self selectedOverlayFontFamilyValue];
+    BOOL limitVisibleLines = self.overlayLimitVisibleLinesSwitch.state == NSControlStateValueOn;
+    NSInteger maxVisibleLines = [self selectedOverlayMaxVisibleLinesValue];
+    [overlayPanel showPreviewWithText:kOverlayPreviewSampleText
+                             fontSize:(CGFloat)fontSize
+                           fontFamily:fontFamily
+                         bottomMargin:(CGFloat)bottomMargin
+                    limitVisibleLines:limitVisibleLines
+                      maxVisibleLines:maxVisibleLines];
+}
+
+- (void)hideRuntimeOverlayPreview {
+    [[self runtimeOverlayPanel] hidePreview];
+}
+
+- (void)syncOverlayPreviewFromControls {
+    [self updateOverlayLineLimitControlsEnabled];
+    [self updateOverlayControlValueLabels];
+    [self showRuntimeOverlayPreview];
+}
+
+- (void)overlayControlChanged:(id)sender {
+    [self syncOverlayPreviewFromControls];
+}
+
+- (void)resetOverlaySettings:(id)sender {
+    [self selectOverlayFontFamilyValue:kOverlayFontFamilyDefault];
+    self.overlayFontSizeSlider.integerValue = kOverlayFontSizeDefault;
+    self.overlayBottomMarginSlider.integerValue = kOverlayBottomMarginDefault;
+    self.overlayLimitVisibleLinesSwitch.state = kOverlayLimitVisibleLinesDefault ? NSControlStateValueOn : NSControlStateValueOff;
+    [self selectOverlayMaxVisibleLinesValue:kOverlayMaxVisibleLinesDefault];
+    [self syncOverlayPreviewFromControls];
+}
+
 - (NSView *)buildHotkeyPane {
     CGFloat paneWidth = 600;
     CGFloat cardWidth = paneWidth - 48;
@@ -1094,11 +1348,17 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 
 - (void)setRuntimeHotkeyMonitoringSuspended:(BOOL)suspended {
     id appDelegate = NSApp.delegate;
-    if ([appDelegate respondsToSelector:@selector(hotkeyMonitor)]) {
-        id monitor = [appDelegate valueForKey:@"hotkeyMonitor"];
-        if ([monitor respondsToSelector:@selector(setSuspended:)]) {
-            [monitor setSuspended:suspended];
-        }
+    if (!appDelegate) return;
+
+    id monitor = nil;
+    @try {
+        monitor = [appDelegate valueForKey:@"hotkeyMonitor"];
+    } @catch (__unused NSException *exception) {
+        return;
+    }
+
+    if ([monitor respondsToSelector:@selector(setSuspended:)]) {
+        [monitor setSuspended:suspended];
     }
 }
 
@@ -1990,6 +2250,154 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     return field;
 }
 
+- (NSSlider *)overlaySliderWithMin:(double)minValue max:(double)maxValue action:(SEL)action {
+    NSSlider *slider = [[NSSlider alloc] initWithFrame:NSMakeRect(0, 0, 228, 24)];
+    slider.minValue = minValue;
+    slider.maxValue = maxValue;
+    slider.numberOfTickMarks = 0;
+    slider.continuous = YES;
+    slider.target = self;
+    slider.action = action;
+    return slider;
+}
+
+- (NSTextField *)overlayValueLabel {
+    NSTextField *label = [NSTextField labelWithString:@""];
+    label.alignment = NSTextAlignmentRight;
+    label.font = [NSFont monospacedDigitSystemFontOfSize:12 weight:NSFontWeightMedium];
+    label.textColor = [NSColor secondaryLabelColor];
+    label.frame = NSMakeRect(0, 0, 54, 18);
+    return label;
+}
+
+- (NSArray<NSString *> *)availableOverlayFontFamilies {
+    if (self.overlayAvailableFontFamilies.count > 0) {
+        return self.overlayAvailableFontFamilies;
+    }
+
+    NSMutableOrderedSet<NSString *> *families = [NSMutableOrderedSet orderedSet];
+    for (NSString *family in [[NSFontManager sharedFontManager] availableFontFamilies]) {
+        NSString *normalized = normalizedOverlayFontFamilyValue(family);
+        if (!overlayUsesSystemFontFamily(normalized)) {
+            [families addObject:normalized];
+        }
+    }
+
+    NSArray<NSString *> *sortedFamilies = [[families array] sortedArrayUsingComparator:^NSComparisonResult(NSString *lhs, NSString *rhs) {
+        return [lhs localizedStandardCompare:rhs];
+    }];
+    self.overlayAvailableFontFamilies = sortedFamilies;
+    return sortedFamilies;
+}
+
+- (NSAttributedString *)overlayFontMenuTitleWithLabel:(NSString *)label value:(NSString *)value {
+    NSFont *font = overlayFontForFamily(value, 13.0);
+    return [[NSAttributedString alloc] initWithString:label
+                                           attributes:@{
+        NSFontAttributeName: font,
+        NSForegroundColorAttributeName: [NSColor labelColor],
+    }];
+}
+
+- (NSPopUpButton *)overlayFontFamilyPopupControl {
+    NSPopUpButton *popup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 290, 26) pullsDown:NO];
+    popup.target = self;
+    popup.action = @selector(overlayControlChanged:);
+
+    [popup removeAllItems];
+
+    NSMenuItem *systemItem = [[NSMenuItem alloc] initWithTitle:kOverlayFontFamilySystemLabel action:nil keyEquivalent:@""];
+    systemItem.representedObject = kOverlayFontFamilyDefault;
+    systemItem.attributedTitle = [self overlayFontMenuTitleWithLabel:kOverlayFontFamilySystemLabel value:kOverlayFontFamilyDefault];
+    [popup.menu addItem:systemItem];
+
+    for (NSString *family in [self availableOverlayFontFamilies]) {
+        NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:family action:nil keyEquivalent:@""];
+        item.representedObject = family;
+        item.attributedTitle = [self overlayFontMenuTitleWithLabel:family value:family];
+        [popup.menu addItem:item];
+    }
+
+    return popup;
+}
+
+- (NSPopUpButton *)overlayMaxVisibleLinesPopupControl {
+    NSPopUpButton *popup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 118.0, 28.0) pullsDown:NO];
+    popup.target = self;
+    popup.action = @selector(overlayControlChanged:);
+
+    for (NSInteger value = kOverlayMaxVisibleLinesMin; value <= kOverlayMaxVisibleLinesMax; value++) {
+        NSString *title = [NSString stringWithFormat:@"%ld lines", (long)value];
+        [popup addItemWithTitle:title];
+        popup.lastItem.representedObject = @(value);
+    }
+
+    [popup selectItemAtIndex:0];
+    return popup;
+}
+
+- (NSString *)selectedOverlayFontFamilyValue {
+    NSString *selectedValue = self.overlayFontFamilyPopup.selectedItem.representedObject;
+    return normalizedOverlayFontFamilyValue(selectedValue);
+}
+
+- (NSInteger)selectedOverlayMaxVisibleLinesValue {
+    NSNumber *selectedValue = [self.overlayMaxVisibleLinesPopup.selectedItem.representedObject isKindOfClass:[NSNumber class]]
+        ? self.overlayMaxVisibleLinesPopup.selectedItem.representedObject
+        : nil;
+    return clampedOverlayMaxVisibleLinesValue(selectedValue.integerValue > 0 ? selectedValue.integerValue : kOverlayMaxVisibleLinesDefault);
+}
+
+- (void)selectOverlayFontFamilyValue:(NSString *)value {
+    NSString *normalized = normalizedOverlayFontFamilyValue(value);
+
+    for (NSMenuItem *item in self.overlayFontFamilyPopup.itemArray) {
+        NSString *representedValue = item.representedObject;
+        if (representedValue.length == 0) continue;
+        if ([representedValue isEqualToString:normalized]) {
+            [self.overlayFontFamilyPopup selectItem:item];
+            return;
+        }
+    }
+
+    [self.overlayFontFamilyPopup selectItemAtIndex:0];
+}
+
+- (void)selectOverlayMaxVisibleLinesValue:(NSInteger)value {
+    NSInteger clampedValue = clampedOverlayMaxVisibleLinesValue(value);
+    for (NSMenuItem *item in self.overlayMaxVisibleLinesPopup.itemArray) {
+        NSNumber *representedValue = [item.representedObject isKindOfClass:[NSNumber class]] ? item.representedObject : nil;
+        if (representedValue.integerValue == clampedValue) {
+            [self.overlayMaxVisibleLinesPopup selectItem:item];
+            return;
+        }
+    }
+
+    [self.overlayMaxVisibleLinesPopup selectItemAtIndex:0];
+}
+
+- (void)updateOverlayLineLimitControlsEnabled {
+    self.overlayMaxVisibleLinesPopup.enabled = self.overlayLimitVisibleLinesSwitch.state == NSControlStateValueOn;
+}
+
+- (NSView *)sliderControlWithSlider:(NSSlider *)slider valueLabel:(NSTextField *)valueLabel width:(CGFloat)width {
+    CGFloat spacing = 10.0;
+    CGFloat height = MAX(slider.frame.size.height, valueLabel.frame.size.height);
+    NSView *container = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, height)];
+
+    slider.frame = NSMakeRect(0,
+                              floor((height - slider.frame.size.height) / 2.0),
+                              width - valueLabel.frame.size.width - spacing,
+                              slider.frame.size.height);
+    valueLabel.frame = NSMakeRect(CGRectGetMaxX(slider.frame) + spacing,
+                                  floor((height - valueLabel.frame.size.height) / 2.0),
+                                  valueLabel.frame.size.width,
+                                  valueLabel.frame.size.height);
+    [container addSubview:slider];
+    [container addSubview:valueLabel];
+    return container;
+}
+
 - (NSTextField *)descriptionLabel:(NSString *)text {
     NSTextField *label = [NSTextField wrappingLabelWithString:text];
     label.font = [NSFont systemFontOfSize:12];
@@ -2818,6 +3226,24 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
         self.llmTestResultLabel.stringValue = @"";
         [self updateLlmFieldsEnabled];
+    } else if ([identifier isEqualToString:kToolbarOverlay]) {
+        NSString *fontFamilyRaw = configGet(@"overlay.font_family");
+        NSString *fontSizeRaw = configGet(@"overlay.font_size");
+        NSString *bottomMarginRaw = configGet(@"overlay.bottom_margin");
+        NSString *limitVisibleLinesRaw = configGet(@"overlay.limit_visible_lines");
+        NSString *maxVisibleLinesRaw = configGet(@"overlay.max_visible_lines");
+        NSString *fontFamily = fontFamilyRaw.length > 0 ? normalizedOverlayFontFamilyValue(fontFamilyRaw) : kOverlayFontFamilyDefault;
+        NSInteger fontSize = fontSizeRaw.length > 0 ? clampedOverlayFontSizeValue(fontSizeRaw.integerValue) : kOverlayFontSizeDefault;
+        NSInteger bottomMargin = bottomMarginRaw.length > 0 ? clampedOverlayBottomMarginValue(bottomMarginRaw.integerValue) : kOverlayBottomMarginDefault;
+        BOOL limitVisibleLines = overlayLimitVisibleLinesEnabledValue(limitVisibleLinesRaw);
+        NSInteger maxVisibleLines = maxVisibleLinesRaw.length > 0 ? clampedOverlayMaxVisibleLinesValue(maxVisibleLinesRaw.integerValue) : kOverlayMaxVisibleLinesDefault;
+
+        [self selectOverlayFontFamilyValue:fontFamily];
+        self.overlayFontSizeSlider.integerValue = fontSize;
+        self.overlayBottomMarginSlider.integerValue = bottomMargin;
+        self.overlayLimitVisibleLinesSwitch.state = limitVisibleLines ? NSControlStateValueOn : NSControlStateValueOff;
+        [self selectOverlayMaxVisibleLinesValue:maxVisibleLines];
+        [self syncOverlayPreviewFromControls];
     } else if ([identifier isEqualToString:kToolbarHotkey]) {
         NSString *triggerKeyRaw = configGet(@"hotkey.trigger_key");
         NSString *triggerKey = normalizedHotkeyValue(triggerKeyRaw);
@@ -2981,6 +3407,18 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         NSString *triggerModeValue = [self.triggerModePopup selectedItem].representedObject ?: @"hold";
         saveOk &= configSet(@"hotkey.trigger_mode", triggerModeValue);
     }
+    if (self.overlayFontSizeSlider) {
+        NSString *fontFamily = [self selectedOverlayFontFamilyValue];
+        NSInteger fontSize = clampedOverlayFontSizeValue(lround(self.overlayFontSizeSlider.doubleValue));
+        NSInteger bottomMargin = clampedOverlayBottomMarginValue(lround(self.overlayBottomMarginSlider.doubleValue));
+        BOOL limitVisibleLines = self.overlayLimitVisibleLinesSwitch.state == NSControlStateValueOn;
+        NSInteger maxVisibleLines = [self selectedOverlayMaxVisibleLinesValue];
+        saveOk &= configSet(@"overlay.font_family", fontFamily);
+        saveOk &= configSet(@"overlay.font_size", [NSString stringWithFormat:@"%ld", (long)fontSize]);
+        saveOk &= configSet(@"overlay.bottom_margin", [NSString stringWithFormat:@"%ld", (long)bottomMargin]);
+        saveOk &= configSet(@"overlay.limit_visible_lines", limitVisibleLines ? @"true" : @"false");
+        saveOk &= configSet(@"overlay.max_visible_lines", [NSString stringWithFormat:@"%ld", (long)maxVisibleLines]);
+    }
     if (self.startSoundCheckbox) {
         NSString *startSound = (self.startSoundCheckbox.state == NSControlStateValueOn) ? @"true" : @"false";
         NSString *stopSound = (self.stopSoundCheckbox.state == NSControlStateValueOn) ? @"true" : @"false";
@@ -3051,6 +3489,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
 - (void)cancelSetup:(id)sender {
     [self endHotkeyRecording];
+    [self hideRuntimeOverlayPreview];
     [self.window close];
 }
 

--- a/KoeApp/Koe/StatusBar/SPStatusBarManager.m
+++ b/KoeApp/Koe/StatusBar/SPStatusBarManager.m
@@ -4,6 +4,7 @@
 #import "SPHistoryManager.h"
 #import "koe_core.h"
 #import <Cocoa/Cocoa.h>
+#import <Carbon/Carbon.h>
 #import <ServiceManagement/ServiceManagement.h>
 #import <UserNotifications/UserNotifications.h>
 
@@ -69,8 +70,115 @@ static NSString *displayNameForKeycode(int keycode) {
         case 124: return @"Right Arrow";
         case 125: return @"Down Arrow";
         case 126: return @"Up Arrow";
-        default:  return [NSString stringWithFormat:@"Key %d", keycode];
+        default: break;
     }
+
+    TISInputSourceRef inputSource = TISCopyCurrentKeyboardLayoutInputSource();
+    if (inputSource) {
+        CFDataRef layoutData = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData);
+        if (layoutData) {
+            const UCKeyboardLayout *keyboardLayout = (const UCKeyboardLayout *)CFDataGetBytePtr(layoutData);
+            if (keyboardLayout) {
+                UInt32 deadKeyState = 0;
+                UniChar chars[4];
+                UniCharCount length = 0;
+                OSStatus status = UCKeyTranslate(keyboardLayout,
+                                                 (UInt16)keycode,
+                                                 kUCKeyActionDisplay,
+                                                 0,
+                                                 LMGetKbdType(),
+                                                 kUCKeyTranslateNoDeadKeysBit,
+                                                 &deadKeyState,
+                                                 sizeof(chars) / sizeof(chars[0]),
+                                                 &length,
+                                                 chars);
+                if (status == noErr && length > 0) {
+                    NSString *result = [[NSString stringWithCharacters:chars length:(NSUInteger)length]
+                        stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+                    CFRelease(inputSource);
+                    if (result.length > 0) {
+                        return result.uppercaseString;
+                    }
+                    return [NSString stringWithFormat:@"Key %d", keycode];
+                }
+            }
+        }
+        CFRelease(inputSource);
+    }
+
+    return [NSString stringWithFormat:@"Key %d", keycode];
+}
+
+static BOOL isNumericHotkeyValue(NSString *value) {
+    if (value.length == 0) return NO;
+    NSScanner *scanner = [NSScanner scannerWithString:value];
+    int keycode = 0;
+    return [scanner scanInt:&keycode] && [scanner isAtEnd];
+}
+
+static NSDictionary<NSString *, NSString *> *comboModifierDisplayNames(void) {
+    static NSDictionary<NSString *, NSString *> *displayNames;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        displayNames = @{
+            @"command": @"Command",
+            @"option": @"Option",
+            @"control": @"Control",
+            @"shift": @"Shift",
+            @"fn": @"Fn",
+        };
+    });
+    return displayNames;
+}
+
+static NSArray<NSString *> *comboModifierOrder(void) {
+    return @[@"command", @"option", @"control", @"shift", @"fn"];
+}
+
+static NSString *normalizedHotkeyComboValue(NSString *value) {
+    if (![value containsString:@"+"]) return nil;
+
+    NSMutableOrderedSet<NSString *> *modifiers = [NSMutableOrderedSet orderedSet];
+    NSString *keyToken = nil;
+
+    for (NSString *rawPart in [value componentsSeparatedByString:@"+"]) {
+        NSString *part = [[rawPart stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+        if (part.length == 0) return nil;
+
+        NSString *normalizedModifier = nil;
+        if ([part isEqualToString:@"cmd"] || [part isEqualToString:@"command"]) {
+            normalizedModifier = @"command";
+        } else if ([part isEqualToString:@"alt"] || [part isEqualToString:@"option"]) {
+            normalizedModifier = @"option";
+        } else if ([part isEqualToString:@"ctrl"] || [part isEqualToString:@"control"]) {
+            normalizedModifier = @"control";
+        } else if ([part isEqualToString:@"shift"]) {
+            normalizedModifier = @"shift";
+        } else if ([part isEqualToString:@"fn"] || [part isEqualToString:@"function"] || [part isEqualToString:@"globe"]) {
+            normalizedModifier = @"fn";
+        }
+
+        if (normalizedModifier) {
+            [modifiers addObject:normalizedModifier];
+            continue;
+        }
+
+        if (keyToken != nil || !isNumericHotkeyValue(part)) {
+            return nil;
+        }
+        keyToken = [NSString stringWithFormat:@"%ld", (long)part.integerValue];
+    }
+
+    if (modifiers.count == 0 || keyToken.length == 0) return nil;
+
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    for (NSString *modifier in comboModifierOrder()) {
+        if ([modifiers containsObject:modifier]) {
+            [parts addObject:modifier];
+        }
+    }
+    [parts addObject:keyToken];
+    return [parts componentsJoinedByString:@"+"];
 }
 
 static NSString *displayNameForHotkeyValue(NSString *value) {
@@ -95,13 +203,25 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     if ([value isEqualToString:@"fn"]) {
         return @"Fn (Globe)";
     }
-    // Numeric keycode: show friendly name or "Keycode XX"
-    NSScanner *scanner = [NSScanner scannerWithString:value];
-    int keycode;
-    if ([scanner scanInt:&keycode] && [scanner isAtEnd]) {
+    NSString *normalizedCombo = normalizedHotkeyComboValue(value);
+    if (normalizedCombo.length > 0) {
+        NSMutableArray<NSString *> *parts = [NSMutableArray array];
+        NSArray<NSString *> *tokens = [normalizedCombo componentsSeparatedByString:@"+"];
+        NSDictionary<NSString *, NSString *> *displayNames = comboModifierDisplayNames();
+        for (NSInteger idx = 0; idx < (NSInteger)tokens.count; idx++) {
+            NSString *token = tokens[idx];
+            if (idx == (NSInteger)tokens.count - 1) {
+                [parts addObject:displayNameForKeycode(token.intValue)];
+            } else {
+                [parts addObject:displayNames[token] ?: token.capitalizedString];
+            }
+        }
+        return [parts componentsJoinedByString:@" + "];
+    }
+    if (isNumericHotkeyValue(value)) {
+        int keycode = value.intValue;
         return displayNameForKeycode(keycode);
     }
-    // Unknown string value: show as-is
     return value;
 }
 
@@ -143,7 +263,7 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     self.statusMenuItem.enabled = NO;
     [menu addItem:self.statusMenuItem];
 
-    self.hotkeyDisplayItem = [[NSMenuItem alloc] initWithTitle:@"Hotkeys: Fn / Left Option"
+    self.hotkeyDisplayItem = [[NSMenuItem alloc] initWithTitle:@"Shortcut: Fn"
                                                         action:nil
                                                  keyEquivalent:@""];
     self.hotkeyDisplayItem.enabled = NO;
@@ -384,15 +504,11 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
 
 - (void)refreshHotkeyDisplay {
     char *t = sp_config_resolved_trigger_key();
-    char *c = sp_config_resolved_cancel_key();
     NSString *triggerKey = t ? @(t) : @"fn";
-    NSString *cancelKey  = c ? @(c) : @"left_option";
     sp_core_free_string(t);
-    sp_core_free_string(c);
 
-    self.hotkeyDisplayItem.title = [NSString stringWithFormat:@"Hotkeys: %@ / %@",
-                                    displayNameForHotkeyValue(triggerKey),
-                                    displayNameForHotkeyValue(cancelKey)];
+    self.hotkeyDisplayItem.title = [NSString stringWithFormat:@"Shortcut: %@",
+                                    displayNameForHotkeyValue(triggerKey)];
 }
 
 #pragma mark - Microphone Selection

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I tried nearly every voice input app on the market. They were either paid, ugly,
 
 Koe takes a different approach:
 
-- **Minimal runtime UI.** Koe stays out of the way with a menu bar item, a small floating status pill with native frosted-glass vibrancy during active sessions, and an optional built-in settings window when you actually need to configure it.
+- **Minimal runtime UI.** Koe stays out of the way with a menu bar item, a small floating status pill with native frosted-glass vibrancy during active sessions, optional post-processing template actions above the result bubble, and an optional built-in settings window when you actually need to configure it.
 - **All configuration lives in plain text files** under `~/.koe/`. You can edit them with any text editor, vim, a script, or the built-in settings UI.
 - **Dictionary is a plain `.txt` file.** No need to open an app and add words one by one through a GUI. Just edit `~/.koe/dictionary.txt` — one term per line. You can even use Claude Code or other AI tools to bulk-generate domain-specific terms.
 - **Changes take effect immediately.** Edit any config file and the new settings are used automatically. ASR, LLM, dictionary, and prompt changes apply on the next hotkey press. Hotkey changes are detected within a few seconds. No restart, no reload button.
@@ -25,11 +25,12 @@ Koe takes a different approach:
 
 ## How It Works
 
-1. Press and hold the trigger key (default: **Fn**, configurable) — Koe starts listening
+1. Press the trigger shortcut (default: **Fn**, configurable). In `hold` mode you press-and-hold to record; in `toggle` mode you tap once to start and tap again to stop.
 2. Audio streams in real-time to a cloud ASR service (Doubao/豆包 by ByteDance)
 3. A floating status pill shows real-time interim recognition text as you speak
-4. The ASR transcript is corrected by an LLM — fixing capitalization, punctuation, spacing, and terminology
+4. The overlay stays visible through ASR finalization and LLM correction, so you can see both the final transcript and corrected result
 5. The corrected text is automatically pasted into the active input field
+6. If overlay templates are enabled, you can optionally click a template or press `1-9` to rewrite the result and copy that variant to the clipboard
 
 ASR provider support:
 
@@ -67,10 +68,10 @@ The feed file lives at `docs/update-feed.json` and should contain at least:
 
 ```json
 {
-  "version": "1.0.13",
-  "build": 14,
+  "version": "1.0.14",
+  "build": 15,
   "minimum_system_version": "14.0",
-  "download_url": "https://github.com/missuo/koe/releases/download/v1.0.13/Koe-macOS-arm64.zip"
+  "download_url": "https://github.com/missuo/koe/releases/download/v1.0.14/Koe-macOS-arm64.zip"
 }
 ```
 
@@ -142,9 +143,10 @@ for warning/error notifications and update-related diagnostics.
 All config files live in `~/.koe/` and are auto-generated on first launch. You
 can edit them directly, or use the built-in settings window (Setup Wizard) from
 the menu bar. The settings window includes tabs for ASR, LLM, Controls, Dictionary,
-and Prompt. The Prompt tab edits `system_prompt.txt`; advanced knobs such as
-`user_prompt.txt`, ASR custom `headers`, and `llm.no_reasoning_control` remain
-file-based settings. When a local ASR provider is selected, the ASR tab shows
+System Prompt, Templates, and About. The System Prompt tab edits `system_prompt.txt`;
+the Templates tab manages prompt-template visibility, ordering, and prompts; advanced
+knobs such as `user_prompt.txt`, ASR custom `headers`, and `llm.no_reasoning_control`
+remain file-based settings. When a local ASR provider is selected, the ASR tab shows
 provider-specific controls: model picker with download/delete for MLX and
 Sherpa-ONNX, or language picker with asset status and download for Apple Speech.
 The LLM tab supports both OpenAI-compatible APIs and local MLX models — selecting
@@ -346,13 +348,12 @@ feedback:
 
 ```yaml
 hotkey:
-  # Trigger key for voice input.
+  # Trigger shortcut for voice input.
   # Options: fn | left_option | right_option | left_command | right_command | left_control | right_control
-  # You can also use a raw macOS keycode number such as 96 (F5) or 122 (F1).
+  # You can also use a raw macOS keycode number such as 96 (F5) or 122 (F1),
+  # or a normalized key combo such as "command+shift+49".
   trigger_key: "fn"
-  # Cancel key for aborting the current session.
-  # Must be different from trigger_key. Raw keycodes are also supported here.
-  cancel_key: "left_option"
+  trigger_mode: "hold"  # "hold" | "toggle"
 ```
 
 | Option | Key | Notes |
@@ -365,12 +366,16 @@ hotkey:
 | `left_control` | Left Control | Available on all Mac keyboards |
 | `right_control` | Right Control | Only on full-size/external keyboards |
 
-Hotkey changes take effect automatically within a few seconds. The trigger key
-starts voice input, and the cancel key aborts the current session without output.
-If the configured trigger key and cancel key collide, Koe normalizes them and
-writes the corrected pair back to `config.yaml`. For common raw keycodes, the
-menu bar and Setup Wizard show a friendly label such as `F5` or `Escape` instead
-of only the numeric value.
+Hotkey changes take effect automatically within a few seconds. Koe now uses a
+single trigger shortcut model:
+
+- `hold`: press-and-hold to record, release to stop
+- `toggle`: tap once to start, tap again to stop
+
+You can choose a named modifier key, a raw macOS keycode, or record a custom
+shortcut combination directly in the Controls pane. Recorded combinations are
+normalized in config and shown with friendly labels in the menu bar and settings
+UI instead of raw numeric key values.
 
 #### Dictionary
 
@@ -438,6 +443,37 @@ Available template placeholders in `user_prompt.txt`:
 The default prompts are tuned for software developers working in mixed Chinese-English, but you can adapt them for any language or domain.
 If either prompt file is missing or empty, Koe falls back to the built-in defaults
 compiled into `koe-core`.
+
+### Prompt Templates
+
+Koe can optionally keep the overlay visible after the default correction and show
+rewrite templates above the result bubble. The Templates pane lets you add, edit,
+remove, reorder, and enable or disable up to 9 templates.
+
+```yaml
+llm:
+  prompt_templates_enabled: true
+
+prompt_templates:
+  - name: "翻译英文"
+    enabled: true
+    shortcut: 1
+    system_prompt: "将用户的语音输入翻译为流畅的英文。保持原意，不要添加额外内容。只输出翻译结果。"
+
+  - name: "邮件润色"
+    enabled: true
+    shortcut: 2
+    system_prompt: "将用户的语音输入整理为简洁、礼貌、自然的英文邮件内容。只输出最终邮件正文。"
+```
+
+- `llm.prompt_templates_enabled` is the global switch for showing template buttons in the overlay.
+- `enabled` controls whether a specific template is shown.
+- `shortcut` is the contextual overlay slot (`1-9`) after reordering.
+- `system_prompt` and `system_prompt_path` are mutually exclusive.
+
+After the normal correction is pasted, you can hover or click a template button,
+or press `1-9`, to run a second-pass rewrite. Rewrite results are copied to the
+clipboard instead of being auto-pasted, so you can decide whether to use them.
 
 ## Usage Statistics
 
@@ -671,6 +707,11 @@ All providers:
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for commit conventions, PR guidelines, and the full contributor workflow.
+
+## Contributors
+
+- Vincent Yang — creator and maintainer
+- luolei — contributor for the 1.0.14 release cycle, including prompt templates, shortcut workflow, and settings/overlay interaction polish
 
 ## License
 

--- a/docs/superpowers/plans/2026-04-09-overlay-triggermode-ui.md
+++ b/docs/superpowers/plans/2026-04-09-overlay-triggermode-ui.md
@@ -1,0 +1,939 @@
+# Overlay Flow, Trigger Mode & UI Modernization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve the Koe voice input experience with (1) an overlay that shows ASR and LLM results through the full session lifecycle, (2) a configurable hold/toggle trigger mode, and (3) a modernized Arc Browser-style Controls panel.
+
+**Architecture:** Changes span three layers — Rust core (new FFI callback + config field), ObjC bridge/app delegate (overlay lifecycle + trigger mode), and UI (card-based Controls panel). Each task is independent enough to build and test separately.
+
+**Tech Stack:** Rust (koe-core), Objective-C (KoeApp), cbindgen (C header generation)
+
+**Spec:** `docs/superpowers/specs/2026-04-09-overlay-triggermode-ui-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `koe-core/src/ffi.rs` | Modify | Add `on_asr_final_text` callback to `SPCallbacks`, add `invoke_asr_final_text()`, add `trigger_mode` to `SPHotkeyConfig` |
+| `koe-core/src/lib.rs` | Modify | Call `invoke_asr_final_text()` after ASR finalization, expose `trigger_mode` in `sp_core_get_hotkey_config()` |
+| `koe-core/src/config.rs` | Modify | Add `trigger_mode` field to `HotkeySection` |
+| `koe-core/target/koe_core.h` | Regenerate | cbindgen auto-generates from Rust changes |
+| `KoeApp/Koe/Bridge/SPRustBridge.h` | Modify | Add `rustBridgeDidReceiveAsrFinalText:` delegate method |
+| `KoeApp/Koe/Bridge/SPRustBridge.m` | Modify | Add `bridge_on_asr_final_text` callback, register it |
+| `KoeApp/Koe/Overlay/SPOverlayPanel.h` | Modify | Add `updateDisplayText:`, `lingerAndDismiss:` methods |
+| `KoeApp/Koe/Overlay/SPOverlayPanel.m` | Modify | Allow interim text in non-recording states, add linger dismiss logic |
+| `KoeApp/Koe/Hotkey/SPHotkeyMonitor.h` | Modify | Add `triggerMode` property enum |
+| `KoeApp/Koe/Hotkey/SPHotkeyMonitor.m` | Modify | Gate tap behavior on `triggerMode` |
+| `KoeApp/Koe/AppDelegate/SPAppDelegate.m` | Modify | Handle new ASR final text callback, linger timer, read trigger mode from config |
+| `KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m` | Modify | Redesign Controls panel with card layout, add trigger mode popup |
+
+---
+
+## Task 1: Add `trigger_mode` to Rust Config
+
+**Files:**
+- Modify: `koe-core/src/config.rs:314-335` (HotkeySection)
+
+- [ ] **Step 1: Add `trigger_mode` field to `HotkeySection`**
+
+In `koe-core/src/config.rs`, add the field after `cancel_key`:
+
+```rust
+#[derive(Debug, Deserialize, Clone)]
+pub struct HotkeySection {
+    #[serde(
+        default = "default_trigger_key",
+        deserialize_with = "deserialize_string_or_int"
+    )]
+    pub trigger_key: String,
+
+    #[serde(
+        default = "default_cancel_key",
+        deserialize_with = "deserialize_string_or_int"
+    )]
+    pub cancel_key: String,
+
+    /// Trigger mode: "hold" (press-and-hold, default) or "toggle" (tap to start/stop).
+    #[serde(default = "default_trigger_mode")]
+    pub trigger_mode: String,
+}
+```
+
+- [ ] **Step 2: Add the default function**
+
+Add near the other default functions (search for `fn default_trigger_key`):
+
+```rust
+fn default_trigger_mode() -> String {
+    "hold".into()
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cargo build --manifest-path koe-core/Cargo.toml 2>&1 | tail -5`
+Expected: Compiles successfully. Existing configs without `trigger_mode` will deserialize with `"hold"` default.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add koe-core/src/config.rs
+git commit -m "feat(config): add trigger_mode field to hotkey section"
+```
+
+---
+
+## Task 2: Expose `trigger_mode` and `on_asr_final_text` in FFI
+
+**Files:**
+- Modify: `koe-core/src/ffi.rs:28-50` (SPCallbacks struct), `koe-core/src/ffi.rs:138-154` (SPHotkeyConfig struct)
+
+- [ ] **Step 1: Add `on_asr_final_text` to `SPCallbacks`**
+
+In `koe-core/src/ffi.rs`, add after the `on_interim_text` field (line 49):
+
+```rust
+pub struct SPCallbacks {
+    pub on_session_ready: Option<extern "C" fn(token: u64)>,
+    pub on_session_error: Option<extern "C" fn(token: u64, message: *const c_char)>,
+    pub on_session_warning: Option<extern "C" fn(token: u64, message: *const c_char)>,
+    pub on_final_text_ready: Option<extern "C" fn(token: u64, text: *const c_char)>,
+    pub on_log_event: Option<extern "C" fn(level: c_int, message: *const c_char)>,
+    pub on_state_changed: Option<extern "C" fn(token: u64, state: *const c_char)>,
+    pub on_interim_text: Option<extern "C" fn(token: u64, text: *const c_char)>,
+    /// Called when ASR finalization completes with the final recognized text,
+    /// before LLM correction begins. Used to display ASR result in the overlay.
+    pub on_asr_final_text: Option<extern "C" fn(token: u64, text: *const c_char)>,
+}
+```
+
+- [ ] **Step 2: Add `invoke_asr_final_text` function**
+
+Add after the existing `invoke_interim_text` function (around line 126):
+
+```rust
+pub fn invoke_asr_final_text(token: u64, text: &str) {
+    let cb = CALLBACKS.lock().unwrap();
+    if let Some(ref cbs) = *cb {
+        if let Some(f) = cbs.on_asr_final_text {
+            let c_text = CString::new(text).unwrap_or_default();
+            f(token, c_text.as_ptr());
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add `trigger_mode` to `SPHotkeyConfig`**
+
+In `koe-core/src/ffi.rs`, add to the `SPHotkeyConfig` struct after `cancel_modifier_flag`:
+
+```rust
+pub struct SPHotkeyConfig {
+    pub trigger_key_code: u16,
+    pub trigger_alt_key_code: u16,
+    pub trigger_modifier_flag: u64,
+    pub cancel_key_code: u16,
+    pub cancel_alt_key_code: u16,
+    pub cancel_modifier_flag: u64,
+    /// Trigger mode: 0 = hold (press-and-hold), 1 = toggle (tap to start/stop)
+    pub trigger_mode: u8,
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cargo build --manifest-path koe-core/Cargo.toml 2>&1 | tail -5`
+Expected: Compiles successfully.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add koe-core/src/ffi.rs
+git commit -m "feat(ffi): add on_asr_final_text callback and trigger_mode to SPHotkeyConfig"
+```
+
+---
+
+## Task 3: Wire FFI Changes in Rust Core (`lib.rs`)
+
+**Files:**
+- Modify: `koe-core/src/lib.rs:16` (import), `koe-core/src/lib.rs:565-587` (sp_core_get_hotkey_config), `koe-core/src/lib.rs:770-772` (after ASR finalization)
+
+- [ ] **Step 1: Add `invoke_asr_final_text` to imports**
+
+In `koe-core/src/lib.rs` line 16, add to the existing import:
+
+```rust
+    SPFeedbackConfig, SPHotkeyConfig, SPSessionContext, SPSessionMode,
+```
+
+No change needed here — `invoke_asr_final_text` is already accessible from the `ffi` module. Just make sure the function is `pub`.
+
+- [ ] **Step 2: Call `invoke_asr_final_text` after ASR finalization**
+
+In `koe-core/src/lib.rs`, after the ASR text is finalized (around line 770, after `session.asr_text = Some(asr_text.clone());`), add:
+
+```rust
+    // Store ASR text in session
+    {
+        let mut s = session_arc.lock().unwrap();
+        if let Some(ref mut session) = *s {
+            session.asr_text = Some(asr_text.clone());
+        }
+    }
+
+    // Notify ObjC of the final ASR text so the overlay can display it
+    // during the LLM correction phase.
+    invoke_asr_final_text(session_token, &asr_text);
+
+    // --- LLM Correction ---
+```
+
+- [ ] **Step 3: Expose `trigger_mode` in `sp_core_get_hotkey_config`**
+
+In `koe-core/src/lib.rs`, modify `sp_core_get_hotkey_config()` (line 565) to include `trigger_mode`:
+
+```rust
+pub extern "C" fn sp_core_get_hotkey_config() -> SPHotkeyConfig {
+    let global = CORE.lock().unwrap();
+    if let Some(ref core) = *global {
+        let params = core.config.hotkey.resolve();
+        let mode = match core.config.hotkey.trigger_mode.as_str() {
+            "toggle" => 1u8,
+            _ => 0u8,
+        };
+        SPHotkeyConfig {
+            trigger_key_code: params.trigger.key_code,
+            trigger_alt_key_code: params.trigger.alt_key_code,
+            trigger_modifier_flag: params.trigger.modifier_flag,
+            cancel_key_code: params.cancel.key_code,
+            cancel_alt_key_code: params.cancel.alt_key_code,
+            cancel_modifier_flag: params.cancel.modifier_flag,
+            trigger_mode: mode,
+        }
+    } else {
+        SPHotkeyConfig {
+            trigger_key_code: 63,
+            trigger_alt_key_code: 179,
+            trigger_modifier_flag: 0x00800000,
+            cancel_key_code: 58,
+            cancel_alt_key_code: 0,
+            cancel_modifier_flag: 0x00000020,
+            trigger_mode: 0,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cargo build --manifest-path koe-core/Cargo.toml 2>&1 | tail -5`
+Expected: Compiles successfully.
+
+- [ ] **Step 5: Regenerate C header**
+
+Run: `cd koe-core && cbindgen --config cbindgen.toml --crate koe-core --output target/koe_core.h`
+Verify the new header contains `on_asr_final_text` in `SPCallbacks` and `trigger_mode` in `SPHotkeyConfig`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add koe-core/src/lib.rs koe-core/target/koe_core.h
+git commit -m "feat(core): emit asr_final_text callback and expose trigger_mode in hotkey config"
+```
+
+---
+
+## Task 4: ObjC Bridge — Add `on_asr_final_text` Callback
+
+**Files:**
+- Modify: `KoeApp/Koe/Bridge/SPRustBridge.h:9-16` (delegate protocol)
+- Modify: `KoeApp/Koe/Bridge/SPRustBridge.m:0-100` (callback functions and registration)
+
+- [ ] **Step 1: Add delegate method to `SPRustBridge.h`**
+
+Add after `rustBridgeDidReceiveInterimText:` (line 15):
+
+```objc
+@protocol SPRustBridgeDelegate <NSObject>
+- (void)rustBridgeDidBecomeReady;
+- (void)rustBridgeDidReceiveFinalText:(NSString *)text;
+- (void)rustBridgeDidEncounterError:(NSString *)message;
+- (void)rustBridgeDidReceiveWarning:(NSString *)message;
+- (void)rustBridgeDidChangeState:(NSString *)state;
+- (void)rustBridgeDidReceiveInterimText:(NSString *)text;
+- (void)rustBridgeDidReceiveAsrFinalText:(NSString *)text;
+@end
+```
+
+- [ ] **Step 2: Add C callback function in `SPRustBridge.m`**
+
+Add after `bridge_on_interim_text` (around line 87):
+
+```objc
+static void bridge_on_asr_final_text(uint64_t token, const char *text) {
+    NSString *txt = text ? [NSString stringWithUTF8String:text] : @"";
+    id<SPRustBridgeDelegate> delegate = _bridgeDelegate;
+    if (delegate) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (token != _currentSessionToken) return;
+            [delegate rustBridgeDidReceiveAsrFinalText:txt];
+        });
+    }
+}
+```
+
+- [ ] **Step 3: Register the callback**
+
+Find where `SPCallbacks` is populated (search for `sp_core_register_callbacks` in SPRustBridge.m) and add the new field:
+
+```objc
+struct SPCallbacks callbacks = {
+    .on_session_ready = bridge_on_session_ready,
+    .on_session_error = bridge_on_session_error,
+    .on_session_warning = bridge_on_session_warning,
+    .on_final_text_ready = bridge_on_final_text_ready,
+    .on_log_event = bridge_on_log_event,
+    .on_state_changed = bridge_on_state_changed,
+    .on_interim_text = bridge_on_interim_text,
+    .on_asr_final_text = bridge_on_asr_final_text,
+};
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add KoeApp/Koe/Bridge/SPRustBridge.h KoeApp/Koe/Bridge/SPRustBridge.m
+git commit -m "feat(bridge): add on_asr_final_text callback and delegate method"
+```
+
+---
+
+## Task 5: Overlay — Support Text Display in All Phases + Linger Dismiss
+
+**Files:**
+- Modify: `KoeApp/Koe/Overlay/SPOverlayPanel.h`
+- Modify: `KoeApp/Koe/Overlay/SPOverlayPanel.m:302-367` (state handling), `KoeApp/Koe/Overlay/SPOverlayPanel.m:444-454` (hide)
+
+- [ ] **Step 1: Add new methods to `SPOverlayPanel.h`**
+
+```objc
+@interface SPOverlayPanel : NSObject
+
+- (instancetype)init;
+
+/// Update displayed state. Same state strings as SPStatusBarManager.
+- (void)updateState:(NSString *)state;
+
+/// Update interim ASR text shown during recording.
+- (void)updateInterimText:(NSString *)text;
+
+/// Update display text shown during non-recording phases (ASR result, LLM result).
+- (void)updateDisplayText:(NSString *)text;
+
+/// Dismiss the overlay after a dynamic linger period based on text length.
+- (void)lingerAndDismiss;
+
+@end
+```
+
+- [ ] **Step 2: Remove recording-only gate on `updateInterimText`**
+
+In `SPOverlayPanel.m`, the `updateInterimText:` method (line 362) currently returns early if not recording. We need a separate method for non-recording text. Rename the guard:
+
+```objc
+- (void)updateInterimText:(NSString *)text {
+    if (![self.currentState hasPrefix:@"recording"]) return;
+    self.contentView.interimText = text;
+    [self resizeAndCenterAnimated:YES];
+    [self.contentView setNeedsDisplay:YES];
+}
+
+- (void)updateDisplayText:(NSString *)text {
+    self.contentView.interimText = text;
+    [self resizeAndCenterAnimated:YES];
+    [self.contentView setNeedsDisplay:YES];
+}
+```
+
+- [ ] **Step 3: Add `lingerAndDismiss` method**
+
+Add a property to track the linger timer in the `@interface` extension, then implement:
+
+Add to the private interface (search for `@property` block in the `@interface SPOverlayPanel ()` extension):
+
+```objc
+@property (nonatomic, strong) NSTimer *lingerTimer;
+```
+
+Then add the method implementation:
+
+```objc
+- (void)lingerAndDismiss {
+    [self.lingerTimer invalidate];
+    self.lingerTimer = nil;
+
+    // Dynamic linger: clamp(charCount * 0.03, 0.8, 2.5)
+    NSString *displayText = self.contentView.interimText ?: self.contentView.statusText ?: @"";
+    NSUInteger charCount = displayText.length;
+    NSTimeInterval linger = fmin(fmax(charCount * 0.03, 0.8), 2.5);
+
+    self.lingerTimer = [NSTimer scheduledTimerWithTimeInterval:linger
+                                                      repeats:NO
+                                                        block:^(NSTimer *timer) {
+        self.lingerTimer = nil;
+        self.sessionMaxWidth = 0;
+        self.sessionMaxHeight = 0;
+        [self hide];
+        self.currentState = @"idle";
+    }];
+}
+```
+
+- [ ] **Step 4: Modify `updateState:` to not auto-hide on "completed"**
+
+In `updateState:` (line 309), change the idle/completed handling so "completed" triggers linger instead of immediate hide. Actually, we won't use the "completed" state for this — the AppDelegate will call `lingerAndDismiss` directly. No change needed here.
+
+- [ ] **Step 5: Cancel linger timer when a new session starts**
+
+In `updateState:`, at the top of the method, add:
+
+```objc
+- (void)updateState:(NSString *)state {
+    // Cancel any pending linger dismiss from a previous session
+    [self.lingerTimer invalidate];
+    self.lingerTimer = nil;
+
+    self.currentState = state;
+    [self stopAnimation];
+    // ... rest of method unchanged
+```
+
+- [ ] **Step 6: Build and verify**
+
+Run: `make build-lite 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add KoeApp/Koe/Overlay/SPOverlayPanel.h KoeApp/Koe/Overlay/SPOverlayPanel.m
+git commit -m "feat(overlay): add displayText and lingerAndDismiss for full-lifecycle display"
+```
+
+---
+
+## Task 6: AppDelegate — Wire Overlay Full-Lifecycle + Trigger Mode
+
+**Files:**
+- Modify: `KoeApp/Koe/AppDelegate/SPAppDelegate.m:28-45` (applyHotkeyConfig), `334-369` (rustBridgeDidReceiveFinalText), `443-447` (rustBridgeDidChangeState)
+
+- [ ] **Step 1: Implement `rustBridgeDidReceiveAsrFinalText:`**
+
+Add this new delegate method in the `SPRustBridgeDelegate` section:
+
+```objc
+- (void)rustBridgeDidReceiveAsrFinalText:(NSString *)text {
+    NSLog(@"[Koe] ASR final text: %lu chars", (unsigned long)text.length);
+    [self.overlayPanel updateDisplayText:text];
+}
+```
+
+- [ ] **Step 2: Modify `rustBridgeDidReceiveFinalText:` for linger behavior**
+
+Replace the overlay-to-idle transition at the end of `rustBridgeDidReceiveFinalText:` with linger:
+
+```objc
+- (void)rustBridgeDidReceiveFinalText:(NSString *)text {
+    if (self.quitting) return;
+    NSLog(@"[Koe] Final text received (%lu chars)", (unsigned long)text.length);
+
+    // Record history
+    NSInteger durationMs = 0;
+    if (self.recordingStartTime) {
+        durationMs = (NSInteger)(-[self.recordingStartTime timeIntervalSinceNow] * 1000);
+        self.recordingStartTime = nil;
+    }
+    [[SPHistoryManager sharedManager] recordSessionWithDurationMs:durationMs text:text];
+
+    // Show corrected text in overlay before pasting
+    [self.overlayPanel updateDisplayText:text];
+
+    [self.statusBarManager updateState:@"pasting"];
+    [self.overlayPanel updateState:@"pasting"];
+
+    // Backup clipboard, write text, paste, restore
+    [self.clipboardManager backup];
+    [self.clipboardManager writeText:text];
+
+    uint64_t token = self.rustBridge.currentSessionToken;
+
+    if ([self.permissionManager isAccessibilityGranted]) {
+        [self.pasteManager simulatePasteWithCompletion:^{
+            [self.clipboardManager scheduleRestoreAfterDelay:1500];
+            if (token != self.rustBridge.currentSessionToken) return;
+            [self.statusBarManager updateState:@"idle"];
+            // Don't immediately hide overlay — linger to show the result
+            [self.overlayPanel lingerAndDismiss];
+        }];
+    } else {
+        NSLog(@"[Koe] Accessibility not granted — text copied to clipboard only");
+        [self.statusBarManager updateState:@"idle"];
+        [self.overlayPanel lingerAndDismiss];
+    }
+}
+```
+
+- [ ] **Step 3: Update `rustBridgeDidChangeState:` to show ASR text during correcting phase**
+
+The existing handler simply forwards state to overlay and status bar. The "correcting" state change from Rust will automatically update the overlay's status text and color (already handled in SPOverlayPanel.updateState). The ASR final text is set via `rustBridgeDidReceiveAsrFinalText:` which calls `updateDisplayText:`. No change needed here — the overlay will show the ASR text set by `updateDisplayText:` while the status label changes to "Thinking..." via `updateState:`.
+
+However, we need to make sure `updateState:` does NOT clear the interimText when transitioning to "correcting" or "preparing_paste" phases. Currently line 307 clears it on every state change. Fix:
+
+In `SPOverlayPanel.m`, modify `updateState:` to only clear interim text when starting a new recording:
+
+```objc
+- (void)updateState:(NSString *)state {
+    [self.lingerTimer invalidate];
+    self.lingerTimer = nil;
+
+    self.currentState = state;
+    [self stopAnimation];
+
+    // Only clear display text when starting a new recording session
+    if ([state hasPrefix:@"recording"]) {
+        self.contentView.interimText = nil;
+    }
+
+    if ([state isEqualToString:@"idle"] || [state isEqualToString:@"completed"]) {
+        // ... rest unchanged
+```
+
+- [ ] **Step 4: Apply trigger mode from config**
+
+In `applyHotkeyConfig:restartMonitorIfNeeded:` (line 28), add trigger mode handling:
+
+```objc
+- (void)applyHotkeyConfig:(struct SPHotkeyConfig)hotkeyConfig restartMonitorIfNeeded:(BOOL)restartIfNeeded {
+    BOOL changed = self.hotkeyMonitor.targetKeyCode != hotkeyConfig.trigger_key_code ||
+                   self.hotkeyMonitor.altKeyCode != hotkeyConfig.trigger_alt_key_code ||
+                   self.hotkeyMonitor.targetModifierFlag != hotkeyConfig.trigger_modifier_flag ||
+                   self.hotkeyMonitor.cancelKeyCode != hotkeyConfig.cancel_key_code ||
+                   self.hotkeyMonitor.cancelAltKeyCode != hotkeyConfig.cancel_alt_key_code ||
+                   self.hotkeyMonitor.cancelModifierFlag != hotkeyConfig.cancel_modifier_flag ||
+                   self.hotkeyMonitor.triggerMode != hotkeyConfig.trigger_mode;
+
+    if (!changed) return;
+
+    if (restartIfNeeded) {
+        [self.hotkeyMonitor stop];
+    }
+
+    self.hotkeyMonitor.targetKeyCode = hotkeyConfig.trigger_key_code;
+    self.hotkeyMonitor.altKeyCode = hotkeyConfig.trigger_alt_key_code;
+    self.hotkeyMonitor.targetModifierFlag = hotkeyConfig.trigger_modifier_flag;
+    self.hotkeyMonitor.cancelKeyCode = hotkeyConfig.cancel_key_code;
+    self.hotkeyMonitor.cancelAltKeyCode = hotkeyConfig.cancel_alt_key_code;
+    self.hotkeyMonitor.cancelModifierFlag = hotkeyConfig.cancel_modifier_flag;
+    self.hotkeyMonitor.triggerMode = hotkeyConfig.trigger_mode;
+
+    if (restartIfNeeded) {
+        [self.hotkeyMonitor start];
+    }
+}
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `make build-lite 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add KoeApp/Koe/AppDelegate/SPAppDelegate.m KoeApp/Koe/Overlay/SPOverlayPanel.m
+git commit -m "feat(app): wire overlay full-lifecycle display and trigger mode config"
+```
+
+---
+
+## Task 7: Hotkey Monitor — Gate Tap on Trigger Mode
+
+**Files:**
+- Modify: `KoeApp/Koe/Hotkey/SPHotkeyMonitor.h:12-46`
+- Modify: `KoeApp/Koe/Hotkey/SPHotkeyMonitor.m:313-335` (handleTriggerUp)
+
+- [ ] **Step 1: Add `triggerMode` property to header**
+
+In `SPHotkeyMonitor.h`, add after `holdThresholdMs`:
+
+```objc
+/// Trigger mode: 0 = hold (short press ignored), 1 = toggle (tap to start/stop).
+@property (nonatomic, assign) uint8_t triggerMode;
+```
+
+- [ ] **Step 2: Gate tap in `handleTriggerUp`**
+
+In `SPHotkeyMonitor.m`, modify `handleTriggerUp` (line 313):
+
+```objc
+- (void)handleTriggerUp {
+    if (!self.running) return;
+    NSLog(@"[Koe] Trigger UP (state=%ld)", (long)self.state);
+    switch (self.state) {
+        case SPHotkeyStatePending:
+            [self cancelHoldTimer];
+            if (self.triggerMode == 1) {
+                // Toggle mode: short press starts recording
+                self.state = SPHotkeyStateRecordingToggle;
+                [self.delegate hotkeyMonitorDidDetectTapStart];
+            } else {
+                // Hold mode: short press is ignored
+                self.state = SPHotkeyStateIdle;
+            }
+            break;
+
+        case SPHotkeyStateRecordingHold:
+            self.state = SPHotkeyStateIdle;
+            [self.delegate hotkeyMonitorDidDetectHoldEnd];
+            break;
+
+        case SPHotkeyStateConsumeKeyUp:
+            self.state = SPHotkeyStateIdle;
+            break;
+
+        default:
+            break;
+    }
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `make build-lite 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add KoeApp/Koe/Hotkey/SPHotkeyMonitor.h KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
+git commit -m "feat(hotkey): gate tap-to-toggle on trigger_mode config"
+```
+
+---
+
+## Task 8: UI — Modernized Controls Panel with Card Layout
+
+**Files:**
+- Modify: `KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m:723-822` (buildHotkeyPane)
+
+- [ ] **Step 1: Add card layout helper methods**
+
+Add these helper methods in the `// ─── UI Helpers` section (after `descriptionLabel:`):
+
+```objc
+// ─── Card Layout Helpers ───────────────────────────────────────────
+
+/// Create a card view (white rounded rect) with a title and row views.
+- (NSView *)cardWithTitle:(NSString *)title rows:(NSArray<NSView *> *)rows width:(CGFloat)width {
+    CGFloat cardPad = 16.0;
+    CGFloat rowHeight = 44.0;
+    CGFloat separatorInset = 16.0;
+
+    // Card content height
+    CGFloat cardHeight = rows.count * rowHeight;
+    // Title height
+    CGFloat titleHeight = title.length > 0 ? 28.0 : 0.0;
+    CGFloat totalHeight = titleHeight + cardHeight;
+
+    NSView *container = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, totalHeight)];
+
+    // Title label
+    if (title.length > 0) {
+        NSTextField *titleLabel = [NSTextField labelWithString:title.uppercaseString];
+        titleLabel.font = [NSFont systemFontOfSize:12 weight:NSFontWeightSemibold];
+        titleLabel.textColor = [NSColor colorWithRed:0.525 green:0.525 blue:0.557 alpha:1.0];
+        titleLabel.frame = NSMakeRect(cardPad, cardHeight, width - 2 * cardPad, 20);
+        [container addSubview:titleLabel];
+    }
+
+    // Card background
+    NSView *card = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, width, cardHeight)];
+    card.wantsLayer = YES;
+    card.layer.backgroundColor = [NSColor whiteColor].CGColor;
+    card.layer.cornerRadius = 12.0;
+    [container addSubview:card];
+
+    // Layout rows from top to bottom
+    for (NSUInteger i = 0; i < rows.count; i++) {
+        NSView *row = rows[i];
+        CGFloat rowY = cardHeight - (i + 1) * rowHeight;
+        row.frame = NSMakeRect(0, rowY, width, rowHeight);
+        [card addSubview:row];
+
+        // Add separator between rows (not after last)
+        if (i < rows.count - 1) {
+            NSView *sep = [[NSView alloc] initWithFrame:NSMakeRect(separatorInset, rowY, width - separatorInset, 1)];
+            sep.wantsLayer = YES;
+            sep.layer.backgroundColor = [NSColor colorWithRed:0.898 green:0.898 blue:0.918 alpha:1.0].CGColor;
+            [card addSubview:sep];
+        }
+    }
+
+    return container;
+}
+
+/// Create a single card row with a label on the left and a control on the right.
+- (NSView *)cardRowWithLabel:(NSString *)label control:(NSView *)control {
+    CGFloat rowHeight = 44.0;
+    CGFloat pad = 16.0;
+    NSView *row = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 100, rowHeight)];
+
+    NSTextField *lbl = [NSTextField labelWithString:label];
+    lbl.font = [NSFont systemFontOfSize:13 weight:NSFontWeightRegular];
+    lbl.textColor = [NSColor colorWithRed:0.114 green:0.114 blue:0.122 alpha:1.0];
+    lbl.frame = NSMakeRect(pad, (rowHeight - 20) / 2.0, 200, 20);
+    [row addSubview:lbl];
+
+    // Position control on the right side
+    CGFloat controlW = control.frame.size.width;
+    CGFloat controlH = control.frame.size.height;
+    control.autoresizingMask = NSViewMinXMargin;
+    // Will be repositioned when row frame is set; use a tag for width reference
+    control.frame = NSMakeRect(row.frame.size.width - pad - controlW, (rowHeight - controlH) / 2.0, controlW, controlH);
+    [row addSubview:control];
+
+    return row;
+}
+
+/// Reposition right-aligned controls after the row frame is finalized.
+- (void)finalizeCardRowLayout:(NSView *)card {
+    CGFloat pad = 16.0;
+    for (NSView *row in card.subviews) {
+        if (![row isKindOfClass:[NSView class]] || row.subviews.count < 2) continue;
+        for (NSView *sub in row.subviews) {
+            if ([sub isKindOfClass:[NSPopUpButton class]] || [sub isKindOfClass:[NSSwitch class]]) {
+                CGFloat controlW = sub.frame.size.width;
+                CGFloat controlH = sub.frame.size.height;
+                sub.frame = NSMakeRect(row.frame.size.width - pad - controlW,
+                                       (row.frame.size.height - controlH) / 2.0,
+                                       controlW, controlH);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Rebuild `buildHotkeyPane` with card layout**
+
+Replace the entire `buildHotkeyPane` method:
+
+```objc
+- (NSView *)buildHotkeyPane {
+    CGFloat paneWidth = 600;
+    CGFloat cardWidth = paneWidth - 48; // 24pt margin each side
+    CGFloat cardSpacing = 16.0;
+    CGFloat topPad = 24.0;
+
+    // ── Build controls ──
+    // Trigger Key popup
+    self.hotkeyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
+    [self.hotkeyPopup addItemsWithTitles:@[
+        @"Fn (Globe)",
+        @"Left Option (\u2325)",
+        @"Right Option (\u2325)",
+        @"Left Command (\u2318)",
+        @"Right Command (\u2318)",
+        @"Left Control (\u2303)",
+        @"Right Control (\u2303)",
+    ]];
+    [self.hotkeyPopup itemAtIndex:0].representedObject = @"fn";
+    [self.hotkeyPopup itemAtIndex:1].representedObject = @"left_option";
+    [self.hotkeyPopup itemAtIndex:2].representedObject = @"right_option";
+    [self.hotkeyPopup itemAtIndex:3].representedObject = @"left_command";
+    [self.hotkeyPopup itemAtIndex:4].representedObject = @"right_command";
+    [self.hotkeyPopup itemAtIndex:5].representedObject = @"left_control";
+    [self.hotkeyPopup itemAtIndex:6].representedObject = @"right_control";
+
+    // Trigger Mode popup
+    self.triggerModePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
+    [self.triggerModePopup addItemsWithTitles:@[
+        @"Hold (Press & Hold)",
+        @"Toggle (Tap to Start/Stop)",
+    ]];
+    [self.triggerModePopup itemAtIndex:0].representedObject = @"hold";
+    [self.triggerModePopup itemAtIndex:1].representedObject = @"toggle";
+
+    // Cancel Key popup
+    self.cancelHotkeyPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
+    [self.cancelHotkeyPopup addItemsWithTitles:@[
+        @"Fn (Globe)",
+        @"Left Option (\u2325)",
+        @"Right Option (\u2325)",
+        @"Left Command (\u2318)",
+        @"Right Command (\u2318)",
+        @"Left Control (\u2303)",
+        @"Right Control (\u2303)",
+    ]];
+    [self.cancelHotkeyPopup itemAtIndex:0].representedObject = @"fn";
+    [self.cancelHotkeyPopup itemAtIndex:1].representedObject = @"left_option";
+    [self.cancelHotkeyPopup itemAtIndex:2].representedObject = @"right_option";
+    [self.cancelHotkeyPopup itemAtIndex:3].representedObject = @"left_command";
+    [self.cancelHotkeyPopup itemAtIndex:4].representedObject = @"right_command";
+    [self.cancelHotkeyPopup itemAtIndex:5].representedObject = @"left_control";
+    [self.cancelHotkeyPopup itemAtIndex:6].representedObject = @"right_control";
+
+    // ── Trigger card ──
+    NSView *triggerCard = [self cardWithTitle:@"Trigger" rows:@[
+        [self cardRowWithLabel:@"Trigger Key" control:self.hotkeyPopup],
+        [self cardRowWithLabel:@"Trigger Mode" control:self.triggerModePopup],
+        [self cardRowWithLabel:@"Cancel Key" control:self.cancelHotkeyPopup],
+    ] width:cardWidth];
+
+    // ── Feedback Sounds card ──
+    self.startSoundCheckbox = [[NSSwitch alloc] initWithFrame:NSMakeRect(0, 0, 38, 22)];
+    self.stopSoundCheckbox = [[NSSwitch alloc] initWithFrame:NSMakeRect(0, 0, 38, 22)];
+    self.errorSoundCheckbox = [[NSSwitch alloc] initWithFrame:NSMakeRect(0, 0, 38, 22)];
+
+    NSView *feedbackCard = [self cardWithTitle:@"Feedback Sounds" rows:@[
+        [self cardRowWithLabel:@"Recording starts" control:self.startSoundCheckbox],
+        [self cardRowWithLabel:@"Recording stops" control:self.stopSoundCheckbox],
+        [self cardRowWithLabel:@"Error occurs" control:self.errorSoundCheckbox],
+    ] width:cardWidth];
+
+    // ── Layout ──
+    CGFloat triggerH = triggerCard.frame.size.height;
+    CGFloat feedbackH = feedbackCard.frame.size.height;
+    CGFloat contentHeight = topPad + triggerH + cardSpacing + feedbackH + 56; // 56 for buttons
+
+    NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
+    pane.wantsLayer = YES;
+    pane.layer.backgroundColor = [NSColor colorWithRed:0.961 green:0.961 blue:0.969 alpha:1.0].CGColor;
+
+    CGFloat y = contentHeight - topPad;
+
+    // Place trigger card
+    y -= triggerH;
+    triggerCard.frame = NSMakeRect(24, y, cardWidth, triggerH);
+    [pane addSubview:triggerCard];
+    [self finalizeCardRowLayout:[triggerCard.subviews objectAtIndex:1]]; // the card NSView
+
+    // Place feedback card
+    y -= cardSpacing + feedbackH;
+    feedbackCard.frame = NSMakeRect(24, y, cardWidth, feedbackH);
+    [pane addSubview:feedbackCard];
+    [self finalizeCardRowLayout:[feedbackCard.subviews objectAtIndex:1]];
+
+    // Save / Cancel buttons
+    [self addButtonsToPane:pane atY:16 width:paneWidth];
+
+    return pane;
+}
+```
+
+- [ ] **Step 3: Add `triggerModePopup` property**
+
+In the private `@interface SPSetupWizardWindowController ()` section, add:
+
+```objc
+@property (nonatomic, strong) NSPopUpButton *triggerModePopup;
+```
+
+- [ ] **Step 4: Update `loadValuesForPane:` for trigger mode**
+
+Find the hotkey loading section in `loadValuesForPane:` (search for `kToolbarHotkey`) and add trigger mode loading:
+
+```objc
+    // Load trigger mode
+    NSString *triggerMode = configGet(@"hotkey.trigger_mode");
+    if ([triggerMode isEqualToString:@"toggle"]) {
+        [self.triggerModePopup selectItemAtIndex:1];
+    } else {
+        [self.triggerModePopup selectItemAtIndex:0];
+    }
+```
+
+- [ ] **Step 5: Update `saveConfig:` to save trigger mode**
+
+Find where hotkey values are saved (search for `hotkey.trigger_key` in the save method) and add:
+
+```objc
+    // Save trigger mode
+    NSString *triggerModeValue = [self.triggerModePopup selectedItem].representedObject ?: @"hold";
+    configSet(@"hotkey.trigger_mode", triggerModeValue);
+```
+
+- [ ] **Step 6: Handle NSSwitch state for feedback sounds**
+
+The old code used `NSButton` checkboxes (`state == NSControlStateValueOn`). `NSSwitch` uses the same `.state` property, so `loadValuesForPane:` and `saveConfig:` should work without changes, but verify:
+- Load: `self.startSoundCheckbox.state = [configGet(@"feedback.start_sound") isEqualToString:@"true"] ? NSControlStateValueOn : NSControlStateValueOff;`
+- Save: `configSet(@"feedback.start_sound", self.startSoundCheckbox.state == NSControlStateValueOn ? @"true" : @"false");`
+
+Check that the existing load/save code is compatible with `NSSwitch`. `NSSwitch` inherits from `NSControl` and uses the same `state` property as `NSButton` checkbox, so it should be compatible.
+
+- [ ] **Step 7: Build and verify**
+
+Run: `make build-lite 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 8: Test manually**
+
+Launch the app: `open ~/Library/Developer/Xcode/DerivedData/Koe-*/Build/Products/Release/Koe.app`
+Open Settings → Controls tab. Verify:
+- Light gray background with white rounded cards
+- "TRIGGER" card with 3 rows: Trigger Key, Trigger Mode, Cancel Key
+- "FEEDBACK SOUNDS" card with 3 toggle switches
+- Save/Cancel buttons at bottom
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+git commit -m "feat(ui): modernize Controls panel with Arc-style card layout and trigger mode"
+```
+
+---
+
+## Task 9: Integration Test — Full Flow Verification
+
+- [ ] **Step 1: Full rebuild**
+
+```bash
+make build-lite 2>&1 | tail -10
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 2: Launch and test overlay lifecycle**
+
+Launch the app. Configure an ASR provider with valid credentials (or use DoubaoIME free mode). Press and hold the trigger key, speak a sentence, release.
+
+Verify:
+1. Overlay shows "Listening..." with red waveform during recording
+2. After release, overlay shows "Recognizing..." with orange/blue dots
+3. If LLM enabled: overlay shows "Thinking..." with purple dots, ASR text visible
+4. After LLM: overlay shows "Pasting..." with green checkmark, corrected text visible
+5. Overlay lingers for ~0.8-2.5s showing the final text, then fades out
+
+- [ ] **Step 3: Test trigger mode**
+
+Open Settings → Controls. Change Trigger Mode to "Toggle (Tap to Start/Stop)". Save.
+- Tap the trigger key once → recording starts
+- Tap again → recording stops, pipeline continues
+- Switch back to "Hold" → short taps are ignored, only hold works
+
+- [ ] **Step 4: Test card UI**
+
+Verify Controls panel:
+- Cards have 12pt corner radius, white background on light gray
+- Row separators visible between items
+- Controls right-aligned within rows
+- NSSwitch toggles work for feedback sounds
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: integration verification for overlay flow, trigger mode, and UI updates"
+```

--- a/docs/superpowers/plans/2026-04-09-prompt-templates.md
+++ b/docs/superpowers/plans/2026-04-09-prompt-templates.md
@@ -1,0 +1,23 @@
+# Prompt Templates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add prompt template selection to the Koe overlay, allowing users to rewrite ASR text with alternative prompts (translate, tweet, Xiaohongshu, etc.) after default LLM correction.
+
+**Architecture:** Rust core handles config parsing and LLM rewrite calls. ObjC overlay becomes interactive during the template selection phase. AppDelegate coordinates number key monitoring and rewrite flow.
+
+**Tech Stack:** Rust (koe-core), Objective-C (KoeApp), cbindgen
+
+**Spec:** `docs/superpowers/specs/2026-04-09-prompt-templates-design.md`
+
+---
+
+## Task Overview
+
+1. Rust config: PromptTemplate struct + parsing
+2. Rust FFI: rewrite callback + template query
+3. Rust core: rewrite function + template JSON
+4. ObjC Bridge: rewrite callback + methods
+5. Overlay: template button drawing + interaction
+6. AppDelegate: rewrite flow coordination + number key monitoring
+7. Integration build + test

--- a/docs/superpowers/specs/2026-04-09-overlay-style-settings-design.md
+++ b/docs/superpowers/specs/2026-04-09-overlay-style-settings-design.md
@@ -1,0 +1,189 @@
+# Overlay Style Settings and Long-Text Behavior
+
+**Date:** 2026-04-10
+**Status:** Implemented
+
+## Overview
+
+This change turns the bottom live transcript overlay into a configurable surface instead of a fixed hard-coded HUD.
+
+Users can now control:
+
+1. The font family used by the live transcript overlay.
+2. The transcript text size.
+3. The distance from the bottom of the screen.
+4. Whether long live text is capped to a visible line count.
+5. The visible line cap when limiting is enabled (`3`, `4`, or `5` lines).
+
+All Overlay style changes are previewed through the real desktop overlay itself. The previous in-window mock preview was removed so Settings no longer maintains a second rendering path that can drift from runtime behavior.
+
+## Problem
+
+The original overlay implementation used a fixed visual style:
+
+- `13pt` medium system font.
+- `10pt` bottom margin.
+- No user control over font family or visible line policy.
+- No stable strategy for very long interim transcripts.
+
+That caused two classes of issues:
+
+- Accessibility and preference issues: some users needed larger text or a different font.
+- Layout polish issues: long live text could grow awkwardly, feel cramped, or produce rough-looking clipping behavior.
+
+## Goals
+
+- Let users tune overlay typography without editing config files.
+- Keep the runtime overlay horizontally centered at all times.
+- Let users move the overlay vertically with a bottom-offset control.
+- Support both compact and fully expanded long-text behavior.
+- Keep the long-text experience visually polished, with stable scrolling when line limiting is enabled.
+- Apply saved settings immediately without restarting the app.
+
+## Non-Goals
+
+- No freeform drag placement for the overlay.
+- No horizontal position control.
+- No per-state styling differences between recording, processing, and final result states.
+- No custom overlay colors, blur themes, or border themes in this change.
+
+## Final UX
+
+### Settings Entry
+
+The Settings window includes a dedicated `Overlay` pane with the `captions.bubble` symbol.
+
+### Controls
+
+The pane exposes these controls:
+
+- `Font`
+- `Text Size`
+- `Distance from Bottom`
+- `Limit Visible Lines`
+- `Max Visible Lines`
+- `Reset to Default`
+
+### Preview Model
+
+Overlay changes are previewed by showing the real desktop overlay with temporary unsaved values.
+
+This keeps preview behavior aligned with runtime behavior for:
+
+- font metrics
+- bubble height
+- bottom offset
+- centered positioning
+- long-text wrapping and scrolling
+
+When the user closes Settings, cancels, or switches away from the Overlay pane, the temporary preview is dismissed and the configured appearance is restored.
+
+## Long-Text Behavior
+
+### Limited Mode
+
+When `Limit Visible Lines` is enabled:
+
+- The overlay keeps the full transcript text in memory.
+- The visible viewport is capped to `3-5` lines.
+- New content scrolls upward inside the bubble instead of overflowing the frame.
+- The bubble height remains stable within the configured visible-line window.
+
+This keeps the UI compact while preserving the full transcript for later model processing.
+
+### Unlimited Mode
+
+When `Limit Visible Lines` is disabled:
+
+- The overlay expands to fit the full current live transcript.
+- Text still wraps inside the bubble width and does not spill outside the bubble frame.
+
+### Visual Polish
+
+To avoid rough edges during long dictation:
+
+- internal paddings scale with the active font line height
+- bubble height is measured from actual text layout rather than fixed constants
+- previous dark edge artifacts and fade masks were removed
+
+## Runtime Layout Rules
+
+The overlay frame remains horizontally centered:
+
+- `x = midX(visibleFrame) - overlayWidth / 2`
+- `y = minY(visibleFrame) + configuredBottomMargin`
+
+The overlay width continues to grow based on text content up to the runtime maximum width.
+
+When line limiting is enabled, the visible text viewport height is derived from the configured number of measured text lines. When line limiting is disabled, the bubble grows to the measured full text height.
+
+## Configuration
+
+Overlay settings are stored in `~/.koe/config.yaml`:
+
+```yaml
+overlay:
+  font_family: "system"
+  font_size: 13
+  bottom_margin: 10
+  limit_visible_lines: true
+  max_visible_lines: 3
+```
+
+Rules:
+
+- `font_family`
+  - string
+  - `"system"` uses the platform system font
+- `font_size`
+  - numeric
+  - clamped to `12...28`
+- `bottom_margin`
+  - numeric
+  - clamped to `0...180`
+- `limit_visible_lines`
+  - boolean
+  - default `true`
+- `max_visible_lines`
+  - numeric
+  - clamped to `3...5`
+
+## Architecture Summary
+
+### Rust
+
+`koe-core/src/config.rs`
+
+- adds `OverlaySection`
+- adds defaults for font family, text size, bottom margin, and long-text settings
+- includes overlay defaults in generated config text and tests
+
+### Objective-C Runtime Overlay
+
+`KoeApp/Koe/Overlay/SPOverlayPanel.{h,m}`
+
+- loads overlay appearance from config
+- exposes temporary preview APIs for Settings
+- measures text height with TextKit-backed layout
+- supports capped visible-line scrolling for long live transcripts
+- recalculates padding and bubble geometry from the selected font
+
+### Objective-C Settings UI
+
+`KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m`
+
+- adds the Overlay pane and controls
+- lists available system font families
+- pushes unsaved control values into the real overlay preview
+- saves overlay config back to `config.yaml`
+
+### App Delegate
+
+`KoeApp/Koe/AppDelegate/SPAppDelegate.m`
+
+- reloads overlay appearance after config saves
+- reloads overlay appearance when config file changes are detected
+
+## Result
+
+The overlay now behaves like a configurable product surface instead of a fixed hard-coded component, while staying visually consistent with the live runtime experience.

--- a/docs/superpowers/specs/2026-04-09-overlay-triggermode-ui-design.md
+++ b/docs/superpowers/specs/2026-04-09-overlay-triggermode-ui-design.md
@@ -35,12 +35,12 @@ After the user releases the trigger key, the overlay transitions through ASR/LLM
 Dynamic based on character count of the final text:
 
 ```
-linger_seconds = clamp(char_count * 0.05, 1.5, 5.0)
+linger_seconds = clamp(char_count * 0.03, 0.8, 2.5)
 ```
 
-- < 30 chars: 1.5s
-- 30-100 chars: 1.5s-5.0s (linear)
-- > 100 chars: 5.0s cap
+- < 27 chars: 0.8s
+- 27-83 chars: 0.8s-2.5s (linear)
+- > 83 chars: 2.5s cap
 
 #### Implementation Changes
 

--- a/docs/superpowers/specs/2026-04-09-overlay-triggermode-ui-design.md
+++ b/docs/superpowers/specs/2026-04-09-overlay-triggermode-ui-design.md
@@ -1,0 +1,176 @@
+# Overlay Flow, Trigger Mode, and UI Modernization
+
+**Date:** 2026-04-09
+**Status:** Approved
+
+## Overview
+
+Three improvements to the Koe voice input experience:
+
+1. **Overlay full-lifecycle display** — keep the overlay visible through ASR finalization and LLM correction, showing results to the user before dismissing.
+2. **Trigger mode toggle** — add a config option and UI control to switch between "hold" (press-and-hold) and "toggle" (tap-to-start/stop) trigger modes.
+3. **UI modernization** — redesign the Settings window panels in an Arc Browser-inspired style with card-based grouping. Start with Controls panel as pilot.
+
+## 1. Overlay Full-Lifecycle Display
+
+### Problem
+
+After the user releases the trigger key, the overlay transitions through ASR/LLM states but never shows the actual recognized or corrected text. The overlay goes from interim ASR text directly to "Pasting..." and disappears. Users have no visibility into what was recognized or corrected.
+
+### Design
+
+#### Phase Timeline
+
+| Phase | Indicator Color | Status Text | Content Area |
+|-------|----------------|-------------|--------------|
+| Recording | Red (#FF5252) | Listening... | Real-time ASR interim text (unchanged) |
+| ASR finalizing | Orange (#FFC71C) | Recognizing... | Last interim text preserved |
+| LLM correcting | Blue (#46C8FF) | Optimizing... | Final ASR text displayed |
+| LLM complete | Green (#4DD74D) | Done | Corrected text displayed |
+| Pasting + linger | Green (#4DD74D) | Done | Corrected text stays visible |
+| Dismiss | — | — | Fade out |
+
+#### Linger Duration
+
+Dynamic based on character count of the final text:
+
+```
+linger_seconds = clamp(char_count * 0.05, 1.5, 5.0)
+```
+
+- < 30 chars: 1.5s
+- 30-100 chars: 1.5s-5.0s (linear)
+- > 100 chars: 5.0s cap
+
+#### Implementation Changes
+
+**Rust side (koe-core/src/lib.rs):**
+- After ASR finalization completes, call a new FFI callback `invoke_asr_final_text(token, text)` to send the final ASR text to ObjC before starting LLM correction.
+- After LLM correction completes, the existing `invoke_final_text_ready` continues to deliver the corrected text.
+
+**ObjC side (SPRustBridge + SPAppDelegate):**
+- Add `on_asr_final_text` callback to `SPCallbacks` struct.
+- In `rustBridgeDidReceiveAsrFinalText:`, call `overlayPanel.updateInterimText(text)` so the ASR result is shown during the "Optimizing..." phase.
+- In `rustBridgeDidReceiveFinalText:`, update the overlay with corrected text and set state to a new "done" state (green checkmark + text visible).
+- After paste completes, start linger timer based on text length, then fade out.
+
+**SPOverlayPanel:**
+- Add `SPOverlayModeSuccess` variant that shows both checkmark and text content (currently success mode only shows "Pasting..." with no content text).
+- Rename existing content display logic: `interimText` is shown during recording + ASR phases; after LLM, set it to the corrected text.
+- Add `lingerAndDismiss:` method that waits N seconds then fades out.
+
+## 2. Trigger Mode Toggle
+
+### Problem
+
+The hotkey monitor already supports both hold and tap modes (180ms threshold), but both are always active with no user control. Users may want to use only one mode.
+
+### Design
+
+#### Config
+
+```yaml
+hotkey:
+  trigger_key: "fn"
+  cancel_key: "left_option"
+  trigger_mode: "hold"  # "hold" | "toggle"
+```
+
+Default: `"hold"` (current default behavior — press and hold to record).
+
+#### Behavior
+
+| Mode | Short press (< 180ms) | Long press (>= 180ms) |
+|------|-----------------------|-----------------------|
+| `hold` | Ignored (no action) | Start recording; release = stop |
+| `toggle` | Tap to start; tap again to stop | Also starts recording; release = stop |
+
+#### Implementation Changes
+
+**Rust side (koe-core/src/config.rs):**
+- Add `trigger_mode` field to hotkey config section, with `"hold"` default.
+- Validate: must be `"hold"` or `"toggle"`.
+
+**ObjC side (SPHotkeyMonitor):**
+- Add `triggerMode` property (enum: `SPTriggerModeHold`, `SPTriggerModeToggle`).
+- In `holdTimerFired()`: always proceed (both modes support hold).
+- In `handleTriggerUp()` from `SPHotkeyStatePending` (short press): check mode.
+  - `hold`: transition back to Idle, do not start recording.
+  - `toggle`: transition to `SPHotkeyStateRecordingToggle`, call `hotkeyMonitorDidDetectTapStart`.
+- SPAppDelegate reads config on launch and on config change, sets `hotkeyMonitor.triggerMode`.
+
+**UI (SPSetupWizardWindowController):**
+- Add `Trigger Mode` popup in Controls panel between Trigger Key and Cancel Key.
+- Two items: "Hold (Press & Hold)" and "Toggle (Tap to Start/Stop)".
+- Saves to `hotkey.trigger_mode`.
+
+## 3. UI Modernization (Controls Panel Pilot)
+
+### Problem
+
+Current Settings UI uses traditional macOS Preferences style with label-left / control-right two-column layout. Feels dated compared to modern macOS apps.
+
+### Design Direction
+
+Arc Browser-inspired: light background, white rounded-corner card groups, clean separation, generous spacing.
+
+#### Visual Spec
+
+- **Window background:** Light gray (#F5F5F7)
+- **Card background:** White (#FFFFFF)
+- **Card corner radius:** 12pt
+- **Card shadow:** None (rely on background contrast)
+- **Card inner padding:** 16pt horizontal, 0pt vertical (rows handle their own padding)
+- **Card outer margin:** 24pt from window edges, 16pt between cards
+- **Row height:** 44pt
+- **Row separator:** 1px line, color #E5E5EA, inset 16pt from left
+- **Row label:** SF Pro Text 13pt regular, left-aligned, #1D1D1F
+- **Row control:** Right-aligned within row
+- **Group title:** SF Pro Text 12pt semibold, uppercase, #86868B, 8pt above card
+
+#### Controls Panel Layout
+
+```
+Group: "TRIGGER"
+  Row: Trigger Key       [NSPopUpButton]
+  ---
+  Row: Trigger Mode      [NSPopUpButton]
+  ---
+  Row: Cancel Key        [NSPopUpButton]
+
+Group: "FEEDBACK SOUNDS"
+  Row: Recording starts  [NSSwitch]
+  ---
+  Row: Recording stops   [NSSwitch]
+  ---
+  Row: Error occurs      [NSSwitch]
+```
+
+#### Implementation Approach
+
+Create reusable helper methods for the card-based layout so other panels can adopt later:
+
+- `cardViewWithRows:title:width:` — builds a card NSView with title and row subviews.
+- `cardRow:control:` — builds a single row with label + control.
+- `cardSeparator:` — builds a 1px separator line.
+
+Existing checkboxes replaced with `NSSwitch` for a more modern look (available macOS 10.15+).
+
+#### Migration Plan
+
+1. **Phase 1 (this PR):** Controls panel only, plus shared card helpers.
+2. **Phase 2 (future):** Migrate ASR, LLM, Dictionary, Prompt, About panels.
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `koe-core/src/config.rs` | Add `trigger_mode` field |
+| `koe-core/src/lib.rs` | Add `invoke_asr_final_text` callback, linger logic |
+| `koe-core/src/ffi.rs` | Add `on_asr_final_text` to callbacks struct |
+| `koe-core/src/session.rs` | No changes needed (states already exist) |
+| `KoeApp/Koe/Bridge/SPRustBridge.h/.m` | Add `on_asr_final_text` callback, delegate method |
+| `KoeApp/Koe/AppDelegate/SPAppDelegate.m` | Handle new callback, linger timer, trigger mode config |
+| `KoeApp/Koe/Overlay/SPOverlayPanel.h/.m` | Show text in success mode, add `lingerAndDismiss:` |
+| `KoeApp/Koe/Hotkey/SPHotkeyMonitor.h/.m` | Add `triggerMode` property, gate tap behavior |
+| `KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m` | New card-based Controls panel, trigger mode UI |

--- a/docs/superpowers/specs/2026-04-09-prompt-templates-design.md
+++ b/docs/superpowers/specs/2026-04-09-prompt-templates-design.md
@@ -1,0 +1,152 @@
+# Prompt Templates Selection Feature
+
+**Date:** 2026-04-09
+**Status:** Approved
+
+## Overview
+
+After the default LLM correction and auto-paste, the overlay stays visible and shows optional prompt template buttons. Users can press a number key (1-9) or click a button to rewrite the ASR text with a different prompt (e.g., translate, tweet style, Xiaohongshu style). The rewritten text is copied to clipboard (not auto-pasted).
+
+## Flow
+
+1. Default flow completes: ASR → LLM correction → auto-paste → Overlay shows corrected text
+2. If `prompt_templates` are configured, Overlay expands to show a button row: `[1] 翻译  [2] 推文  [3] 小红书`
+3. User can:
+   - **Do nothing** → Overlay disappears after linger time (extended to 4s when templates are configured)
+   - **Press number key 1-9** → Triggers rewrite with that template
+   - **Click a button** → Same as pressing the number key
+4. On rewrite trigger:
+   - Overlay switches to "Rewriting..." (processing mode, blue)
+   - Rust calls LLM with the template's system_prompt + ASR original text
+   - Result is copied to clipboard
+   - Overlay shows rewritten text + "Copied" indicator (green)
+   - Overlay lingers then disappears
+
+## Configuration
+
+```yaml
+prompt_templates:
+  - name: "翻译为英文"
+    shortcut: 1
+    system_prompt: "将用户的语音输入翻译为流畅的英文。保持原意，不要添加额外内容。只输出翻译结果。"
+
+  - name: "推文风格"
+    shortcut: 2
+    system_prompt: "将用户的语音输入改写为适合发 Twitter/X 的简短推文。280字符以内，可适当加emoji。只输出推文内容。"
+
+  - name: "小红书风格"
+    shortcut: 3
+    system_prompt: "将用户的语音输入改写为适合小红书的帖子风格。加上合适的emoji和标题，语气活泼亲切。只输出帖子内容。"
+```
+
+Fields:
+- `name`: Display name shown on button
+- `shortcut`: Number key 1-9
+- `system_prompt`: Inline system prompt text (mutually exclusive with `system_prompt_path`)
+- `system_prompt_path`: Path to prompt file, relative to `~/.koe/` (optional, alternative to inline)
+
+Max 9 templates. User prompt reuses the default `user_prompt.txt` template with `{{asr_text}}` placeholder. Dictionary entries and interim history are also passed.
+
+## Architecture
+
+### Rust Side
+
+**Config** (`config.rs`):
+- New `prompt_templates: Vec<PromptTemplate>` in top-level config
+- `PromptTemplate { name, shortcut, system_prompt, system_prompt_path }`
+
+**FFI** (`ffi.rs`):
+- New callback: `on_rewrite_text_ready: Option<extern "C" fn(token: u64, text: *const c_char)>`
+- New invoke: `invoke_rewrite_text_ready(token, text)`
+
+**Core** (`lib.rs`):
+- New FFI function: `sp_core_rewrite_with_template(template_index: i32, asr_text: *const c_char) -> i32`
+  - Loads the template's system_prompt
+  - Constructs LLM request with template's system_prompt + rendered user_prompt (using asr_text)
+  - Uses the same LLM provider config (base_url, api_key, model, etc.)
+  - Calls `invoke_rewrite_text_ready` with result
+  - Returns 0 on success, -1 on error
+- New FFI function: `sp_core_get_prompt_templates_json() -> *mut c_char`
+  - Returns JSON array: `[{"name":"翻译","shortcut":1}, ...]`
+  - ObjC calls this to know which templates to display
+
+### ObjC Side
+
+**SPOverlayPanel** — Major changes:
+- New mode: `SPOverlayModeTemplateSelection` — shows corrected text + button row
+- `ignoresMouseEvents` set to NO during template selection phase
+- Button row: horizontal strip of rounded-rect buttons with `[N] Name` labels
+- Hover highlight on buttons
+- Click handler calls delegate method
+- New delegate protocol for overlay interaction events
+
+**SPHotkeyMonitor / AppDelegate**:
+- During template selection phase, monitor NSEvent for number keys 1-9
+- Route key press to trigger rewrite
+
+**SPRustBridge**:
+- Register `on_rewrite_text_ready` callback
+- Add `rewriteWithTemplate:asrText:` method
+- Add `promptTemplatesJSON` method
+- New delegate method: `rustBridgeDidReceiveRewriteText:`
+
+**SPAppDelegate**:
+- Store `lastAsrText` from `rustBridgeDidReceiveAsrFinalText:` for rewrite use
+- On template selection (from overlay click or number key):
+  - Call `rustBridge.rewriteWithTemplate:asrText:`
+  - Update overlay to "Rewriting..." state
+- On rewrite text received:
+  - Copy to clipboard (no auto-paste)
+  - Update overlay with rewritten text + "Copied" indicator
+  - Linger then dismiss
+
+### Overlay Visual Design
+
+**Template selection state:**
+```
+╭─────────────────────────────────────────────╮
+│ ✓  校正后的文本显示在这里...                    │
+│─────────────────────────────────────────────│
+│  ❶ 翻译为英文    ❷ 推文风格    ❸ 小红书      │
+╰─────────────────────────────────────────────╯
+```
+
+- Top: green checkmark + corrected text (existing success mode)
+- Separator: 1px line
+- Bottom: button row, 32pt height, buttons with 8pt corner radius
+- Button style: semi-transparent white background (20%), white text, number prefix
+- Hover: background brightens to 40%
+- Active/pressed: background 50%
+
+**Rewriting state:**
+```
+╭─────────────────────────────────────────────╮
+│ ⟳  Rewriting... (翻译为英文)                  │
+╰─────────────────────────────────────────────╯
+```
+
+**Rewrite complete:**
+```
+╭─────────────────────────────────────────────╮
+│ ✓  Rewritten text here... (Copied)          │
+╰─────────────────────────────────────────────╯
+```
+
+### Linger Timing
+
+- When prompt_templates are configured: linger extended to `max(4.0, existing_linger)` seconds
+- During rewrite processing: no auto-dismiss
+- After rewrite complete: standard linger formula applies
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `koe-core/src/config.rs` | Add `PromptTemplate` struct, `prompt_templates` field |
+| `koe-core/src/ffi.rs` | Add `on_rewrite_text_ready` callback, `invoke_rewrite_text_ready` |
+| `koe-core/src/lib.rs` | Add `sp_core_rewrite_with_template`, `sp_core_get_prompt_templates_json` |
+| `koe-core/src/prompt.rs` | Add helper to load template system_prompt from inline or file |
+| `KoeApp/Koe/Bridge/SPRustBridge.h/.m` | Add rewrite callback, delegate method, bridge methods |
+| `KoeApp/Koe/Overlay/SPOverlayPanel.h/.m` | Add template selection mode, button drawing, click/hover handling, delegate protocol |
+| `KoeApp/Koe/Hotkey/SPHotkeyMonitor.h/.m` | No changes (number key monitoring done via NSEvent in AppDelegate) |
+| `KoeApp/Koe/AppDelegate/SPAppDelegate.m` | Store ASR text, handle template selection, number key monitoring, rewrite flow |

--- a/docs/update-feed.json
+++ b/docs/update-feed.json
@@ -1,22 +1,21 @@
 {
-  "version": "1.0.13",
-  "build": 14,
-  "published_at": "2026-04-05T00:00:00Z",
+  "version": "1.0.14",
+  "build": 15,
+  "published_at": "2026-04-09T00:00:00Z",
   "minimum_system_version": "14.0",
-  "download_url": "https://github.com/missuo/koe/releases/download/v1.0.13/Koe-macOS-arm64.zip",
-  "release_notes_url": "https://github.com/missuo/koe/releases/tag/v1.0.13",
+  "download_url": "https://github.com/missuo/koe/releases/download/v1.0.14/Koe-macOS-arm64.zip",
+  "release_notes_url": "https://github.com/missuo/koe/releases/tag/v1.0.14",
   "notes": [
-    "Add Apple Speech provider for zero-config on-device ASR (macOS 26+).",
-    "Add custom HTTP headers support for third-party ASR WebSocket endpoints.",
-    "Add no_reasoning_control option to disable LLM thinking/reasoning.",
-    "Move LLM test connection into Rust core for accurate results.",
-    "Fix repeated accessibility permission prompts, add grant actions to menu.",
-    "Fix clipboard not restoring to empty state after dictation.",
-    "Fix state machine race between Rust and ObjC after text delivery.",
-    "Fix audio capture error handling and session startup failures.",
-    "Fix hotkey race window between menu close and quit action.",
-    "Redact transcription text from INFO logs for privacy.",
-    "Atomic config file writes to prevent corruption.",
-    "Centralize workspace dependencies for consistent builds."
+    "Add a full overlay lifecycle that shows ASR final text, corrected text, and optional follow-up template actions.",
+    "Add a Templates settings pane to add, edit, reorder, and hide prompt templates.",
+    "Add overlay rewrite templates with click, hover, and contextual 1-9 shortcuts.",
+    "Add configurable trigger modes for hold-to-talk and tap-to-toggle workflows.",
+    "Add custom shortcut recording for trigger keys, including modifier combinations.",
+    "Simplify hotkeys to a single trigger shortcut that starts and stops recording.",
+    "Reduce the built-in prompt templates to a minimal English-translation starter template.",
+    "Fix template editor state loss and prompt cross-contamination when switching rows.",
+    "Fix overlay template visibility and prompt restoration after creating or switching templates.",
+    "Fix template number shortcuts and recorded trigger combos leaking characters into the focused app.",
+    "Polish Controls, LLM, and Templates settings UI for more consistent native spacing and switches."
   ]
 }

--- a/docs/update-feed.json
+++ b/docs/update-feed.json
@@ -7,10 +7,13 @@
   "release_notes_url": "https://github.com/missuo/koe/releases/tag/v1.0.14",
   "notes": [
     "Add a full overlay lifecycle that shows ASR final text, corrected text, and optional follow-up template actions.",
+    "Add Overlay settings for font family, text size, bottom offset, and long-text line limiting.",
     "Add a Templates settings pane to add, edit, reorder, and hide prompt templates.",
     "Add overlay rewrite templates with click, hover, and contextual 1-9 shortcuts.",
     "Add configurable trigger modes for hold-to-talk and tap-to-toggle workflows.",
     "Add custom shortcut recording for trigger keys, including modifier combinations.",
+    "Preview Overlay style changes directly in the real desktop overlay position instead of an in-window mock preview.",
+    "Improve long live transcript rendering with stable scrolling, dynamic font-based spacing, and cleaner edge treatment.",
     "Simplify hotkeys to a single trigger shortcut that starts and stops recording.",
     "Reduce the built-in prompt templates to a minimal English-translation starter template.",
     "Fix template editor state loss and prompt cross-contamination when switching rows.",

--- a/koe-asr/src/doubaoime.rs
+++ b/koe-asr/src/doubaoime.rs
@@ -26,6 +26,7 @@ const SAMPLE_RATE: u32 = 16000;
 const FRAME_DURATION_MS: u32 = 20;
 const SAMPLES_PER_FRAME: usize = (SAMPLE_RATE * FRAME_DURATION_MS / 1000) as usize; // 320
 const BYTES_PER_FRAME: usize = SAMPLES_PER_FRAME * 2; // 640
+const TOKEN_REFRESH_INTERVAL_MS: u64 = 12 * 60 * 60 * 1000;
 
 // ─── Protobuf Encoding/Decoding ────────────────────────────────────
 
@@ -219,6 +220,23 @@ struct DeviceCredentials {
     clientudid: String,
     #[serde(default)]
     token: String,
+    #[serde(default)]
+    token_updated_at_ms: u64,
+}
+
+fn unix_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn should_refresh_token(creds: &DeviceCredentials) -> bool {
+    if creds.token.is_empty() || creds.token_updated_at_ms == 0 {
+        return true;
+    }
+
+    unix_timestamp_ms().saturating_sub(creds.token_updated_at_ms) >= TOKEN_REFRESH_INTERVAL_MS
 }
 
 fn generate_cdid() -> String {
@@ -420,6 +438,7 @@ async fn register_device(http: &reqwest::Client) -> Result<DeviceCredentials> {
         openudid,
         clientudid,
         token: String::new(),
+        token_updated_at_ms: 0,
     })
 }
 
@@ -494,23 +513,9 @@ async fn get_asr_token(http: &reqwest::Client, device_id: &str, cdid: &str) -> R
 }
 
 async fn ensure_credentials(credential_path: &Path) -> Result<DeviceCredentials> {
-    // Try loading from cache
-    if let Some(creds) = load_credentials(credential_path) {
-        if !creds.device_id.is_empty() && !creds.token.is_empty() {
-            log::info!(
-                "[DoubaoIME] Using cached credentials (device_id={})",
-                creds.device_id
-            );
-            return Ok(creds);
-        }
-    }
-
     let http = reqwest::Client::new();
-
-    // Check if we have a cached device_id but no token
     let mut creds = if let Some(creds) = load_credentials(credential_path) {
         if !creds.device_id.is_empty() {
-            log::info!("[DoubaoIME] Cached device_id found, refreshing token...");
             creds
         } else {
             register_device(&http).await?
@@ -519,18 +524,44 @@ async fn ensure_credentials(credential_path: &Path) -> Result<DeviceCredentials>
         register_device(&http).await?
     };
 
-    // Get token
-    let token = get_asr_token(&http, &creds.device_id, &creds.cdid).await?;
-    creds.token = token;
+    if !should_refresh_token(&creds) {
+        log::info!(
+            "[DoubaoIME] Using cached credentials (device_id={}, token_age={}s)",
+            creds.device_id,
+            unix_timestamp_ms()
+                .saturating_sub(creds.token_updated_at_ms)
+                / 1000
+        );
+        return Ok(creds);
+    }
 
-    // Save
-    save_credentials(credential_path, &creds)?;
     log::info!(
-        "[DoubaoIME] Credentials saved to {}",
-        credential_path.display()
+        "[DoubaoIME] Refreshing ASR token for device_id={}",
+        creds.device_id
     );
 
-    Ok(creds)
+    match get_asr_token(&http, &creds.device_id, &creds.cdid).await {
+        Ok(token) => {
+            creds.token = token;
+            creds.token_updated_at_ms = unix_timestamp_ms();
+            save_credentials(credential_path, &creds)?;
+            log::info!(
+                "[DoubaoIME] Credentials saved to {}",
+                credential_path.display()
+            );
+            Ok(creds)
+        }
+        Err(err) => {
+            if !creds.token.is_empty() {
+                log::warn!(
+                    "[DoubaoIME] Token refresh failed, falling back to cached token: {err}"
+                );
+                Ok(creds)
+            } else {
+                Err(err)
+            }
+        }
+    }
 }
 
 // ─── Opus Encoder ──────────────────────────────────────────────────

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -15,6 +15,23 @@ pub struct Config {
     pub dictionary: DictionarySection,
     #[serde(default)]
     pub hotkey: HotkeySection,
+    #[serde(default)]
+    pub prompt_templates: Vec<PromptTemplate>,
+}
+
+/// A named prompt template selectable from the overlay UI.
+#[derive(Debug, Deserialize, Clone)]
+pub struct PromptTemplate {
+    /// Display name shown on the overlay button
+    pub name: String,
+    /// Shortcut key number (1-9)
+    pub shortcut: u8,
+    /// Inline system prompt text (mutually exclusive with system_prompt_path)
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    /// Path to system prompt file, relative to ~/.koe/ (alternative to inline)
+    #[serde(default)]
+    pub system_prompt_path: Option<String>,
 }
 
 // ─── ASR V2 Configuration ───────────────────────────────────────────
@@ -634,6 +651,27 @@ fn resolve_path(p: &str) -> PathBuf {
         path.to_path_buf()
     } else {
         config_dir().join(path)
+    }
+}
+
+impl PromptTemplate {
+    /// Resolve the system prompt: inline text takes priority, then file path.
+    pub fn resolve_system_prompt(&self) -> Option<String> {
+        if let Some(ref text) = self.system_prompt {
+            if !text.is_empty() {
+                return Some(text.clone());
+            }
+        }
+        if let Some(ref path) = self.system_prompt_path {
+            let resolved = resolve_path(path);
+            if let Ok(content) = std::fs::read_to_string(&resolved) {
+                let trimmed = content.trim().to_string();
+                if !trimmed.is_empty() {
+                    return Some(trimmed);
+                }
+            }
+        }
+        None
     }
 }
 

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -1,5 +1,5 @@
 use crate::errors::{KoeError, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 /// Root configuration structure matching ~/.koe/config.yaml
@@ -20,7 +20,7 @@ pub struct Config {
 }
 
 /// A named prompt template selectable from the overlay UI.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PromptTemplate {
     /// Display name shown on the overlay button
     pub name: String,
@@ -1000,6 +1000,11 @@ pub fn config_get(key_path: &str) -> Result<String> {
         _ => String::new(),
     };
     Ok(s)
+}
+
+/// Write serialized YAML to config.yaml atomically.
+pub fn atomic_write_config(data: &str) -> Result<()> {
+    atomic_write_file(&config_path(), data)
 }
 
 /// Write data to a file atomically: write to a temp sibling, then rename.

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -332,6 +332,10 @@ pub struct HotkeySection {
         deserialize_with = "deserialize_string_or_int"
     )]
     pub cancel_key: String,
+
+    /// Trigger mode: "hold" (press-and-hold, default) or "toggle" (tap to start/stop).
+    #[serde(default = "default_trigger_mode")]
+    pub trigger_mode: String,
 }
 
 /// Resolved hotkey parameters for the native side
@@ -552,6 +556,10 @@ fn default_trigger_key() -> String {
 
 fn default_cancel_key() -> String {
     "left_option".into()
+}
+
+fn default_trigger_mode() -> String {
+    "hold".into()
 }
 
 fn default_cancel_key_for_trigger(trigger_key: &str) -> &'static str {

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub dictionary: DictionarySection,
     #[serde(default)]
     pub hotkey: HotkeySection,
+    #[serde(default)]
+    pub overlay: OverlaySection,
     #[serde(default = "default_prompt_templates")]
     pub prompt_templates: Vec<PromptTemplate>,
 }
@@ -305,6 +307,20 @@ pub struct FeedbackSection {
 pub struct DictionarySection {
     #[serde(default = "default_dictionary_path")]
     pub path: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct OverlaySection {
+    #[serde(default = "default_overlay_font_family")]
+    pub font_family: String,
+    #[serde(default = "default_overlay_font_size")]
+    pub font_size: u16,
+    #[serde(default = "default_overlay_bottom_margin")]
+    pub bottom_margin: u16,
+    #[serde(default = "default_overlay_limit_visible_lines")]
+    pub limit_visible_lines: bool,
+    #[serde(default = "default_overlay_max_visible_lines")]
+    pub max_visible_lines: u16,
 }
 
 /// Deserialize a YAML value that can be either a string ("fn") or an integer (96)
@@ -657,6 +673,26 @@ fn default_user_prompt_path() -> String {
     "user_prompt.txt".into()
 }
 
+fn default_overlay_font_family() -> String {
+    "system".to_string()
+}
+
+fn default_overlay_font_size() -> u16 {
+    13
+}
+
+fn default_overlay_bottom_margin() -> u16 {
+    10
+}
+
+fn default_overlay_limit_visible_lines() -> bool {
+    true
+}
+
+fn default_overlay_max_visible_lines() -> u16 {
+    3
+}
+
 fn default_translate_to_english_prompt_template() -> PromptTemplate {
     PromptTemplate {
         name: "翻译英文".into(),
@@ -746,6 +782,11 @@ impl Default for FeedbackSection {
     }
 }
 impl Default for DictionarySection {
+    fn default() -> Self {
+        serde_yaml::from_str("{}").unwrap()
+    }
+}
+impl Default for OverlaySection {
     fn default() -> Self {
         serde_yaml::from_str("{}").unwrap()
     }
@@ -1349,6 +1390,13 @@ hotkey:
   # 也可以填 macOS keycode 数字来使用非修饰键，例如 122 (F1)、120 (F2)、99 (F3) 等
   trigger_key: "fn"
 
+overlay:
+  font_family: "system"
+  font_size: 13
+  bottom_margin: 10
+  limit_visible_lines: true
+  max_visible_lines: 3
+
 prompt_templates:
   - name: "翻译英文"
     enabled: true
@@ -1466,6 +1514,11 @@ mod tests {
     fn config_default_includes_single_translation_template() {
         let config = Config::default();
         assert_eq!(config.prompt_templates, default_prompt_templates());
+        assert_eq!(config.overlay.font_family, "system");
+        assert_eq!(config.overlay.font_size, 13);
+        assert_eq!(config.overlay.bottom_margin, 10);
+        assert!(config.overlay.limit_visible_lines);
+        assert_eq!(config.overlay.max_visible_lines, 3);
     }
 
     #[test]

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -15,15 +15,18 @@ pub struct Config {
     pub dictionary: DictionarySection,
     #[serde(default)]
     pub hotkey: HotkeySection,
-    #[serde(default)]
+    #[serde(default = "default_prompt_templates")]
     pub prompt_templates: Vec<PromptTemplate>,
 }
 
 /// A named prompt template selectable from the overlay UI.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct PromptTemplate {
     /// Display name shown on the overlay button
     pub name: String,
+    /// Whether this template should be shown in the overlay selector
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     /// Shortcut key number (1-9)
     pub shortcut: u8,
     /// Inline system prompt text (mutually exclusive with system_prompt_path)
@@ -223,6 +226,8 @@ fn default_apple_speech_locale() -> String {
 pub struct LlmSection {
     #[serde(default = "default_true")]
     pub enabled: bool,
+    #[serde(default = "default_false")]
+    pub prompt_templates_enabled: bool,
     /// LLM provider: "openai" (default) or "mlx"
     #[serde(default = "default_llm_provider")]
     pub provider: String,
@@ -340,19 +345,20 @@ pub struct HotkeySection {
     )]
     pub trigger_key: String,
 
-    /// Cancel key for aborting the current voice input session.
-    /// Options: "fn", "left_option", "right_option", "left_command", "right_command", "left_control", "right_control"
-    /// Or a raw keycode number (e.g. 122 for F1) for non-modifier keys.
-    /// Default: "left_option"
-    #[serde(
-        default = "default_cancel_key",
-        deserialize_with = "deserialize_string_or_int"
-    )]
+    /// Legacy field kept only so older configs still deserialize cleanly.
+    /// Runtime no longer exposes or resolves a separate cancel hotkey.
+    #[serde(default, deserialize_with = "deserialize_string_or_int")]
     pub cancel_key: String,
 
     /// Trigger mode: "hold" (press-and-hold, default) or "toggle" (tap to start/stop).
     #[serde(default = "default_trigger_mode")]
     pub trigger_mode: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HotkeyMatchKind {
+    ModifierOnly = 0,
+    KeyDown = 1,
 }
 
 /// Resolved hotkey parameters for the native side
@@ -362,63 +368,36 @@ pub struct HotkeyParams {
     pub key_code: u16,
     /// Alternative key code (e.g. 179 for Globe key), 0 if none
     pub alt_key_code: u16,
-    /// Modifier flag to check (e.g. NSEventModifierFlagFunction = 0x800000)
+    /// Modifier flag to check. For modifier-only hotkeys this is the key-state
+    /// flag to observe on flagsChanged. For keyDown hotkeys this is the exact
+    /// generic modifier mask required alongside the main key code.
     pub modifier_flag: u64,
-}
-
-/// Resolved trigger/cancel hotkey parameters for the native side.
-#[derive(Debug, Clone, Copy)]
-pub struct ResolvedHotkeyConfig {
-    pub trigger: HotkeyParams,
-    pub cancel: HotkeyParams,
+    /// Whether this hotkey is modifier-only or should be matched on keyDown/up.
+    pub match_kind: HotkeyMatchKind,
 }
 
 impl HotkeySection {
-    pub fn normalized_keys(&self) -> (String, String) {
-        let trigger_key = self.normalized_trigger_key();
-        let cancel_key = self.normalized_cancel_key(&trigger_key);
-        (trigger_key, cancel_key)
+    /// Resolve the configured trigger hotkey into concrete key codes and
+    /// modifier flags for the native side.
+    pub fn resolve(&self) -> HotkeyParams {
+        Self::resolve_key(&self.normalized_trigger_key())
     }
 
-    /// Resolve the configured trigger/cancel hotkeys into concrete key codes
-    /// and modifier flags. If both hotkeys are configured to the same key,
-    /// keep the trigger key and fall back the cancel key to a distinct default.
-    pub fn resolve(&self) -> ResolvedHotkeyConfig {
-        let (trigger_key, cancel_key) = self.normalized_keys();
-        ResolvedHotkeyConfig {
-            trigger: Self::resolve_key(&trigger_key),
-            cancel: Self::resolve_key(&cancel_key),
-        }
-    }
-
-    fn normalized_trigger_key(&self) -> String {
+    pub fn normalized_trigger_key(&self) -> String {
         Self::normalize_trigger_key_name(&self.trigger_key)
-    }
-
-    fn normalized_cancel_key(&self, trigger_key: &str) -> String {
-        let cancel_key = Self::normalize_cancel_key_name(&self.cancel_key);
-        if cancel_key == trigger_key {
-            default_cancel_key_for_trigger(trigger_key).into()
-        } else {
-            cancel_key
-        }
     }
 
     fn normalize_trigger_key_name(value: &str) -> String {
         match value {
             "left_option" | "right_option" | "left_command" | "right_command" | "left_control"
             | "right_control" | "fn" => value.into(),
-            _ if Self::parse_raw_keycode(value).is_some() => value.into(),
+            _ if Self::parse_raw_keycode(value).is_some() => {
+                Self::parse_raw_keycode(value).unwrap().to_string()
+            }
+            _ if Self::parse_hotkey_combo(value).is_some() => {
+                Self::parse_hotkey_combo(value).unwrap().normalized_value
+            }
             _ => default_trigger_key(),
-        }
-    }
-
-    fn normalize_cancel_key_name(value: &str) -> String {
-        match value {
-            "left_option" | "right_option" | "left_command" | "right_command" | "left_control"
-            | "right_control" | "fn" => value.into(),
-            _ if Self::parse_raw_keycode(value).is_some() => value.into(),
-            _ => default_cancel_key(),
         }
     }
 
@@ -436,37 +415,124 @@ impl HotkeySection {
         }
     }
 
+    fn parse_hotkey_combo(value: &str) -> Option<ParsedHotkeyCombo> {
+        if !value.contains('+') {
+            return None;
+        }
+
+        let mut key_code = None;
+        let mut modifier_mask = 0_u64;
+
+        for raw_token in value.split('+') {
+            let token = raw_token.trim().to_ascii_lowercase();
+            if token.is_empty() {
+                return None;
+            }
+
+            if let Some(flag) = Self::combo_modifier_flag(&token) {
+                modifier_mask |= flag;
+                continue;
+            }
+
+            if key_code.is_some() {
+                return None;
+            }
+            key_code = Self::parse_raw_keycode(&token);
+            if key_code.is_none() {
+                return None;
+            }
+        }
+
+        let key_code = key_code?;
+        if modifier_mask == 0 {
+            return None;
+        }
+
+        let mut parts: Vec<String> = Self::combo_modifier_tokens_from_mask(modifier_mask)
+            .into_iter()
+            .map(|token| token.to_string())
+            .collect();
+        parts.push(key_code.to_string());
+
+        Some(ParsedHotkeyCombo {
+            key_code,
+            modifier_mask,
+            normalized_value: parts.join("+"),
+        })
+    }
+
+    fn combo_modifier_flag(token: &str) -> Option<u64> {
+        match token {
+            "command" | "cmd" => Some(0x0010_0000),
+            "option" | "alt" => Some(0x0008_0000),
+            "control" | "ctrl" => Some(0x0004_0000),
+            "shift" => Some(0x0002_0000),
+            "fn" | "function" | "globe" => Some(0x0080_0000),
+            _ => None,
+        }
+    }
+
+    fn combo_modifier_tokens_from_mask(mask: u64) -> Vec<&'static str> {
+        let ordered = [
+            ("command", 0x0010_0000_u64),
+            ("option", 0x0008_0000_u64),
+            ("control", 0x0004_0000_u64),
+            ("shift", 0x0002_0000_u64),
+            ("fn", 0x0080_0000_u64),
+        ];
+
+        ordered
+            .into_iter()
+            .filter_map(|(token, flag)| ((mask & flag) != 0).then_some(token))
+            .collect()
+    }
+
     fn resolve_key(key: &str) -> HotkeyParams {
         match key {
             "left_option" => HotkeyParams {
                 key_code: 58, // kVK_Option
                 alt_key_code: 0,
                 modifier_flag: 0x00000020, // NX_DEVICELALTKEYMASK
+                match_kind: HotkeyMatchKind::ModifierOnly,
             },
             "right_option" => HotkeyParams {
                 key_code: 61, // kVK_RightOption
                 alt_key_code: 0,
                 modifier_flag: 0x00000040, // NX_DEVICERALTKEYMASK
+                match_kind: HotkeyMatchKind::ModifierOnly,
             },
             "left_command" => HotkeyParams {
                 key_code: 55, // kVK_Command
                 alt_key_code: 0,
                 modifier_flag: 0x00000008, // NX_DEVICELCMDKEYMASK
+                match_kind: HotkeyMatchKind::ModifierOnly,
             },
             "right_command" => HotkeyParams {
                 key_code: 54, // kVK_RightCommand
                 alt_key_code: 0,
                 modifier_flag: 0x00000010, // NX_DEVICERCMDKEYMASK
+                match_kind: HotkeyMatchKind::ModifierOnly,
             },
             "left_control" => HotkeyParams {
                 key_code: 59, // kVK_Control
                 alt_key_code: 0,
                 modifier_flag: 0x00000001, // NX_DEVICELCTLKEYMASK
+                match_kind: HotkeyMatchKind::ModifierOnly,
             },
             "right_control" => HotkeyParams {
                 key_code: 62, // kVK_RightControl
                 alt_key_code: 0,
                 modifier_flag: 0x00002000, // NX_DEVICERCTLKEYMASK
+                match_kind: HotkeyMatchKind::ModifierOnly,
+            },
+            _ if Self::parse_hotkey_combo(key).is_some() => {
+                let combo = Self::parse_hotkey_combo(key).unwrap();
+                HotkeyParams {
+                    key_code: combo.key_code,
+                    alt_key_code: 0,
+                    modifier_flag: combo.modifier_mask,
+                    match_kind: HotkeyMatchKind::KeyDown,
+                }
             },
             // Raw keycode (non-modifier key, detected via keyDown/keyUp)
             _ if Self::parse_raw_keycode(key).is_some() => {
@@ -475,6 +541,7 @@ impl HotkeySection {
                     key_code: code,
                     alt_key_code: 0,
                     modifier_flag: 0,
+                    match_kind: HotkeyMatchKind::KeyDown,
                 }
             }
             // "fn" or anything else defaults to Fn/Globe
@@ -482,9 +549,17 @@ impl HotkeySection {
                 key_code: 63,              // kVK_Function (Fn)
                 alt_key_code: 179,         // Globe key on newer keyboards
                 modifier_flag: 0x00800000, // NSEventModifierFlagFunction
+                match_kind: HotkeyMatchKind::ModifierOnly,
             },
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedHotkeyCombo {
+    key_code: u16,
+    modifier_mask: u64,
+    normalized_value: String,
 }
 
 // ─── Defaults ───────────────────────────────────────────────────────
@@ -540,6 +615,9 @@ fn default_final_wait_timeout() -> u64 {
 fn default_true() -> bool {
     true
 }
+fn default_false() -> bool {
+    false
+}
 fn default_top_p() -> f64 {
     1.0
 }
@@ -571,28 +649,75 @@ fn default_trigger_key() -> String {
     "fn".into()
 }
 
-fn default_cancel_key() -> String {
-    "left_option".into()
-}
-
 fn default_trigger_mode() -> String {
     "hold".into()
 }
 
-fn default_cancel_key_for_trigger(trigger_key: &str) -> &'static str {
-    match trigger_key {
-        "fn" => "left_option",
-        "left_option" => "right_option",
-        "right_option" => "left_command",
-        "left_command" => "right_command",
-        "right_command" => "left_control",
-        "left_control" => "right_control",
-        "right_control" => "fn",
-        _ => "left_option",
-    }
-}
 fn default_user_prompt_path() -> String {
     "user_prompt.txt".into()
+}
+
+fn default_translate_to_english_prompt_template() -> PromptTemplate {
+    PromptTemplate {
+        name: "翻译英文".into(),
+        enabled: true,
+        shortcut: 1,
+        system_prompt: Some(
+            "将用户的语音输入翻译为流畅的英文。保持原意，不要添加额外内容。只输出翻译结果。"
+                .into(),
+        ),
+        system_prompt_path: None,
+    }
+}
+
+fn default_prompt_templates() -> Vec<PromptTemplate> {
+    vec![default_translate_to_english_prompt_template()]
+}
+
+fn legacy_default_prompt_templates() -> Vec<PromptTemplate> {
+    vec![
+        default_translate_to_english_prompt_template(),
+        PromptTemplate {
+            name: "繁体中文".into(),
+            enabled: true,
+            shortcut: 2,
+            system_prompt: Some(
+                "将用户的语音输入翻译为流畅的繁体中文。保持原意，不要添加额外内容。只输出翻译结果。"
+                    .into(),
+            ),
+            system_prompt_path: None,
+        },
+        PromptTemplate {
+            name: "推文风格".into(),
+            enabled: true,
+            shortcut: 3,
+            system_prompt: Some(
+                "将用户的语音输入改写为适合发 Twitter/X 的简短推文。280字符以内，可适当加emoji。只输出推文内容。"
+                    .into(),
+            ),
+            system_prompt_path: None,
+        },
+        PromptTemplate {
+            name: "小红书".into(),
+            enabled: true,
+            shortcut: 4,
+            system_prompt: Some(
+                "将用户的语音输入改写为适合小红书的帖子风格。加上合适的emoji和标题，语气活泼亲切。只输出帖子内容。"
+                    .into(),
+            ),
+            system_prompt_path: None,
+        },
+        PromptTemplate {
+            name: "优化技术名词".into(),
+            enabled: true,
+            shortcut: 5,
+            system_prompt: Some(
+                "将用户的语音输入中包含的技术相关名词进行校正。保持原意，不要添加额外内容。只输出校正之后的结果。"
+                    .into(),
+            ),
+            system_prompt_path: None,
+        },
+    ]
 }
 
 impl Default for Config {
@@ -826,9 +951,9 @@ fn migrate_config_v1_to_v2(path: &Path) -> Result<bool> {
     Ok(true)
 }
 
-/// Ensure hotkey config persisted on disk includes both trigger and cancel keys.
-/// This backfills `hotkey.cancel_key` for older configs and normalizes duplicate
-/// trigger/cancel combinations into a valid persisted config.
+/// Ensure hotkey config persisted on disk uses the normalized trigger key.
+/// The legacy `hotkey.cancel_key` field is ignored at runtime and no longer
+/// written back to disk.
 fn normalize_hotkey_config(path: &Path, config: &Config) -> Result<bool> {
     let raw = std::fs::read_to_string(path)
         .map_err(|e| KoeError::Config(format!("read {}: {e}", path.display())))?;
@@ -841,7 +966,7 @@ fn normalize_hotkey_config(path: &Path, config: &Config) -> Result<bool> {
         None => return Ok(false),
     };
 
-    let (normalized_trigger, normalized_cancel) = config.hotkey.normalized_keys();
+    let normalized_trigger = config.hotkey.normalized_trigger_key();
     let hotkey_key = serde_yaml::Value::String("hotkey".into());
 
     let hotkey_value = doc_map
@@ -854,19 +979,13 @@ fn normalize_hotkey_config(path: &Path, config: &Config) -> Result<bool> {
     };
 
     let trigger_key = serde_yaml::Value::String("trigger_key".into());
-    let cancel_key = serde_yaml::Value::String("cancel_key".into());
-
     let stored_trigger = hotkey_map.get(&trigger_key).and_then(|v| v.as_str());
-    let stored_cancel = hotkey_map.get(&cancel_key).and_then(|v| v.as_str());
 
-    if stored_trigger == Some(normalized_trigger.as_str())
-        && stored_cancel == Some(normalized_cancel.as_str())
-    {
+    if stored_trigger == Some(normalized_trigger.as_str()) {
         return Ok(false);
     }
 
     hotkey_map.insert(trigger_key, serde_yaml::Value::String(normalized_trigger));
-    hotkey_map.insert(cancel_key, serde_yaml::Value::String(normalized_cancel));
 
     let yaml_str = serde_yaml::to_string(&doc)
         .map_err(|e| KoeError::Config(format!("serialize normalized config: {e}")))?;
@@ -880,6 +999,47 @@ fn normalize_hotkey_config(path: &Path, config: &Config) -> Result<bool> {
     atomic_write_file(path, &output)?;
 
     log::info!("normalized hotkey config on disk");
+    Ok(true)
+}
+
+/// Replace the previous bundled template set with the new minimal default,
+/// but only when the user still has the legacy built-in templates unchanged.
+fn normalize_prompt_templates_config(path: &Path, config: &Config) -> Result<bool> {
+    if config.prompt_templates != legacy_default_prompt_templates() {
+        return Ok(false);
+    }
+
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| KoeError::Config(format!("read {}: {e}", path.display())))?;
+
+    let mut doc: serde_yaml::Value = serde_yaml::from_str(&raw)
+        .map_err(|e| KoeError::Config(format!("parse {}: {e}", path.display())))?;
+
+    let doc_map = match doc.as_mapping_mut() {
+        Some(map) => map,
+        None => return Ok(false),
+    };
+
+    let yaml_templates = serde_yaml::to_value(default_prompt_templates())
+        .map_err(|e| KoeError::Config(format!("serialize prompt templates: {e}")))?;
+
+    doc_map.insert(
+        serde_yaml::Value::String("prompt_templates".into()),
+        yaml_templates,
+    );
+
+    let yaml_str = serde_yaml::to_string(&doc)
+        .map_err(|e| KoeError::Config(format!("serialize normalized config: {e}")))?;
+
+    let output = format!(
+        "# Koe - Voice Input Tool Configuration\n\
+         # ~/.koe/config.yaml\n\n\
+         {yaml_str}"
+    );
+
+    atomic_write_file(path, &output)?;
+
+    log::info!("normalized legacy prompt templates on disk");
     Ok(true)
 }
 
@@ -910,8 +1070,21 @@ pub fn load_config() -> Result<Config> {
 
     let substituted = substitute_env_vars(&raw);
 
-    let config: Config = serde_yaml::from_str(&substituted)
+    let mut config: Config = serde_yaml::from_str(&substituted)
         .map_err(|e| KoeError::Config(format!("parse {}: {e}", path.display())))?;
+
+    match normalize_prompt_templates_config(&path, &config) {
+        Ok(true) => {
+            log::info!("config file updated with minimal default prompt templates");
+            let raw = std::fs::read_to_string(&path)
+                .map_err(|e| KoeError::Config(format!("read {}: {e}", path.display())))?;
+            let substituted = substitute_env_vars(&raw);
+            config = serde_yaml::from_str(&substituted)
+                .map_err(|e| KoeError::Config(format!("parse {}: {e}", path.display())))?;
+        }
+        Ok(false) => {}
+        Err(e) => log::warn!("prompt templates normalization failed: {e}"),
+    }
 
     match normalize_hotkey_config(&path, &config) {
         Ok(true) => log::info!("config file updated with normalized hotkey settings"),
@@ -1142,6 +1315,7 @@ asr:
 
 llm:
   enabled: true        # set to false to skip LLM correction entirely
+  prompt_templates_enabled: false  # show rewrite template buttons above the overlay after transcription
   provider: "openai"   # "openai" (default) or "mlx" (local Apple Silicon)
 
   # OpenAI-compatible endpoint for text correction
@@ -1174,9 +1348,12 @@ hotkey:
   # 触发键：fn | left_option | right_option | left_command | right_command | left_control | right_control
   # 也可以填 macOS keycode 数字来使用非修饰键，例如 122 (F1)、120 (F2)、99 (F3) 等
   trigger_key: "fn"
-  # 取消键：fn | left_option | right_option | left_command | right_command | left_control | right_control
-  # 也可以填 macOS keycode 数字（不能与触发键重复）
-  cancel_key: "left_option"
+
+prompt_templates:
+  - name: "翻译英文"
+    enabled: true
+    shortcut: 1
+    system_prompt: "将用户的语音输入翻译为流畅的英文。保持原意，不要添加额外内容。只输出翻译结果。"
 "#;
 
 const DEFAULT_DICTIONARY_TXT: &str = r#"# Koe User Dictionary
@@ -1221,80 +1398,99 @@ mod tests {
     }
 
     #[test]
-    fn normalized_keys_dedup_fn() {
-        let h = HotkeySection {
-            trigger_key: "fn".into(),
-            cancel_key: "fn".into(),
-        };
-        let (t, c) = h.normalized_keys();
-        assert_eq!(t, "fn");
-        assert_eq!(c, "left_option");
-    }
-
-    #[test]
-    fn normalized_keys_dedup_left_option() {
-        // Status bar used to fallback to "fn" here, but core uses "right_option"
-        let h = HotkeySection {
-            trigger_key: "left_option".into(),
-            cancel_key: "left_option".into(),
-        };
-        let (t, c) = h.normalized_keys();
-        assert_eq!(t, "left_option");
-        assert_eq!(c, "right_option");
-    }
-
-    #[test]
-    fn normalized_keys_dedup_right_option() {
-        let h = HotkeySection {
-            trigger_key: "right_option".into(),
-            cancel_key: "right_option".into(),
-        };
-        let (t, c) = h.normalized_keys();
-        assert_eq!(t, "right_option");
-        assert_eq!(c, "left_command");
-    }
-
-    #[test]
-    fn normalized_keys_distinct_passes_through() {
-        let h = HotkeySection {
-            trigger_key: "fn".into(),
-            cancel_key: "right_command".into(),
-        };
-        let (t, c) = h.normalized_keys();
-        assert_eq!(t, "fn");
-        assert_eq!(c, "right_command");
-    }
-
-    #[test]
     fn normalized_keys_invalid_trigger_falls_back_to_fn() {
         let h = HotkeySection {
             trigger_key: "nonexistent".into(),
             cancel_key: "left_option".into(),
+            trigger_mode: "hold".into(),
         };
-        let (t, c) = h.normalized_keys();
-        assert_eq!(t, "fn");
-        assert_eq!(c, "left_option");
+        assert_eq!(h.normalized_trigger_key(), "fn");
     }
 
     #[test]
-    fn normalize_hotkey_config_backfills_missing_cancel_key() {
+    fn normalize_hotkey_config_normalizes_trigger_only() {
         let path = temp_config_path("hotkey-config");
-        fs::write(&path, "hotkey:\n  trigger_key: left_option\n").unwrap();
+        fs::write(&path, "hotkey:\n  trigger_key: 0x7A\n").unwrap();
 
         let config = Config {
             hotkey: HotkeySection {
-                trigger_key: "left_option".into(),
+                trigger_key: "0x7A".into(),
                 cancel_key: "".into(),
+                trigger_mode: "hold".into(),
             },
             ..Config::default()
         };
 
         let changed = normalize_hotkey_config(&path, &config).unwrap();
         let output = fs::read_to_string(&path).unwrap();
+        let doc: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        let hotkey = doc.get("hotkey").and_then(|v| v.as_mapping()).unwrap();
+        let trigger = hotkey
+            .get(serde_yaml::Value::String("trigger_key".into()))
+            .and_then(|v| v.as_str())
+            .unwrap();
 
         assert!(changed);
-        assert!(output.contains("trigger_key: left_option"));
-        assert!(output.contains("cancel_key: right_option"));
+        assert_eq!(trigger, "122");
+        assert!(!output.contains("cancel_key:"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn normalized_keys_canonicalize_combo() {
+        let h = HotkeySection {
+            trigger_key: "shift+cmd+49".into(),
+            cancel_key: "command+shift+49".into(),
+            trigger_mode: "hold".into(),
+        };
+        assert_eq!(h.normalized_trigger_key(), "command+shift+49");
+    }
+
+    #[test]
+    fn resolve_combo_hotkey_uses_keydown_match_kind() {
+        let h = HotkeySection {
+            trigger_key: "cmd+shift+49".into(),
+            cancel_key: "option+53".into(),
+            trigger_mode: "hold".into(),
+        };
+        let resolved = h.resolve();
+
+        assert_eq!(resolved.key_code, 49);
+        assert_eq!(resolved.alt_key_code, 0);
+        assert_eq!(resolved.modifier_flag, 0x0010_0000 | 0x0002_0000);
+        assert_eq!(resolved.match_kind, HotkeyMatchKind::KeyDown);
+    }
+
+    #[test]
+    fn config_default_includes_single_translation_template() {
+        let config = Config::default();
+        assert_eq!(config.prompt_templates, default_prompt_templates());
+    }
+
+    #[test]
+    fn normalize_prompt_templates_config_replaces_legacy_defaults() {
+        let path = temp_config_path("prompt-templates");
+        let mut doc = serde_yaml::Mapping::new();
+        doc.insert(
+            serde_yaml::Value::String("prompt_templates".into()),
+            serde_yaml::to_value(legacy_default_prompt_templates()).unwrap(),
+        );
+        fs::write(&path, serde_yaml::to_string(&serde_yaml::Value::Mapping(doc)).unwrap()).unwrap();
+
+        let config = Config {
+            prompt_templates: legacy_default_prompt_templates(),
+            ..Config::default()
+        };
+
+        let changed = normalize_prompt_templates_config(&path, &config).unwrap();
+        let output = fs::read_to_string(&path).unwrap();
+        let doc: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        let stored_templates: Vec<PromptTemplate> =
+            serde_yaml::from_value(doc.get("prompt_templates").cloned().unwrap()).unwrap();
+
+        assert!(changed);
+        assert_eq!(stored_templates, default_prompt_templates());
 
         let _ = fs::remove_file(path);
     }

--- a/koe-core/src/ffi.rs
+++ b/koe-core/src/ffi.rs
@@ -169,14 +169,12 @@ pub struct SPHotkeyConfig {
     pub trigger_key_code: u16,
     /// Trigger hotkey alternative key code (e.g. 179 for Globe key), 0 if none
     pub trigger_alt_key_code: u16,
-    /// Trigger hotkey modifier flag (e.g. 0x800000 for Fn)
+    /// Trigger hotkey modifier flag. For modifier-only hotkeys this is the
+    /// observed key-state flag; for keyDown hotkeys this is the required
+    /// generic modifier mask.
     pub trigger_modifier_flag: u64,
-    /// Cancel hotkey primary key code
-    pub cancel_key_code: u16,
-    /// Cancel hotkey alternative key code, 0 if none
-    pub cancel_alt_key_code: u16,
-    /// Cancel hotkey modifier flag
-    pub cancel_modifier_flag: u64,
+    /// Trigger hotkey match kind: 0 = modifier-only, 1 = keyDown/keyUp.
+    pub trigger_match_kind: u8,
     /// Trigger mode: 0 = hold (press-and-hold), 1 = toggle (tap to start/stop)
     pub trigger_mode: u8,
 }

--- a/koe-core/src/ffi.rs
+++ b/koe-core/src/ffi.rs
@@ -48,6 +48,9 @@ pub struct SPCallbacks {
     /// Called when an interim (partial) ASR result arrives during recording
     /// text is a UTF-8 C string, caller must NOT free it
     pub on_interim_text: Option<extern "C" fn(token: u64, text: *const c_char)>,
+    /// Called when ASR finalization completes with the final recognized text,
+    /// before LLM correction begins. Used to display ASR result in the overlay.
+    pub on_asr_final_text: Option<extern "C" fn(token: u64, text: *const c_char)>,
 }
 
 static CALLBACKS: Mutex<Option<SPCallbacks>> = Mutex::new(None);
@@ -126,6 +129,16 @@ pub fn invoke_interim_text(token: u64, text: &str) {
     }
 }
 
+pub fn invoke_asr_final_text(token: u64, text: &str) {
+    let cb = CALLBACKS.lock().unwrap();
+    if let Some(ref cbs) = *cb {
+        if let Some(f) = cbs.on_asr_final_text {
+            let c_text = CString::new(text).unwrap_or_default();
+            f(token, c_text.as_ptr());
+        }
+    }
+}
+
 /// Feedback configuration exposed to the Obj-C layer
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -151,6 +164,8 @@ pub struct SPHotkeyConfig {
     pub cancel_alt_key_code: u16,
     /// Cancel hotkey modifier flag
     pub cancel_modifier_flag: u64,
+    /// Trigger mode: 0 = hold (press-and-hold), 1 = toggle (tap to start/stop)
+    pub trigger_mode: u8,
 }
 
 /// Helper to convert a C string pointer to a Rust &str

--- a/koe-core/src/ffi.rs
+++ b/koe-core/src/ffi.rs
@@ -51,6 +51,9 @@ pub struct SPCallbacks {
     /// Called when ASR finalization completes with the final recognized text,
     /// before LLM correction begins. Used to display ASR result in the overlay.
     pub on_asr_final_text: Option<extern "C" fn(token: u64, text: *const c_char)>,
+    /// Called when a rewrite (using an alternative prompt template) completes.
+    /// text is a UTF-8 C string, caller must NOT free it.
+    pub on_rewrite_text_ready: Option<extern "C" fn(token: u64, text: *const c_char)>,
 }
 
 static CALLBACKS: Mutex<Option<SPCallbacks>> = Mutex::new(None);
@@ -133,6 +136,16 @@ pub fn invoke_asr_final_text(token: u64, text: &str) {
     let cb = CALLBACKS.lock().unwrap();
     if let Some(ref cbs) = *cb {
         if let Some(f) = cbs.on_asr_final_text {
+            let c_text = CString::new(text).unwrap_or_default();
+            f(token, c_text.as_ptr());
+        }
+    }
+}
+
+pub fn invoke_rewrite_text_ready(token: u64, text: &str) {
+    let cb = CALLBACKS.lock().unwrap();
+    if let Some(ref cbs) = *cb {
+        if let Some(f) = cbs.on_rewrite_text_ready {
             let c_text = CString::new(text).unwrap_or_default();
             f(token, c_text.as_ptr());
         }

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -11,9 +11,9 @@ pub mod telemetry;
 
 use crate::config::Config;
 use crate::ffi::{
-    cstr_to_str, invoke_final_text_ready, invoke_interim_text, invoke_session_error,
-    invoke_session_ready, invoke_session_warning, invoke_state_changed, SPCallbacks,
-    SPFeedbackConfig, SPHotkeyConfig, SPSessionContext, SPSessionMode,
+    cstr_to_str, invoke_asr_final_text, invoke_final_text_ready, invoke_interim_text,
+    invoke_session_error, invoke_session_ready, invoke_session_warning, invoke_state_changed,
+    SPCallbacks, SPFeedbackConfig, SPHotkeyConfig, SPSessionContext, SPSessionMode,
 };
 #[cfg(feature = "mlx")]
 use crate::llm::mlx::MlxLlmProvider;
@@ -772,6 +772,10 @@ async fn run_session(
             session.asr_text = Some(asr_text.clone());
         }
     }
+
+    // Notify ObjC of the final ASR text so the overlay can display it
+    // during the LLM correction phase.
+    invoke_asr_final_text(session_token, &asr_text);
 
     // --- LLM Correction ---
     // Check cancellation before the (potentially slow) LLM call so that an

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -12,8 +12,9 @@ pub mod telemetry;
 use crate::config::Config;
 use crate::ffi::{
     cstr_to_str, invoke_asr_final_text, invoke_final_text_ready, invoke_interim_text,
-    invoke_session_error, invoke_session_ready, invoke_session_warning, invoke_state_changed,
-    SPCallbacks, SPFeedbackConfig, SPHotkeyConfig, SPSessionContext, SPSessionMode,
+    invoke_rewrite_text_ready, invoke_session_error, invoke_session_ready,
+    invoke_session_warning, invoke_state_changed, SPCallbacks, SPFeedbackConfig, SPHotkeyConfig,
+    SPSessionContext, SPSessionMode,
 };
 #[cfg(feature = "mlx")]
 use crate::llm::mlx::MlxLlmProvider;
@@ -67,6 +68,9 @@ struct Core {
     user_prompt_template: String,
     llm_http_client: Client,
     llm_warmup_state: Arc<Mutex<LlmWarmupState>>,
+    /// Session token from the most recent sp_core_session_begin call.
+    /// Used by sp_core_rewrite_with_template to route callbacks.
+    current_session_token: u64,
 }
 
 static CORE: Mutex<Option<Core>> = Mutex::new(None);
@@ -146,6 +150,7 @@ pub unsafe extern "C" fn sp_core_create(config_path: *const c_char) -> i32 {
         user_prompt_template,
         llm_http_client,
         llm_warmup_state: Arc::new(Mutex::new(LlmWarmupState::default())),
+        current_session_token: 0,
     };
 
     let mut global = CORE.lock().unwrap();
@@ -269,6 +274,7 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
     let session = Session::new(context.mode, bundle_id, context.frontmost_pid);
     let session_id = session.id.clone();
     let session_token = context.session_token;
+    core.current_session_token = session_token;
     let mode = context.mode;
 
     // Abort any still-running old session: signal its cancelled flag and close
@@ -537,6 +543,158 @@ pub extern "C" fn sp_core_session_cancel() -> i32 {
         // Drop the audio sender to unblock the session task
         core.audio_tx = None;
     }
+    0
+}
+
+/// Return prompt templates as JSON array.
+/// Each entry: {"name":"...","shortcut":N}
+/// Caller must free with sp_core_free_string().
+#[no_mangle]
+pub extern "C" fn sp_core_get_prompt_templates_json() -> *mut c_char {
+    let global = CORE.lock().unwrap();
+    if let Some(ref core) = *global {
+        let templates: Vec<serde_json::Value> = core
+            .config
+            .prompt_templates
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "name": t.name,
+                    "shortcut": t.shortcut,
+                })
+            })
+            .collect();
+        let json = serde_json::to_string(&templates).unwrap_or_else(|_| "[]".into());
+        CString::new(json).unwrap_or_default().into_raw()
+    } else {
+        CString::new("[]").unwrap_or_default().into_raw()
+    }
+}
+
+/// Rewrite ASR text using a specific prompt template.
+/// template_index is 0-based into the prompt_templates array.
+/// The rewrite runs asynchronously; result delivered via on_rewrite_text_ready callback.
+///
+/// # Safety
+/// `asr_text_ptr` must be a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn sp_core_rewrite_with_template(
+    template_index: i32,
+    asr_text_ptr: *const c_char,
+) -> i32 {
+    let asr_text = match unsafe { cstr_to_str(asr_text_ptr) } {
+        Some(s) => s.to_string(),
+        None => return -1,
+    };
+
+    let global = CORE.lock().unwrap();
+    let core = match global.as_ref() {
+        Some(c) => c,
+        None => return -1,
+    };
+
+    let idx = template_index as usize;
+    let template = match core.config.prompt_templates.get(idx) {
+        Some(t) => t.clone(),
+        None => {
+            log::error!(
+                "sp_core_rewrite_with_template: invalid index {idx}"
+            );
+            return -1;
+        }
+    };
+
+    let template_system_prompt = match template.resolve_system_prompt() {
+        Some(p) => p,
+        None => {
+            log::error!(
+                "sp_core_rewrite_with_template: no system prompt for template '{}'",
+                template.name
+            );
+            return -1;
+        }
+    };
+
+    // Gather LLM config and dependencies
+    let llm_config = core.config.llm.clone();
+    let dictionary = core.dictionary.clone();
+    let user_prompt_template = core.user_prompt_template.clone();
+    let llm_http_client = core.llm_http_client.clone();
+    let session_token = core.current_session_token;
+    let runtime_handle = core.runtime.handle().clone();
+
+    drop(global); // Release lock before spawning
+
+    runtime_handle.spawn(async move {
+        log::info!(
+            "rewrite: using template '{}' with {} chars of ASR text",
+            template.name,
+            asr_text.len()
+        );
+
+        let llm: Box<dyn LlmProvider> = match llm_config.provider.as_str() {
+            #[cfg(feature = "mlx")]
+            "mlx" => {
+                let model_path = config::resolve_model_dir(&llm_config.mlx.model)
+                    .to_string_lossy()
+                    .to_string();
+                Box::new(MlxLlmProvider::new(
+                    model_path,
+                    llm_config.temperature,
+                    llm_config.top_p,
+                    llm_config.max_output_tokens,
+                    llm_config.timeout_ms,
+                ))
+            }
+            _ => Box::new(OpenAiCompatibleProvider::new(
+                llm_http_client,
+                llm_config.base_url.clone(),
+                llm_config.api_key.clone(),
+                llm_config.model.clone(),
+                llm_config.temperature,
+                llm_config.top_p,
+                llm_config.max_output_tokens,
+                llm_config.max_token_parameter,
+                llm_config.no_reasoning_control,
+            )),
+        };
+
+        let candidates = prompt::filter_dictionary_candidates(
+            &dictionary,
+            &asr_text,
+            llm_config.dictionary_max_candidates,
+        );
+        let user_prompt =
+            prompt::render_user_prompt(&user_prompt_template, &asr_text, &candidates, &[]);
+
+        let request = CorrectionRequest {
+            asr_text: asr_text.clone(),
+            dictionary_entries: candidates,
+            system_prompt: template_system_prompt,
+            user_prompt,
+        };
+
+        match llm.correct(&request).await {
+            Ok(result) => {
+                log::info!(
+                    "rewrite: template '{}' produced {} chars",
+                    template.name,
+                    result.len()
+                );
+                invoke_rewrite_text_ready(session_token, &result);
+            }
+            Err(e) => {
+                log::error!("rewrite: template '{}' failed: {e}", template.name);
+                invoke_session_warning(
+                    session_token,
+                    &format!("Rewrite failed: {e}"),
+                );
+                // Fall back to original ASR text
+                invoke_rewrite_text_ready(session_token, &asr_text);
+            }
+        }
+    });
+
     0
 }
 

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -566,6 +566,7 @@ pub extern "C" fn sp_core_get_hotkey_config() -> SPHotkeyConfig {
     let global = CORE.lock().unwrap();
     if let Some(ref core) = *global {
         let params = core.config.hotkey.resolve();
+        let trigger_mode: u8 = if core.config.hotkey.trigger_mode == "toggle" { 1 } else { 0 };
         SPHotkeyConfig {
             trigger_key_code: params.trigger.key_code,
             trigger_alt_key_code: params.trigger.alt_key_code,
@@ -573,6 +574,7 @@ pub extern "C" fn sp_core_get_hotkey_config() -> SPHotkeyConfig {
             cancel_key_code: params.cancel.key_code,
             cancel_alt_key_code: params.cancel.alt_key_code,
             cancel_modifier_flag: params.cancel.modifier_flag,
+            trigger_mode,
         }
     } else {
         SPHotkeyConfig {
@@ -582,6 +584,7 @@ pub extern "C" fn sp_core_get_hotkey_config() -> SPHotkeyConfig {
             cancel_key_code: 58,
             cancel_alt_key_code: 0,
             cancel_modifier_flag: 0x00000020,
+            trigger_mode: 0,
         }
     }
 }

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -1000,10 +1000,11 @@ async fn run_session(
 
     let asr_text = aggregator.best_text().to_string();
     if asr_text.is_empty() {
-        log::warn!("[{session_id}] no ASR text available: no speech recognized");
-        invoke_session_error(session_token, "no speech recognized");
-        invoke_state_changed(session_token, "failed");
+        // A silent recording is a valid no-op, not a user-visible failure.
+        // Exit quietly so the app returns to idle without error sounds or alerts.
+        log::info!("[{session_id}] no ASR text available: treating silent recording as empty result");
         cleanup_session(&session_arc);
+        invoke_state_changed(session_token, "idle");
         return;
     }
 
@@ -1793,10 +1794,10 @@ mod tests {
 
     /// Simulates the post-ASR decision: should the session fail?
     /// Mirrors the logic from run_session after asr.close().
-    fn should_fail_session(asr_error: &Option<String>, asr_text: &str) -> bool {
-        // Fail if there was an error (regardless of accumulated text)
-        // or if there's no text at all
-        asr_error.is_some() || asr_text.is_empty()
+    fn should_fail_session(asr_error: &Option<String>, _asr_text: &str) -> bool {
+        // Only real ASR errors should fail the session.
+        // An empty transcript is treated as a quiet no-op.
+        asr_error.is_some()
     }
 
     #[test]
@@ -1818,7 +1819,7 @@ mod tests {
     }
 
     #[test]
-    fn no_error_no_text_fails() {
-        assert!(should_fail_session(&None, ""));
+    fn no_error_no_text_does_not_fail() {
+        assert!(!should_fail_session(&None, ""));
     }
 }

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -35,6 +35,7 @@ use koe_asr::{MlxConfig, MlxProvider};
 use koe_asr::{SherpaOnnxConfig, SherpaOnnxProvider};
 use reqwest::Client;
 
+use std::collections::HashSet;
 use std::ffi::c_char;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -546,26 +547,38 @@ pub extern "C" fn sp_core_session_cancel() -> i32 {
     0
 }
 
+fn validate_prompt_templates(templates: &[config::PromptTemplate]) -> std::result::Result<(), String> {
+    if templates.len() > 9 {
+        return Err("Prompt templates are limited to 9 entries.".into());
+    }
+
+    let mut used_shortcuts = HashSet::new();
+    for template in templates {
+        if !(1..=9).contains(&template.shortcut) {
+            return Err(format!(
+                "Template '{}' uses invalid shortcut {}. Shortcuts must be between 1 and 9.",
+                template.name, template.shortcut
+            ));
+        }
+        if !used_shortcuts.insert(template.shortcut) {
+            return Err(format!(
+                "Duplicate template shortcut {} detected. Each template needs a unique shortcut.",
+                template.shortcut
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 /// Return prompt templates as JSON array.
-/// Each entry: {"name":"...","shortcut":N}
+/// Each entry mirrors config::PromptTemplate for lossless round-tripping.
 /// Caller must free with sp_core_free_string().
 #[no_mangle]
 pub extern "C" fn sp_core_get_prompt_templates_json() -> *mut c_char {
     let global = CORE.lock().unwrap();
     if let Some(ref core) = *global {
-        let templates: Vec<serde_json::Value> = core
-            .config
-            .prompt_templates
-            .iter()
-            .map(|t| {
-                serde_json::json!({
-                    "name": t.name,
-                    "shortcut": t.shortcut,
-                    "system_prompt": t.system_prompt.as_deref().unwrap_or(""),
-                })
-            })
-            .collect();
-        let json = serde_json::to_string(&templates).unwrap_or_else(|_| "[]".into());
+        let json = serde_json::to_string(&core.config.prompt_templates).unwrap_or_else(|_| "[]".into());
         CString::new(json).unwrap_or_default().into_raw()
     } else {
         CString::new("[]").unwrap_or_default().into_raw()
@@ -592,6 +605,10 @@ pub unsafe extern "C" fn sp_core_set_prompt_templates_json(json_str: *const c_ch
             return -1;
         }
     };
+    if let Err(message) = validate_prompt_templates(&templates) {
+        log::error!("sp_core_set_prompt_templates_json: validation error: {message}");
+        return -1;
+    }
 
     // Update config file
     let path = config::config_path();
@@ -796,7 +813,7 @@ pub extern "C" fn sp_core_get_feedback_config() -> SPFeedbackConfig {
 }
 
 /// Query current hotkey configuration.
-/// Returns key codes and modifier flags for the configured trigger/cancel keys.
+/// Returns key codes and modifier flags for the configured trigger key.
 #[no_mangle]
 pub extern "C" fn sp_core_get_hotkey_config() -> SPHotkeyConfig {
     let global = CORE.lock().unwrap();
@@ -804,12 +821,10 @@ pub extern "C" fn sp_core_get_hotkey_config() -> SPHotkeyConfig {
         let params = core.config.hotkey.resolve();
         let trigger_mode: u8 = if core.config.hotkey.trigger_mode == "toggle" { 1 } else { 0 };
         SPHotkeyConfig {
-            trigger_key_code: params.trigger.key_code,
-            trigger_alt_key_code: params.trigger.alt_key_code,
-            trigger_modifier_flag: params.trigger.modifier_flag,
-            cancel_key_code: params.cancel.key_code,
-            cancel_alt_key_code: params.cancel.alt_key_code,
-            cancel_modifier_flag: params.cancel.modifier_flag,
+            trigger_key_code: params.key_code,
+            trigger_alt_key_code: params.alt_key_code,
+            trigger_modifier_flag: params.modifier_flag,
+            trigger_match_kind: params.match_kind as u8,
             trigger_mode,
         }
     } else {
@@ -817,9 +832,7 @@ pub extern "C" fn sp_core_get_hotkey_config() -> SPHotkeyConfig {
             trigger_key_code: 63,
             trigger_alt_key_code: 179,
             trigger_modifier_flag: 0x00800000,
-            cancel_key_code: 58,
-            cancel_alt_key_code: 0,
-            cancel_modifier_flag: 0x00000020,
+            trigger_match_kind: 0,
             trigger_mode: 0,
         }
     }
@@ -1395,19 +1408,8 @@ pub unsafe extern "C" fn sp_config_set(key_path: *const c_char, value: *const c_
 #[no_mangle]
 pub extern "C" fn sp_config_resolved_trigger_key() -> *mut c_char {
     let key = match config::load_config() {
-        Ok(cfg) => cfg.hotkey.normalized_keys().0,
+        Ok(cfg) => cfg.hotkey.normalized_trigger_key(),
         Err(_) => "fn".into(),
-    };
-    CString::new(key).unwrap_or_default().into_raw()
-}
-
-/// Returns the resolved cancel hotkey name after normalization and dedup.
-/// The caller must free the returned string with sp_core_free_string().
-#[no_mangle]
-pub extern "C" fn sp_config_resolved_cancel_key() -> *mut c_char {
-    let key = match config::load_config() {
-        Ok(cfg) => cfg.hotkey.normalized_keys().1,
-        Err(_) => "left_option".into(),
     };
     CString::new(key).unwrap_or_default().into_raw()
 }
@@ -1454,6 +1456,7 @@ pub unsafe extern "C" fn sp_llm_test(
     // Build an LlmSection that merges UI-editable fields with disk config
     let llm_cfg = config::LlmSection {
         enabled: true,
+        prompt_templates_enabled: cfg.llm.prompt_templates_enabled,
         provider: "openai".into(),
         base_url,
         api_key,

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -561,6 +561,7 @@ pub extern "C" fn sp_core_get_prompt_templates_json() -> *mut c_char {
                 serde_json::json!({
                     "name": t.name,
                     "shortcut": t.shortcut,
+                    "system_prompt": t.system_prompt.as_deref().unwrap_or(""),
                 })
             })
             .collect();
@@ -569,6 +570,83 @@ pub extern "C" fn sp_core_get_prompt_templates_json() -> *mut c_char {
     } else {
         CString::new("[]").unwrap_or_default().into_raw()
     }
+}
+
+/// Set prompt templates from a JSON array string.
+/// Each entry: {"name":"...", "shortcut":N, "system_prompt":"..."}
+/// Writes to config.yaml and reloads config.
+///
+/// # Safety
+/// `json_str` must be a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn sp_core_set_prompt_templates_json(json_str: *const c_char) -> i32 {
+    let json = match unsafe { cstr_to_str(json_str) } {
+        Some(s) => s,
+        None => return -1,
+    };
+
+    let templates: Vec<config::PromptTemplate> = match serde_json::from_str(json) {
+        Ok(t) => t,
+        Err(e) => {
+            log::error!("sp_core_set_prompt_templates_json: parse error: {e}");
+            return -1;
+        }
+    };
+
+    // Update config file
+    let path = config::config_path();
+    let raw = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut root: serde_yaml::Value = if raw.trim().is_empty() {
+        serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+    } else {
+        match serde_yaml::from_str(&raw) {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("sp_core_set_prompt_templates_json: yaml parse error: {e}");
+                return -1;
+            }
+        }
+    };
+
+    // Serialize templates to YAML value
+    let yaml_templates = match serde_yaml::to_value(&templates) {
+        Ok(v) => v,
+        Err(e) => {
+            log::error!("sp_core_set_prompt_templates_json: serialize error: {e}");
+            return -1;
+        }
+    };
+
+    if let Some(mapping) = root.as_mapping_mut() {
+        mapping.insert(
+            serde_yaml::Value::String("prompt_templates".into()),
+            yaml_templates,
+        );
+    }
+
+    let serialized = match serde_yaml::to_string(&root) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("sp_core_set_prompt_templates_json: serialize error: {e}");
+            return -1;
+        }
+    };
+
+    if let Err(e) = config::atomic_write_config(&serialized) {
+        log::error!("sp_core_set_prompt_templates_json: write error: {e}");
+        return -1;
+    }
+
+    // Reload config in core
+    let mut global = CORE.lock().unwrap();
+    if let Some(ref mut core) = *global {
+        match config::load_config() {
+            Ok(cfg) => core.config = cfg,
+            Err(e) => log::error!("sp_core_set_prompt_templates_json: reload error: {e}"),
+        }
+    }
+
+    0
 }
 
 /// Rewrite ASR text using a specific prompt template.

--- a/koe-core/src/model_manager.rs
+++ b/koe-core/src/model_manager.rs
@@ -640,6 +640,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test model".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -714,6 +715,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -757,6 +759,7 @@ mod tests {
         let content = b"some model data";
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -824,6 +827,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -870,6 +874,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -938,6 +943,7 @@ mod tests {
         };
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -988,6 +994,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![
@@ -1044,6 +1051,7 @@ mod tests {
         };
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -1107,6 +1115,7 @@ mod tests {
         };
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {


### PR DESCRIPTION
## Summary
- add a dedicated Overlay settings pane for font family, text size, bottom offset, and visible-line controls
- move Overlay previewing to the real desktop overlay so Settings no longer maintains a divergent mock preview
- polish long live transcript behavior with stable scrolling, dynamic font-aware spacing, and cleaner edge treatment
- keep the earlier template workflow, unified trigger shortcut model, and related release-facing docs in the same branch

## Testing
- cargo test -p koe-core config_default_includes_single_translation_template
- xcodebuild -project KoeApp/Koe.xcodeproj -scheme Koe -configuration Debug CODE_SIGNING_ALLOWED=NO build -quiet