### PR TITLE
fix(app): hide Apple Speech provider on x86_64 builds

### DIFF
--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -722,18 +722,23 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     [self.asrProviderPopup lastItem].representedObject = @"doubao";
     [self.asrProviderPopup addItemWithTitle:@"Qwen (\u963f\u91cc\u4e91)"];
     [self.asrProviderPopup lastItem].representedObject = @"qwen";
-    // Add Apple Speech (macOS 26+, no model download required)
+    NSArray<NSString *> *supportedLocalProviders = [self.rustBridge supportedLocalProviders];
+    // Add Apple Speech (macOS 26+, no model download required; also requires the
+    // apple-speech feature to be compiled into the Rust core — excluded on x86_64)
     if (@available(macOS 26.0, *)) {
-        [self.asrProviderPopup addItemWithTitle:@"Apple Speech (On-Device)"];
-        [self.asrProviderPopup lastItem].representedObject = @"apple-speech";
+        if ([supportedLocalProviders containsObject:@"apple-speech"]) {
+            [self.asrProviderPopup addItemWithTitle:@"Apple Speech (On-Device)"];
+            [self.asrProviderPopup lastItem].representedObject = @"apple-speech";
+        }
     }
     // Add local providers supported by this build (model-based)
     NSDictionary *localProviderLabels = @{
         @"mlx": @"MLX (Apple Silicon)",
         @"sherpa-onnx": @"Sherpa-ONNX",
     };
-    for (NSString *provider in [self.rustBridge supportedLocalProviders]) {
-        NSString *label = localProviderLabels[provider] ?: provider;
+    for (NSString *provider in supportedLocalProviders) {
+        NSString *label = localProviderLabels[provider];
+        if (!label) continue;  // apple-speech handled above
         [self.asrProviderPopup addItemWithTitle:label];
         [self.asrProviderPopup lastItem].representedObject = provider;
     }

--- a/KoeApp/project.yml
+++ b/KoeApp/project.yml
@@ -115,7 +115,7 @@ targets:
           export PATH="$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
           cd "${SRCROOT}/.."
           RUST_TARGET="x86_64-apple-darwin"
-          cargo build --manifest-path koe-core/Cargo.toml --release --target "$RUST_TARGET" --no-default-features --features "sherpa-onnx,apple-speech"
+          cargo build --manifest-path koe-core/Cargo.toml --release --target "$RUST_TARGET" --no-default-features --features "sherpa-onnx"
           mkdir -p "${SRCROOT}/../target/release"
           ln -sf "${SRCROOT}/../target/${RUST_TARGET}/release/libkoe_core.a" "${SRCROOT}/../target/release/libkoe_core.a"
         basedOnDependencyAnalysis: false

--- a/koe-core/src/model_manager.rs
+++ b/koe-core/src/model_manager.rs
@@ -106,9 +106,11 @@ pub fn models_dir() -> PathBuf {
 
 // ─── Scan ───────────────────────────────────────────────────────────
 
-/// Local ASR providers supported by this build.
+/// Local ASR providers supported by this build (on-device, feature-gated).
 pub fn supported_providers() -> &'static [&'static str] {
     &[
+        #[cfg(feature = "apple-speech")]
+        "apple-speech",
         #[cfg(feature = "mlx")]
         "mlx",
         #[cfg(feature = "sherpa-onnx")]


### PR DESCRIPTION
## Summary

- Hide the "Apple Speech (On-Device)" ASR option on x86_64 builds. SpeechTranscriber (macOS 26+) cannot run on x86_64: Intel Macs max out at macOS 15, and Rosetta processes on Apple Silicon cannot load the on-device speech assets — every locale reports "Not supported for this language".
- Drop the `apple-speech` cargo feature from the Koe-x86 build script.
- Add `apple-speech` to the feature-gated `supported_providers()` list in `model_manager.rs`, so the wizard can query it at runtime — mirroring the existing MLX / sherpa-onnx pattern.

## Changes

- `koe-core/src/model_manager.rs`: include `"apple-speech"` in `supported_providers()` behind `#[cfg(feature = "apple-speech")]`
- `KoeApp/project.yml`: remove `apple-speech` from Koe-x86 cargo features
- `KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m`: gate the Apple Speech menu item on both `@available(macOS 26.0, *)` and `supportedLocalProviders`

## Test plan

- [x] `make build` on Apple Silicon (macOS 26+) — Apple Speech option visible in Setup Wizard
- [x] `make build-x86_64` — Apple Speech option hidden in Setup Wizard
- [x] `cargo check --manifest-path koe-core/Cargo.toml` (default features) passes
- [x] `cargo check --manifest-path koe-core/Cargo.toml --no-default-features --features "sherpa-onnx"` passes