### PR TITLE
fix(app): hide MLX LLM provider on builds without mlx feature

### DIFF
--- a/KoeApp/Koe/Bridge/SPRustBridge.h
+++ b/KoeApp/Koe/Bridge/SPRustBridge.h
@@ -51,6 +51,9 @@ typedef NS_ENUM(NSInteger, SPSessionModeObjC) {
 /// Return supported local provider names (e.g. @[@"mlx", @"sherpa-onnx"]).
 - (NSArray<NSString *> *)supportedLocalProviders;
 
+/// Return supported LLM provider names (e.g. @[@"openai", @"mlx"]).
+- (NSArray<NSString *> *)supportedLlmProviders;
+
 /// Scan all models and return array of dictionaries.
 /// Each dict: path, provider, description, repo, total_size, status (0/1/2)
 - (NSArray<NSDictionary *> *)scanModels;

--- a/KoeApp/Koe/Bridge/SPRustBridge.m
+++ b/KoeApp/Koe/Bridge/SPRustBridge.m
@@ -216,6 +216,17 @@ static void bridge_on_rewrite_text_ready(uint64_t token, const char *text) {
     return [result isKindOfClass:[NSArray class]] ? result : @[];
 }
 
+- (NSArray<NSString *> *)supportedLlmProviders {
+    char *json = sp_core_supported_llm_providers();
+    if (!json) return @[];
+    NSString *jsonStr = [NSString stringWithUTF8String:json];
+    sp_core_free_string(json);
+    NSData *data = [jsonStr dataUsingEncoding:NSUTF8StringEncoding];
+    if (!data) return @[];
+    NSArray *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    return [result isKindOfClass:[NSArray class]] ? result : @[];
+}
+
 - (NSArray<NSDictionary *> *)scanModels {
     char *json = sp_core_scan_models_json();
     if (!json) return @[];

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -930,12 +930,15 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     // Provider
     [pane addSubview:[self formLabel:@"Provider" frame:NSMakeRect(16, y, labelW, 22)]];
     self.llmProviderPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, fieldW, 26) pullsDown:NO];
+    NSArray<NSString *> *supportedLlmProviders = [self.rustBridge supportedLlmProviders];
     NSMenuItem *openaiItem = [[NSMenuItem alloc] initWithTitle:@"OpenAI Compatible" action:nil keyEquivalent:@""];
     openaiItem.representedObject = @"openai";
     [self.llmProviderPopup.menu addItem:openaiItem];
-    NSMenuItem *mlxItem = [[NSMenuItem alloc] initWithTitle:@"MLX (Apple Silicon)" action:nil keyEquivalent:@""];
-    mlxItem.representedObject = @"mlx";
-    [self.llmProviderPopup.menu addItem:mlxItem];
+    if ([supportedLlmProviders containsObject:@"mlx"]) {
+        NSMenuItem *mlxItem = [[NSMenuItem alloc] initWithTitle:@"MLX (Apple Silicon)" action:nil keyEquivalent:@""];
+        mlxItem.representedObject = @"mlx";
+        [self.llmProviderPopup.menu addItem:mlxItem];
+    }
     [self.llmProviderPopup setTarget:self];
     [self.llmProviderPopup setAction:@selector(llmProviderChanged:)];
     [pane addSubview:self.llmProviderPopup];

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -1345,6 +1345,15 @@ pub extern "C" fn sp_core_supported_local_providers() -> *mut c_char {
     CString::new(json_str).unwrap_or_default().into_raw()
 }
 
+/// Return JSON array of supported LLM provider names (e.g. ["openai","mlx"]).
+/// Caller must free the returned string with sp_core_free_string().
+#[no_mangle]
+pub extern "C" fn sp_core_supported_llm_providers() -> *mut c_char {
+    let providers = llm::supported_providers();
+    let json_str = serde_json::to_string(providers).unwrap_or_else(|_| "[]".to_string());
+    CString::new(json_str).unwrap_or_default().into_raw()
+}
+
 /// Scan all models and return JSON array.
 /// Caller must free the returned string with sp_core_free_string().
 #[no_mangle]

--- a/koe-core/src/llm/mod.rs
+++ b/koe-core/src/llm/mod.rs
@@ -4,6 +4,15 @@ pub mod openai_compatible;
 
 use crate::errors::Result;
 
+/// LLM correction providers supported by this build.
+pub fn supported_providers() -> &'static [&'static str] {
+    &[
+        "openai",
+        #[cfg(feature = "mlx")]
+        "mlx",
+    ]
+}
+
 /// Request for LLM text correction.
 pub struct CorrectionRequest {
     pub asr_text: String,


### PR DESCRIPTION
## Summary

On x86_64 builds, the `mlx` cargo feature is disabled (see `Makefile` / `project.yml`), but the Setup Wizard still hardcoded the "MLX (Apple Silicon)" entry in the LLM provider popup. This PR hides that option on builds that do not include the `mlx` feature, mirroring the pattern already used for the ASR provider popup.

No behavior change for Apple Silicon builds — the MLX LLM option still appears as before.

## Changes

- `koe-core/src/llm/mod.rs`: add `supported_providers()` that conditionally includes `"mlx"` behind `#[cfg(feature = "mlx")]`.
- `koe-core/src/lib.rs`: expose `sp_core_supported_llm_providers()` FFI (mirrors the existing `sp_core_supported_local_providers`).
- `KoeApp/Koe/Bridge/SPRustBridge.{h,m}`: add `-supportedLlmProviders`.
- `KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m`: only add the MLX LLM menu item when the Rust core reports it as supported.

## Test plan

- [x] \`cargo check --manifest-path koe-core/Cargo.toml\` (default features) passes
- [x] \`cargo check --manifest-path koe-core/Cargo.toml --no-default-features --features "sherpa-onnx,apple-speech"\` passes
- [x] \`make build\` on Apple Silicon — MLX LLM option still visible in Setup Wizard
- [x] \`make build-x86_64\` — MLX LLM option hidden in Setup Wizard