### PR TITLE
feat(llm): implement multi-profile system for local and remote endpoints

### DIFF
--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -151,6 +151,10 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 
 // LLM fields
 @property (nonatomic, strong) NSButton *llmEnabledCheckbox;
+@property (nonatomic, strong) NSPopUpButton *llmProfilePopup;
+@property (nonatomic, strong) NSButton *llmAddProfileButton;
+@property (nonatomic, strong) NSButton *llmAddApfelProfileButton;
+@property (nonatomic, strong) NSButton *llmDeleteProfileButton;
 @property (nonatomic, strong) NSPopUpButton *llmProviderPopup;
 @property (nonatomic, strong) NSTextField *llmBaseUrlField;
 @property (nonatomic, strong) NSTextField *llmApiKeyField;
@@ -170,6 +174,8 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
 @property (nonatomic, strong) NSButton *llmModelDeleteButton;
 @property (nonatomic, strong) NSProgressIndicator *llmModelProgressBar;
 @property (nonatomic, strong) NSTextField *llmModelProgressSizeLabel;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableDictionary *> *llmProfiles;
+@property (nonatomic, copy) NSString *activeLlmProfileId;
 
 // Hotkey
 @property (nonatomic, strong) NSPopUpButton *hotkeyPopup;
@@ -528,7 +534,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     CGFloat fieldW = paneWidth - fieldX - 32;
     CGFloat rowH = 32;
 
-    CGFloat contentHeight = 540;
+    CGFloat contentHeight = 580;
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
 
     CGFloat y = contentHeight - 48;
@@ -546,6 +552,29 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     self.llmEnabledCheckbox.frame = NSMakeRect(fieldX, y, 300, 22);
     [pane addSubview:self.llmEnabledCheckbox];
     y -= rowH + 8;
+
+    // Profile
+    [pane addSubview:[self formLabel:@"Profile" frame:NSMakeRect(16, y, labelW, 22)]];
+    self.llmProfilePopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, 190, 26) pullsDown:NO];
+    [self.llmProfilePopup setTarget:self];
+    [self.llmProfilePopup setAction:@selector(llmProfileChanged:)];
+    [pane addSubview:self.llmProfilePopup];
+
+    self.llmAddProfileButton = [NSButton buttonWithTitle:@"Add" target:self action:@selector(addLlmProfile:)];
+    self.llmAddProfileButton.bezelStyle = NSBezelStyleRounded;
+    self.llmAddProfileButton.frame = NSMakeRect(fieldX + 198, y - 2, 56, 26);
+    [pane addSubview:self.llmAddProfileButton];
+
+    self.llmAddApfelProfileButton = [NSButton buttonWithTitle:@"APFEL" target:self action:@selector(addApfelLlmProfile:)];
+    self.llmAddApfelProfileButton.bezelStyle = NSBezelStyleRounded;
+    self.llmAddApfelProfileButton.frame = NSMakeRect(fieldX + 260, y - 2, 68, 26);
+    [pane addSubview:self.llmAddApfelProfileButton];
+
+    self.llmDeleteProfileButton = [NSButton buttonWithTitle:@"Delete" target:self action:@selector(deleteLlmProfile:)];
+    self.llmDeleteProfileButton.bezelStyle = NSBezelStyleRounded;
+    self.llmDeleteProfileButton.frame = NSMakeRect(fieldX + 334, y - 2, 72, 26);
+    [pane addSubview:self.llmDeleteProfileButton];
+    y -= rowH;
 
     // Provider
     [pane addSubview:[self formLabel:@"Provider" frame:NSMakeRect(16, y, labelW, 22)]];
@@ -640,7 +669,7 @@ static NSString *defaultCancelKeyForTrigger(NSString *triggerKey) {
     [pane addSubview:self.llmTestResultLabel];
 
     // --- MLX fields (tag 2010-2012 for show/hide, initially hidden) ---
-    CGFloat mlxY = contentHeight - 48 - 52 - rowH - 8 - rowH;  // same Y as Base URL row
+    CGFloat mlxY = contentHeight - 48 - 52 - rowH - 8 - rowH - rowH;  // same Y as Base URL row
 
     // MLX Model popup + Download button
     NSTextField *llmModelLabel = [self formLabel:@"Model" frame:NSMakeRect(16, mlxY, labelW, 22)];
@@ -1435,6 +1464,217 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     }
 }
 
+- (NSMutableDictionary *)mutableLlmProfileFromDictionary:(NSDictionary *)profile {
+    NSMutableDictionary *copy = [profile mutableCopy] ?: [NSMutableDictionary dictionary];
+    NSDictionary *mlx = copy[@"mlx"];
+    copy[@"mlx"] = [mlx isKindOfClass:[NSDictionary class]] ? [mlx mutableCopy] : [@{@"model": @"mlx/Qwen3-0.6B-4bit"} mutableCopy];
+    return copy;
+}
+
+- (NSMutableDictionary *)defaultOpenAILlmProfileWithName:(NSString *)name {
+    return [@{
+        @"name": name ?: @"OpenAI Compatible",
+        @"provider": @"openai",
+        @"base_url": @"https://api.openai.com/v1",
+        @"api_key": @"",
+        @"model": @"gpt-5.4-nano",
+        @"max_token_parameter": @"max_completion_tokens",
+        @"no_reasoning_control": @"reasoning_effort",
+        @"mlx": @{@"model": @"mlx/Qwen3-0.6B-4bit"},
+    } mutableCopy];
+}
+
+- (NSMutableDictionary *)defaultApfelLlmProfile {
+    return [@{
+        @"name": @"APFEL",
+        @"provider": @"openai",
+        @"base_url": @"http://127.0.0.1:11434/v1",
+        @"api_key": @"",
+        @"model": @"apple-foundationmodel",
+        @"max_token_parameter": @"max_tokens",
+        @"no_reasoning_control": @"none",
+        @"mlx": @{@"model": @"mlx/Qwen3-0.6B-4bit"},
+    } mutableCopy];
+}
+
+- (void)loadLlmProfilesFromCore {
+    char *raw = sp_llm_profiles_json();
+    NSString *jsonStr = raw ? [NSString stringWithUTF8String:raw] : @"";
+    if (raw) sp_core_free_string(raw);
+
+    NSDictionary *payload = nil;
+    if (jsonStr.length > 0) {
+        payload = [NSJSONSerialization JSONObjectWithData:[jsonStr dataUsingEncoding:NSUTF8StringEncoding]
+                                                  options:0
+                                                    error:nil];
+    }
+
+    self.llmProfiles = [NSMutableDictionary dictionary];
+    NSDictionary *profiles = [payload[@"profiles"] isKindOfClass:[NSDictionary class]] ? payload[@"profiles"] : nil;
+    for (NSString *profileId in profiles) {
+        NSDictionary *profile = profiles[profileId];
+        if ([profile isKindOfClass:[NSDictionary class]]) {
+            self.llmProfiles[profileId] = [self mutableLlmProfileFromDictionary:profile];
+        }
+    }
+
+    if (self.llmProfiles.count == 0) {
+        self.llmProfiles[@"openai"] = [self defaultOpenAILlmProfileWithName:@"OpenAI Compatible"];
+        self.llmProfiles[@"apfel"] = [self defaultApfelLlmProfile];
+    }
+
+    NSString *activeProfile = [payload[@"active_profile"] isKindOfClass:[NSString class]] ? payload[@"active_profile"] : @"openai";
+    self.activeLlmProfileId = self.llmProfiles[activeProfile] ? activeProfile : self.llmProfiles.allKeys.firstObject;
+    [self populateLlmProfilePopup];
+    [self applyActiveLlmProfileToFields];
+}
+
+- (void)populateLlmProfilePopup {
+    [self.llmProfilePopup removeAllItems];
+    NSArray<NSString *> *profileIds = [self.llmProfiles.allKeys sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+    for (NSString *profileId in profileIds) {
+        NSDictionary *profile = self.llmProfiles[profileId];
+        NSString *title = [profile[@"name"] isKindOfClass:[NSString class]] && [profile[@"name"] length] > 0
+            ? profile[@"name"] : profileId;
+        [self.llmProfilePopup addItemWithTitle:title];
+        self.llmProfilePopup.lastItem.representedObject = profileId;
+        if ([profileId isEqualToString:self.activeLlmProfileId]) {
+            [self.llmProfilePopup selectItem:self.llmProfilePopup.lastItem];
+        }
+    }
+}
+
+- (NSMutableDictionary *)activeLlmProfile {
+    if (!self.activeLlmProfileId) return nil;
+    return self.llmProfiles[self.activeLlmProfileId];
+}
+
+- (void)syncActiveLlmProfileFromFields {
+    NSMutableDictionary *profile = [self activeLlmProfile];
+    if (!profile) return;
+
+    NSString *provider = self.llmProviderPopup.selectedItem.representedObject ?: @"openai";
+    profile[@"provider"] = provider;
+    profile[@"base_url"] = self.llmBaseUrlField.stringValue ?: @"";
+    NSString *apiKey = self.llmApiKeyToggle.tag == 1 ? self.llmApiKeyField.stringValue : self.llmApiKeySecureField.stringValue;
+    profile[@"api_key"] = apiKey ?: @"";
+    profile[@"model"] = self.llmModelField.stringValue ?: @"";
+    profile[@"max_token_parameter"] = self.maxTokenParamPopup.selectedItem.representedObject ?: @"max_completion_tokens";
+    if (!profile[@"no_reasoning_control"]) {
+        profile[@"no_reasoning_control"] = [provider isEqualToString:@"mlx"] ? @"none" : @"reasoning_effort";
+    }
+
+    if ([provider isEqualToString:@"mlx"]) {
+        NSMutableDictionary *mlx = [profile[@"mlx"] isKindOfClass:[NSMutableDictionary class]]
+            ? profile[@"mlx"] : [@{} mutableCopy];
+        NSString *modelPath = self.llmLocalModelPopup.selectedItem.representedObject;
+        if (modelPath) mlx[@"model"] = modelPath;
+        profile[@"mlx"] = mlx;
+    }
+}
+
+- (void)applyActiveLlmProfileToFields {
+    NSDictionary *profile = [self activeLlmProfile];
+    if (!profile) return;
+
+    NSString *provider = [profile[@"provider"] isKindOfClass:[NSString class]] ? profile[@"provider"] : @"openai";
+    for (NSInteger i = 0; i < self.llmProviderPopup.numberOfItems; i++) {
+        if ([[self.llmProviderPopup itemAtIndex:i].representedObject isEqualToString:provider]) {
+            [self.llmProviderPopup selectItemAtIndex:i];
+            break;
+        }
+    }
+
+    self.llmBaseUrlField.stringValue = [profile[@"base_url"] isKindOfClass:[NSString class]] ? profile[@"base_url"] : @"";
+    NSString *apiKey = [profile[@"api_key"] isKindOfClass:[NSString class]] ? profile[@"api_key"] : @"";
+    self.llmApiKeySecureField.stringValue = apiKey;
+    self.llmApiKeyField.stringValue = apiKey;
+    self.llmApiKeySecureField.hidden = NO;
+    self.llmApiKeyField.hidden = YES;
+    self.llmApiKeyToggle.image = [NSImage imageWithSystemSymbolName:@"eye.slash" accessibilityDescription:@"Show"];
+    self.llmApiKeyToggle.tag = 0;
+    self.llmModelField.stringValue = [profile[@"model"] isKindOfClass:[NSString class]] ? profile[@"model"] : @"";
+
+    NSString *maxTokenParam = [profile[@"max_token_parameter"] isKindOfClass:[NSString class]]
+        ? profile[@"max_token_parameter"] : @"max_completion_tokens";
+    for (NSInteger i = 0; i < self.maxTokenParamPopup.numberOfItems; i++) {
+        if ([[self.maxTokenParamPopup itemAtIndex:i].representedObject isEqualToString:maxTokenParam]) {
+            [self.maxTokenParamPopup selectItemAtIndex:i];
+            break;
+        }
+    }
+
+    if ([provider isEqualToString:@"mlx"]) {
+        [self populateLlmLocalModelPopup];
+        NSString *mlxModel = [profile[@"mlx"] isKindOfClass:[NSDictionary class]] ? profile[@"mlx"][@"model"] : nil;
+        if (mlxModel.length > 0) {
+            for (NSInteger i = 0; i < self.llmLocalModelPopup.numberOfItems; i++) {
+                if ([[self.llmLocalModelPopup itemAtIndex:i].representedObject isEqualToString:mlxModel]) {
+                    [self.llmLocalModelPopup selectItemAtIndex:i];
+                    break;
+                }
+            }
+        }
+        [self updateLlmModelStatusLabel];
+    }
+
+    [self updateLlmFieldsEnabled];
+}
+
+- (NSString *)newLlmProfileIdWithPrefix:(NSString *)prefix {
+    NSString *base = prefix ?: @"profile";
+    if (!self.llmProfiles[base]) return base;
+    NSInteger index = 2;
+    while (self.llmProfiles[[NSString stringWithFormat:@"%@-%ld", base, (long)index]]) {
+        index++;
+    }
+    return [NSString stringWithFormat:@"%@-%ld", base, (long)index];
+}
+
+- (void)llmProfileChanged:(id)sender {
+    [self syncActiveLlmProfileFromFields];
+    self.activeLlmProfileId = self.llmProfilePopup.selectedItem.representedObject ?: self.activeLlmProfileId;
+    [self applyActiveLlmProfileToFields];
+    self.llmTestResultLabel.stringValue = @"";
+}
+
+- (void)addLlmProfile:(id)sender {
+    [self syncActiveLlmProfileFromFields];
+    NSString *profileId = [self newLlmProfileIdWithPrefix:@"custom"];
+    self.llmProfiles[profileId] = [self defaultOpenAILlmProfileWithName:@"Custom LLM"];
+    self.activeLlmProfileId = profileId;
+    [self populateLlmProfilePopup];
+    [self applyActiveLlmProfileToFields];
+}
+
+- (void)addApfelLlmProfile:(id)sender {
+    [self syncActiveLlmProfileFromFields];
+    NSString *profileId = @"apfel";
+    if (!self.llmProfiles[profileId]) {
+        profileId = [self newLlmProfileIdWithPrefix:@"apfel"];
+        self.llmProfiles[profileId] = [self defaultApfelLlmProfile];
+    }
+    self.activeLlmProfileId = profileId;
+    [self populateLlmProfilePopup];
+    [self applyActiveLlmProfileToFields];
+}
+
+- (void)deleteLlmProfile:(id)sender {
+    if (self.llmProfiles.count <= 1 || !self.activeLlmProfileId) return;
+    [self.llmProfiles removeObjectForKey:self.activeLlmProfileId];
+    self.activeLlmProfileId = [self.llmProfiles.allKeys sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)].firstObject;
+    [self populateLlmProfilePopup];
+    [self applyActiveLlmProfileToFields];
+}
+
+- (NSDictionary *)runtimeLlmProfileForActiveProfile {
+    [self syncActiveLlmProfileFromFields];
+    NSMutableDictionary *profile = [[self activeLlmProfile] mutableCopy];
+    if (!profile) return nil;
+    profile[@"id"] = self.activeLlmProfileId ?: @"";
+    return profile;
+}
+
 // ─── Load / Save ────────────────────────────────────────────────────
 
 - (void)loadCurrentValues {
@@ -1515,53 +1755,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         NSString *enabled = configGet(@"llm.enabled");
         self.llmEnabledCheckbox.state = ([enabled isEqualToString:@"false"]) ? NSControlStateValueOff : NSControlStateValueOn;
 
-        // Restore provider selection
-        NSString *llmProvider = configGet(@"llm.provider");
-        if (llmProvider.length == 0) llmProvider = @"openai";
-        for (NSInteger i = 0; i < self.llmProviderPopup.numberOfItems; i++) {
-            if ([[self.llmProviderPopup itemAtIndex:i].representedObject isEqualToString:llmProvider]) {
-                [self.llmProviderPopup selectItemAtIndex:i];
-                break;
-            }
-        }
-
-        // OpenAI fields
-        NSString *baseUrl = configGet(@"llm.base_url");
-        self.llmBaseUrlField.stringValue = baseUrl.length > 0 ? baseUrl : @"https://api.openai.com/v1";
-        NSString *apiKey = configGet(@"llm.api_key");
-        self.llmApiKeySecureField.stringValue = apiKey;
-        self.llmApiKeyField.stringValue = apiKey;
-        self.llmApiKeySecureField.hidden = NO;
-        self.llmApiKeyField.hidden = YES;
-        self.llmApiKeyToggle.image = [NSImage imageWithSystemSymbolName:@"eye.slash" accessibilityDescription:@"Show"];
-        self.llmApiKeyToggle.tag = 0;
-        NSString *model = configGet(@"llm.model");
-        self.llmModelField.stringValue = model.length > 0 ? model : @"gpt-5.4-nano";
-        // Max token parameter
-        NSString *maxTokenParam = configGet(@"llm.max_token_parameter");
-        if (maxTokenParam.length == 0) maxTokenParam = @"max_completion_tokens";
-        for (NSInteger i = 0; i < self.maxTokenParamPopup.numberOfItems; i++) {
-            if ([[self.maxTokenParamPopup itemAtIndex:i].representedObject isEqualToString:maxTokenParam]) {
-                [self.maxTokenParamPopup selectItemAtIndex:i];
-                break;
-            }
-        }
-
-        // MLX model selection
-        if ([llmProvider isEqualToString:@"mlx"]) {
-            [self populateLlmLocalModelPopup];
-            NSString *mlxModel = configGet(@"llm.mlx.model");
-            if (mlxModel.length > 0) {
-                for (NSInteger i = 0; i < self.llmLocalModelPopup.numberOfItems; i++) {
-                    if ([[self.llmLocalModelPopup itemAtIndex:i].representedObject isEqualToString:mlxModel]) {
-                        [self.llmLocalModelPopup selectItemAtIndex:i];
-                        break;
-                    }
-                }
-            }
-            [self updateLlmModelStatusLabel];
-        }
-
+        [self loadLlmProfilesFromCore];
         self.llmTestResultLabel.stringValue = @"";
         [self updateLlmFieldsEnabled];
     } else if ([identifier isEqualToString:kToolbarHotkey]) {
@@ -1701,19 +1895,16 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     if (self.llmEnabledCheckbox) {
         NSString *enabledStr = (self.llmEnabledCheckbox.state == NSControlStateValueOn) ? @"true" : @"false";
         saveOk &= configSet(@"llm.enabled", enabledStr);
-        NSString *llmProvider = self.llmProviderPopup.selectedItem.representedObject ?: @"openai";
-        saveOk &= configSet(@"llm.provider", llmProvider);
-        // OpenAI fields
-        saveOk &= configSet(@"llm.base_url", self.llmBaseUrlField.stringValue);
-        NSString *llmApiKey = self.llmApiKeyToggle.tag == 1 ? self.llmApiKeyField.stringValue : self.llmApiKeySecureField.stringValue;
-        saveOk &= configSet(@"llm.api_key", llmApiKey);
-        saveOk &= configSet(@"llm.model", self.llmModelField.stringValue);
-        NSString *selectedTokenParam = self.maxTokenParamPopup.selectedItem.representedObject ?: @"max_completion_tokens";
-        saveOk &= configSet(@"llm.max_token_parameter", selectedTokenParam);
-        // MLX model
-        if ([llmProvider isEqualToString:@"mlx"]) {
-            NSString *mlxModelPath = self.llmLocalModelPopup.selectedItem.representedObject;
-            if (mlxModelPath) saveOk &= configSet(@"llm.mlx.model", mlxModelPath);
+
+        [self syncActiveLlmProfileFromFields];
+        NSDictionary *payload = @{
+            @"active_profile": self.activeLlmProfileId ?: @"openai",
+            @"profiles": self.llmProfiles ?: @{},
+        };
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
+        NSString *json = jsonData ? [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding] : nil;
+        if (!json || sp_llm_save_profiles_json(json.UTF8String) != 0) {
+            saveOk = NO;
         }
     }
 
@@ -1786,6 +1977,10 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
 - (void)updateLlmFieldsEnabled {
     BOOL enabled = (self.llmEnabledCheckbox.state == NSControlStateValueOn);
+    self.llmProfilePopup.enabled = enabled;
+    self.llmAddProfileButton.enabled = enabled;
+    self.llmAddApfelProfileButton.enabled = enabled;
+    self.llmDeleteProfileButton.enabled = enabled && self.llmProfiles.count > 1;
     self.llmProviderPopup.enabled = enabled;
 
     NSString *provider = self.llmProviderPopup.selectedItem.representedObject ?: @"openai";
@@ -1837,6 +2032,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         [self populateLlmLocalModelPopup];
         [self updateLlmModelStatusLabel];
     }
+    [self syncActiveLlmProfileFromFields];
     self.llmTestResultLabel.stringValue = @"";
 }
 
@@ -2025,13 +2221,27 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 }
 
 - (void)testLlmConnection:(id)sender {
-    NSString *baseUrl = self.llmBaseUrlField.stringValue;
-    NSString *apiKey = self.llmApiKeyToggle.tag == 1 ? self.llmApiKeyField.stringValue : self.llmApiKeySecureField.stringValue;
-    NSString *model = self.llmModelField.stringValue;
-
-    if (baseUrl.length == 0 || apiKey.length == 0 || model.length == 0) {
-        self.llmTestResultLabel.stringValue = @"Please fill in all fields first.";
+    NSDictionary *profile = [self runtimeLlmProfileForActiveProfile];
+    if (!profile) {
+        self.llmTestResultLabel.stringValue = @"Please select an LLM profile first.";
         self.llmTestResultLabel.textColor = [NSColor systemOrangeColor];
+        return;
+    }
+
+    NSString *provider = [profile[@"provider"] isKindOfClass:[NSString class]] ? profile[@"provider"] : @"openai";
+    NSString *baseUrl = [profile[@"base_url"] isKindOfClass:[NSString class]] ? profile[@"base_url"] : @"";
+    NSString *model = [profile[@"model"] isKindOfClass:[NSString class]] ? profile[@"model"] : @"";
+    if ([provider isEqualToString:@"openai"] && (baseUrl.length == 0 || model.length == 0)) {
+        self.llmTestResultLabel.stringValue = @"Please fill in Base URL and Model first.";
+        self.llmTestResultLabel.textColor = [NSColor systemOrangeColor];
+        return;
+    }
+
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:profile options:0 error:nil];
+    NSString *profileJson = jsonData ? [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding] : nil;
+    if (profileJson.length == 0) {
+        self.llmTestResultLabel.stringValue = @"Test failed: invalid profile data";
+        self.llmTestResultLabel.textColor = [NSColor systemRedColor];
         return;
     }
 
@@ -2039,17 +2249,9 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     self.llmTestResultLabel.stringValue = @"Testing...";
     self.llmTestResultLabel.textColor = [NSColor secondaryLabelColor];
 
-    NSString *tokenParam = self.maxTokenParamPopup.selectedItem.representedObject
-        ?: @"max_completion_tokens";
-
-    // Run the Rust-side test on a background thread (sp_llm_test blocks until done)
+    // Run the Rust-side test on a background thread; the profile path matches runtime correction.
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        char *raw = sp_llm_test(
-            baseUrl.UTF8String,
-            apiKey.UTF8String,
-            model.UTF8String,
-            tokenParam.UTF8String
-        );
+        char *raw = sp_llm_test_profile_json(profileJson.UTF8String);
         NSString *jsonStr = raw ? [NSString stringWithUTF8String:raw] : @"";
         if (raw) sp_core_free_string(raw);
 

--- a/KoeApp/project.yml
+++ b/KoeApp/project.yml
@@ -115,6 +115,7 @@ targets:
           export PATH="$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
           cd "${SRCROOT}/.."
           RUST_TARGET="x86_64-apple-darwin"
+          export CMAKE_POLICY_VERSION_MINIMUM=3.5
           cargo build --manifest-path koe-core/Cargo.toml --release --target "$RUST_TARGET" --no-default-features --features "sherpa-onnx,apple-speech"
           mkdir -p "${SRCROOT}/../target/release"
           ln -sf "${SRCROOT}/../target/${RUST_TARGET}/release/libkoe_core.a" "${SRCROOT}/../target/release/libkoe_core.a"

--- a/README.md
+++ b/README.md
@@ -143,12 +143,13 @@ All config files live in `~/.koe/` and are auto-generated on first launch. You
 can edit them directly, or use the built-in settings window (Setup Wizard) from
 the menu bar. The settings window includes tabs for ASR, LLM, Controls, Dictionary,
 and Prompt. The Prompt tab edits `system_prompt.txt`; advanced knobs such as
-`user_prompt.txt`, ASR custom `headers`, and `llm.no_reasoning_control` remain
-file-based settings. When a local ASR provider is selected, the ASR tab shows
+`user_prompt.txt`, ASR custom `headers`, and advanced profile fields such as
+`no_reasoning_control` remain file-based settings. When a local ASR provider is selected, the ASR tab shows
 provider-specific controls: model picker with download/delete for MLX and
 Sherpa-ONNX, or language picker with asset status and download for Apple Speech.
-The LLM tab supports both OpenAI-compatible APIs and local MLX models — selecting
-MLX shows a model picker with download/status controls instead of API fields.
+The LLM tab supports multiple profiles for OpenAI-compatible APIs, APFEL, and
+local MLX models. Selecting MLX shows a model picker with download/status controls
+instead of API fields.
 
 ```
 ~/.koe/
@@ -262,42 +263,31 @@ migrate that flat format into the provider-based v2 layout automatically.
 #### LLM (Text Correction)
 
 After ASR, the transcript is sent to an LLM for correction (capitalization,
-spacing, terminology, filler word removal). Koe supports two LLM providers:
+spacing, terminology, filler word removal). Koe stores multiple LLM profiles and
+uses `llm.active_profile` to choose the endpoint for correction.
 
 - **OpenAI-compatible APIs** — any cloud or self-hosted endpoint that implements the OpenAI chat completions API
+- **APFEL** — an OpenAI-compatible local endpoint preset at `http://127.0.0.1:11434/v1`
 - **MLX** (Apple Silicon only) — fully offline local inference using Qwen3 models, no API key required
 
-The `provider` field selects which backend to use. When set to `"openai"` (default),
-the LLM HTTP client is shared across sessions with HTTP/2 support and connection
-pooling for lower latency. When set to `"mlx"`, inference runs on-device via the
-KoeMLX Swift package — no network access needed.
+OpenAI-compatible profiles, including APFEL, share the LLM HTTP client across
+sessions with HTTP/2 support and connection pooling for lower latency. MLX
+profiles run on-device via the KoeMLX Swift package.
+
+Koe does not install, start, restart, or choose a port for APFEL. Install and
+start APFEL separately with `apfel --serve` or `apfel service install/start`,
+then select the APFEL profile in Koe.
 
 ```yaml
 llm:
   # Set to false to skip LLM correction and paste raw ASR output directly.
   enabled: true
 
-  # LLM provider: "openai" (default) or "mlx" (local Apple Silicon).
-  provider: "openai"
-
-  # OpenAI-compatible API endpoint.
-  # Examples:
-  #   OpenAI:    "https://api.openai.com/v1"
-  #   Anthropic: "https://api.anthropic.com/v1"  (needs compatible proxy)
-  #   Local:     "http://localhost:8080/v1"
-  base_url: "https://api.openai.com/v1"
-
-  # API key. Supports environment variable substitution with ${VAR_NAME} syntax.
-  # Examples:
-  #   Direct:  "sk-xxxxxxxx"
-  #   Env var: "${LLM_API_KEY}"
-  api_key: ""
-
-  # Model name. Use a fast, cheap model — latency matters here.
-  # Recommended: "gpt-5.4-nano" or any similar fast model.
-  model: "gpt-5.4-nano"
+  # Active LLM profile id. Built-in defaults include "openai", "apfel", and "mlx".
+  active_profile: "openai"
 
   # LLM sampling parameters. temperature: 0 = deterministic, best for correction tasks.
+  # These are global correction parameters shared by all profiles.
   temperature: 0
   top_p: 1
 
@@ -306,16 +296,6 @@ llm:
 
   # Max tokens in LLM response. 1024 is plenty for voice input correction.
   max_output_tokens: 1024
-
-  # Token limit field sent to the OpenAI-compatible API.
-  # Use "max_tokens" for older model endpoints.
-  max_token_parameter: "max_completion_tokens"
-
-  # Optional control for providers that expose reasoning/thinking knobs.
-  # "reasoning_effort" sends reasoning_effort: "none" on GPT-5/o-series style APIs.
-  # "thinking" sends thinking: {"type":"disabled"} for providers that use that shape.
-  # "none" sends nothing.
-  no_reasoning_control: "reasoning_effort"
 
   # How many dictionary entries to include in the LLM prompt.
   # 0 = send all entries (recommended for dictionaries under ~500 entries).
@@ -327,10 +307,30 @@ llm:
   system_prompt_path: "system_prompt.txt"
   user_prompt_path: "user_prompt.txt"
 
-  # MLX local LLM (Apple Silicon only).
-  # Model path relative to ~/.koe/models/, or absolute path.
-  mlx:
-    model: "mlx/Qwen3-0.6B-4bit"
+  profiles:
+    openai:
+      name: "OpenAI Compatible"
+      provider: "openai"
+      base_url: "https://api.openai.com/v1"
+      api_key: ""          # supports ${LLM_API_KEY}
+      model: "gpt-5.4-nano"
+      max_token_parameter: "max_completion_tokens"
+      no_reasoning_control: "reasoning_effort"
+
+    apfel:
+      name: "APFEL"
+      provider: "openai"
+      base_url: "http://127.0.0.1:11434/v1"
+      api_key: ""          # APFEL does not require an API key by default
+      model: "apple-foundationmodel"
+      max_token_parameter: "max_tokens"
+      no_reasoning_control: "none"
+
+    mlx:
+      name: "MLX Local"
+      provider: "mlx"
+      mlx:
+        model: "mlx/Qwen3-0.6B-4bit"  # relative to ~/.koe/models/, or absolute path
 ```
 
 #### Feedback (Sound Effects)
@@ -530,6 +530,10 @@ When both ASR and LLM are set to local MLX providers, Koe runs entirely on-devic
 - **Lightest** (ASR 0.6B + LLM 0.6B): ~1.2 GB — runs comfortably on any Apple Silicon Mac
 - **Heaviest** (ASR 1.7B + LLM 1.7B): ~2.9 GB — still fits easily in 8 GB unified memory
 
+APFEL also runs the model outside Koe and exposes it through a local
+OpenAI-compatible HTTP endpoint. Koe only calls that endpoint; it does not manage
+the APFEL service lifecycle.
+
 ### Model Manifest
 
 Each model directory contains a `.koe-manifest.json` describing the model and its files:
@@ -604,7 +608,7 @@ Local ASR providers are controlled by Rust feature flags in `koe-core/Cargo.toml
 Koe is built as a native macOS app with two layers:
 
 - **Objective-C shell** — handles macOS integration: hotkey detection, audio capture, clipboard management, paste simulation, menu bar UI, and usage statistics (SQLite)
-- **Rust core library** — handles ASR (cloud WebSocket streaming + local MLX/sherpa-onnx/Apple Speech), LLM correction (cloud API + local MLX), config management, model management, transcript aggregation, and session orchestration
+- **Rust core library** — handles ASR (cloud WebSocket streaming + local MLX/sherpa-onnx/Apple Speech), LLM correction (OpenAI-compatible profile endpoints + local MLX), config management, model management, transcript aggregation, and session orchestration
 - **Swift KoeMLX package** — bridges MLX inference to Rust via C FFI for on-device ASR (Qwen3-ASR) and LLM text correction (Qwen3) on Apple Silicon
 - **Swift KoeAppleSpeech package** — bridges Apple's SpeechAnalyzer to Rust via C FFI for zero-config on-device ASR (macOS 26+)
 

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -1524,17 +1524,8 @@ asr:
 
 llm:
   enabled: true        # set to false to skip LLM correction entirely
-<<<<<<< HEAD
   prompt_templates_enabled: false  # show rewrite template buttons above the overlay after transcription
-  provider: "openai"   # "openai" (default) or "mlx" (local Apple Silicon)
-
-  # OpenAI-compatible endpoint for text correction
-  base_url: "https://api.openai.com/v1"
-  api_key: ""          # or use ${LLM_API_KEY}
-  model: "gpt-5.4-nano"
-=======
   active_profile: "openai"
->>>>>>> codex-apfel-llm-profiles
   temperature: 0
   top_p: 1
   timeout_ms: 8000

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -1,5 +1,6 @@
 use crate::errors::{KoeError, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 /// Root configuration structure matching ~/.koe/config.yaml
@@ -206,15 +207,12 @@ fn default_apple_speech_locale() -> String {
 pub struct LlmSection {
     #[serde(default = "default_true")]
     pub enabled: bool,
-    /// LLM provider: "openai" (default) or "mlx"
-    #[serde(default = "default_llm_provider")]
-    pub provider: String,
-    #[serde(default)]
-    pub base_url: String,
-    #[serde(default)]
-    pub api_key: String,
-    #[serde(default)]
-    pub model: String,
+    /// Active LLM profile id.
+    #[serde(default = "default_llm_active_profile")]
+    pub active_profile: String,
+    /// Saved LLM profiles keyed by stable profile id.
+    #[serde(default = "default_llm_profiles")]
+    pub profiles: BTreeMap<String, LlmProfileConfig>,
     #[serde(default)]
     pub temperature: f64,
     #[serde(default = "default_top_p")]
@@ -223,22 +221,101 @@ pub struct LlmSection {
     pub timeout_ms: u64,
     #[serde(default = "default_max_output_tokens")]
     pub max_output_tokens: u32,
-    #[serde(default = "default_llm_max_token_parameter")]
-    pub max_token_parameter: LlmMaxTokenParameter,
     #[serde(default = "default_dictionary_max_candidates")]
     pub dictionary_max_candidates: usize,
-    #[serde(default)]
-    pub no_reasoning_control: LlmNoReasoningControl,
     #[serde(default = "default_system_prompt_path")]
     pub system_prompt_path: String,
     #[serde(default = "default_user_prompt_path")]
     pub user_prompt_path: String,
-    /// MLX local LLM configuration (Apple Silicon only)
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct LlmProfilesPayload {
+    pub active_profile: String,
+    pub profiles: BTreeMap<String, LlmProfileConfig>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct LlmProfileConfig {
+    #[serde(default)]
+    pub name: String,
+    /// LLM provider: "openai" or "mlx".
+    #[serde(default = "default_llm_provider")]
+    pub provider: String,
+    #[serde(default)]
+    pub base_url: String,
+    #[serde(default)]
+    pub api_key: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default = "default_llm_max_token_parameter")]
+    pub max_token_parameter: LlmMaxTokenParameter,
+    #[serde(default)]
+    pub no_reasoning_control: LlmNoReasoningControl,
+    /// MLX local LLM configuration (Apple Silicon only).
     #[serde(default)]
     pub mlx: MlxLlmConfig,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct LlmProfileRuntimeConfig {
+    pub id: String,
+    pub name: String,
+    pub provider: String,
+    pub base_url: String,
+    pub api_key: String,
+    pub model: String,
+    pub max_token_parameter: LlmMaxTokenParameter,
+    pub no_reasoning_control: LlmNoReasoningControl,
+    pub mlx: MlxLlmConfig,
+}
+
+impl LlmSection {
+    pub fn active_profile_config(&self) -> Result<LlmProfileRuntimeConfig> {
+        let profile = self.profiles.get(&self.active_profile).ok_or_else(|| {
+            KoeError::Config(format!("LLM profile not found: {}", self.active_profile))
+        })?;
+        Ok(profile.to_runtime_config(&self.active_profile))
+    }
+
+    pub fn profiles_payload(&self) -> LlmProfilesPayload {
+        LlmProfilesPayload {
+            active_profile: self.active_profile.clone(),
+            profiles: self.profiles.clone(),
+        }
+    }
+}
+
+impl LlmProfileConfig {
+    pub fn to_runtime_config(&self, id: &str) -> LlmProfileRuntimeConfig {
+        LlmProfileRuntimeConfig {
+            id: id.to_string(),
+            name: if self.name.is_empty() {
+                id.to_string()
+            } else {
+                self.name.clone()
+            },
+            provider: self.provider.clone(),
+            base_url: self.base_url.clone(),
+            api_key: self.api_key.clone(),
+            model: self.model.clone(),
+            max_token_parameter: self.max_token_parameter,
+            no_reasoning_control: self.no_reasoning_control,
+            mlx: self.mlx.clone(),
+        }
+    }
+}
+
+impl LlmProfileRuntimeConfig {
+    pub fn is_ready(&self) -> bool {
+        match self.provider.as_str() {
+            "mlx" => !self.mlx.model.is_empty(),
+            _ => !self.base_url.is_empty() && !self.model.is_empty(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct MlxLlmConfig {
     /// Model directory name under ~/.koe/models/
     #[serde(default = "default_mlx_llm_model")]
@@ -253,14 +330,29 @@ impl Default for MlxLlmConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+impl Default for LlmProfileConfig {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            provider: default_llm_provider(),
+            base_url: String::new(),
+            api_key: String::new(),
+            model: String::new(),
+            max_token_parameter: default_llm_max_token_parameter(),
+            no_reasoning_control: LlmNoReasoningControl::default(),
+            mlx: MlxLlmConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum LlmMaxTokenParameter {
     MaxTokens,
     MaxCompletionTokens,
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum LlmNoReasoningControl {
     #[default]
@@ -536,6 +628,52 @@ fn default_llm_max_token_parameter() -> LlmMaxTokenParameter {
 }
 fn default_llm_provider() -> String {
     "openai".into()
+}
+fn default_llm_active_profile() -> String {
+    "openai".into()
+}
+fn default_llm_profiles() -> BTreeMap<String, LlmProfileConfig> {
+    let mut profiles = BTreeMap::new();
+    profiles.insert(
+        "apfel".into(),
+        LlmProfileConfig {
+            name: "APFEL".into(),
+            provider: "openai".into(),
+            base_url: "http://127.0.0.1:11434/v1".into(),
+            api_key: String::new(),
+            model: "apple-foundationmodel".into(),
+            max_token_parameter: LlmMaxTokenParameter::MaxTokens,
+            no_reasoning_control: LlmNoReasoningControl::None,
+            mlx: MlxLlmConfig::default(),
+        },
+    );
+    profiles.insert(
+        "mlx".into(),
+        LlmProfileConfig {
+            name: "MLX (Apple Silicon)".into(),
+            provider: "mlx".into(),
+            base_url: String::new(),
+            api_key: String::new(),
+            model: String::new(),
+            max_token_parameter: LlmMaxTokenParameter::MaxTokens,
+            no_reasoning_control: LlmNoReasoningControl::None,
+            mlx: MlxLlmConfig::default(),
+        },
+    );
+    profiles.insert(
+        "openai".into(),
+        LlmProfileConfig {
+            name: "OpenAI Compatible".into(),
+            provider: "openai".into(),
+            base_url: "https://api.openai.com/v1".into(),
+            api_key: String::new(),
+            model: "gpt-5.4-nano".into(),
+            max_token_parameter: LlmMaxTokenParameter::MaxCompletionTokens,
+            no_reasoning_control: LlmNoReasoningControl::ReasoningEffort,
+            mlx: MlxLlmConfig::default(),
+        },
+    );
+    profiles
 }
 fn default_mlx_llm_model() -> String {
     "mlx/Qwen3-0.6B-4bit".into()
@@ -1000,6 +1138,36 @@ pub fn config_set(key_path: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
+pub fn llm_profiles_payload() -> Result<LlmProfilesPayload> {
+    Ok(load_config()?.llm.profiles_payload())
+}
+
+pub fn save_llm_profiles_payload(payload: &LlmProfilesPayload) -> Result<()> {
+    let path = config_path();
+    let raw = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut root: serde_yaml::Value = if raw.trim().is_empty() {
+        serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+    } else {
+        serde_yaml::from_str(&raw)
+            .map_err(|e| KoeError::Config(format!("parse {}: {e}", path.display())))?
+    };
+
+    let llm_map = navigate_to_parent(&mut root, &["llm"]);
+    llm_map.insert(
+        serde_yaml::Value::String("active_profile".into()),
+        serde_yaml::Value::String(payload.active_profile.clone()),
+    );
+    let profiles_value = serde_yaml::to_value(&payload.profiles)
+        .map_err(|e| KoeError::Config(format!("serialize LLM profiles: {e}")))?;
+    llm_map.insert(serde_yaml::Value::String("profiles".into()), profiles_value);
+
+    let serialized =
+        serde_yaml::to_string(&root).map_err(|e| KoeError::Config(format!("serialize: {e}")))?;
+    atomic_write_file(&path, &serialized)?;
+
+    Ok(())
+}
+
 /// Recursively navigate into nested YAML mappings by path segments, creating
 /// intermediate mappings as needed. Returns a mutable ref to the final mapping.
 fn navigate_to_parent<'a>(
@@ -1091,25 +1259,36 @@ asr:
 
 llm:
   enabled: true        # set to false to skip LLM correction entirely
-  provider: "openai"   # "openai" (default) or "mlx" (local Apple Silicon)
-
-  # OpenAI-compatible endpoint for text correction
-  base_url: "https://api.openai.com/v1"
-  api_key: ""          # or use ${LLM_API_KEY}
-  model: "gpt-5.4-nano"
+  active_profile: "openai"
   temperature: 0
   top_p: 1
   timeout_ms: 8000
   max_output_tokens: 1024
-  max_token_parameter: "max_completion_tokens"  # use "max_tokens" for older model endpoints
-  no_reasoning_control: "reasoning_effort"       # "reasoning_effort" (OpenAI o-series), "thinking" (GLM etc.), "none" (send nothing)
   dictionary_max_candidates: 0             # 0 = send all entries to LLM
   system_prompt_path: "system_prompt.txt"  # relative to ~/.koe/
   user_prompt_path: "user_prompt.txt"      # relative to ~/.koe/
-
-  # MLX local LLM (Apple Silicon only)
-  mlx:
-    model: "mlx/Qwen3-1.7B-4bit"          # relative to ~/.koe/models/, or absolute path
+  profiles:
+    openai:
+      name: "OpenAI Compatible"
+      provider: "openai"
+      base_url: "https://api.openai.com/v1"
+      api_key: ""          # or use ${LLM_API_KEY}
+      model: "gpt-5.4-nano"
+      max_token_parameter: "max_completion_tokens"
+      no_reasoning_control: "reasoning_effort"
+    apfel:
+      name: "APFEL"
+      provider: "openai"
+      base_url: "http://127.0.0.1:11434/v1"
+      api_key: ""
+      model: "apple-foundationmodel"
+      max_token_parameter: "max_tokens"
+      no_reasoning_control: "none"
+    mlx:
+      name: "MLX (Apple Silicon)"
+      provider: "mlx"
+      mlx:
+        model: "mlx/Qwen3-0.6B-4bit"      # relative to ~/.koe/models/, or absolute path
 
 feedback:
   start_sound: false
@@ -1246,6 +1425,61 @@ mod tests {
         assert!(output.contains("cancel_key: right_option"));
 
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn default_llm_config_includes_openai_apfel_and_mlx_profiles() {
+        let llm = LlmSection::default();
+
+        assert_eq!(llm.active_profile, "openai");
+        assert!(llm.profiles.contains_key("openai"));
+        assert!(llm.profiles.contains_key("apfel"));
+        assert!(llm.profiles.contains_key("mlx"));
+
+        let apfel = llm.profiles.get("apfel").unwrap();
+        assert_eq!(apfel.provider, "openai");
+        assert_eq!(apfel.base_url, "http://127.0.0.1:11434/v1");
+        assert_eq!(apfel.api_key, "");
+        assert_eq!(apfel.model, "apple-foundationmodel");
+        assert!(matches!(
+            apfel.max_token_parameter,
+            LlmMaxTokenParameter::MaxTokens
+        ));
+        assert!(matches!(
+            apfel.no_reasoning_control,
+            LlmNoReasoningControl::None
+        ));
+    }
+
+    #[test]
+    fn active_profile_config_resolves_apfel_profile() {
+        let llm = LlmSection {
+            active_profile: "apfel".into(),
+            ..LlmSection::default()
+        };
+
+        let active = llm.active_profile_config().unwrap();
+
+        assert_eq!(active.id, "apfel");
+        assert_eq!(active.provider, "openai");
+        assert_eq!(active.base_url, "http://127.0.0.1:11434/v1");
+        assert_eq!(active.api_key, "");
+        assert_eq!(active.model, "apple-foundationmodel");
+        assert!(active.is_ready());
+    }
+
+    #[test]
+    fn mlx_profile_requires_model() {
+        let mut llm = LlmSection {
+            active_profile: "mlx".into(),
+            ..LlmSection::default()
+        };
+        let active = llm.active_profile_config().unwrap();
+        assert!(active.is_ready());
+
+        llm.profiles.get_mut("mlx").unwrap().mlx.model.clear();
+        let active = llm.active_profile_config().unwrap();
+        assert!(!active.is_ready());
     }
 
     // config_set tests are combined into one function because they mutate

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -792,10 +792,14 @@ async fn run_session(
         }
         invoke_state_changed(session_token, "correcting");
 
-        let llm: Box<dyn LlmProvider> = match llm_config.provider.as_str() {
+        let active_profile = llm_config
+            .active_profile_config()
+            .expect("llm_is_ready checked the active LLM profile");
+
+        let llm: Box<dyn LlmProvider> = match active_profile.provider.as_str() {
             #[cfg(feature = "mlx")]
             "mlx" => {
-                let model_path = config::resolve_model_dir(&llm_config.mlx.model)
+                let model_path = config::resolve_model_dir(&active_profile.mlx.model)
                     .to_string_lossy()
                     .to_string();
                 log::info!("[{session_id}] using MLX LLM provider: {model_path}");
@@ -809,14 +813,14 @@ async fn run_session(
             }
             _ => Box::new(OpenAiCompatibleProvider::new(
                 llm_http_client,
-                llm_config.base_url,
-                llm_config.api_key,
-                llm_config.model,
+                active_profile.base_url,
+                active_profile.api_key,
+                active_profile.model,
                 llm_config.temperature,
                 llm_config.top_p,
                 llm_config.max_output_tokens,
-                llm_config.max_token_parameter,
-                llm_config.no_reasoning_control,
+                active_profile.max_token_parameter,
+                active_profile.no_reasoning_control,
             )),
         };
 
@@ -831,7 +835,7 @@ async fn run_session(
         log::debug!("[{session_id}] LLM request — asr_text: \"{}\"", asr_text);
         // Skip interim history for local LLM — small models don't benefit from it
         // and it increases prompt length / inference time.
-        let history = if llm_config.provider == "mlx" {
+        let history = if active_profile.provider == "mlx" {
             &[][..]
         } else {
             &interim_history[..]
@@ -957,11 +961,9 @@ fn llm_is_ready(cfg: &config::LlmSection) -> bool {
     if !cfg.enabled {
         return false;
     }
-    match cfg.provider.as_str() {
-        #[cfg(feature = "mlx")]
-        "mlx" => !cfg.mlx.model.is_empty(),
-        _ => !cfg.base_url.is_empty() && !cfg.api_key.is_empty() && !cfg.model.is_empty(),
-    }
+    cfg.active_profile_config()
+        .map(|profile| profile.is_ready())
+        .unwrap_or(false)
 }
 
 fn start_llm_warmup_if_needed(
@@ -974,8 +976,16 @@ fn start_llm_warmup_if_needed(
     if !llm_is_ready(llm_config) {
         return;
     }
+    let active_profile = match llm_config.active_profile_config() {
+        Ok(profile) => profile,
+        Err(err) => {
+            log::debug!("[{session_id}] skipping LLM warmup; active profile failed: {err}");
+            return;
+        }
+    };
+
     // Local MLX provider doesn't need HTTP warmup
-    if llm_config.provider == "mlx" {
+    if active_profile.provider == "mlx" {
         return;
     }
 
@@ -999,16 +1009,25 @@ fn start_llm_warmup_if_needed(
     let warmup_cfg = llm_config.clone();
     runtime.spawn(async move {
         log::info!("[{warmup_session_id}] starting LLM warmup");
+        let warmup_profile = match warmup_cfg.active_profile_config() {
+            Ok(profile) => profile,
+            Err(err) => {
+                log::debug!("[{warmup_session_id}] LLM warmup profile failed: {err}");
+                let mut state = llm_warmup_state.lock().unwrap();
+                state.in_flight = false;
+                return;
+            }
+        };
         let llm = OpenAiCompatibleProvider::new(
             llm_http_client,
-            warmup_cfg.base_url,
-            warmup_cfg.api_key,
-            warmup_cfg.model,
+            warmup_profile.base_url,
+            warmup_profile.api_key,
+            warmup_profile.model,
             warmup_cfg.temperature,
             warmup_cfg.top_p,
             warmup_cfg.max_output_tokens,
-            warmup_cfg.max_token_parameter,
-            warmup_cfg.no_reasoning_control,
+            warmup_profile.max_token_parameter,
+            warmup_profile.no_reasoning_control,
         );
 
         let warmup_ok = match llm.warmup().await {
@@ -1208,22 +1227,15 @@ pub unsafe extern "C" fn sp_llm_test(
     // Load config from disk for remaining parameters (same as runtime hot-reload)
     let cfg = config::load_config().unwrap_or_default();
 
-    // Build an LlmSection that merges UI-editable fields with disk config
-    let llm_cfg = config::LlmSection {
-        enabled: true,
+    let profile = config::LlmProfileRuntimeConfig {
+        id: "test".into(),
+        name: "Test".into(),
         provider: "openai".into(),
         base_url,
         api_key,
         model,
         max_token_parameter,
-        temperature: cfg.llm.temperature,
-        top_p: cfg.llm.top_p,
-        timeout_ms: cfg.llm.timeout_ms,
-        max_output_tokens: cfg.llm.max_output_tokens,
-        dictionary_max_candidates: cfg.llm.dictionary_max_candidates,
-        no_reasoning_control: cfg.llm.no_reasoning_control,
-        system_prompt_path: cfg.llm.system_prompt_path.clone(),
-        user_prompt_path: cfg.llm.user_prompt_path.clone(),
+        no_reasoning_control: config::LlmNoReasoningControl::ReasoningEffort,
         mlx: Default::default(),
     };
 
@@ -1235,7 +1247,7 @@ pub unsafe extern "C" fn sp_llm_test(
     let dict_path = config::resolve_dictionary_path(&cfg);
     let dictionary = dictionary::load_dictionary(&dict_path).unwrap_or_default();
     let candidates =
-        prompt::filter_dictionary_candidates(&dictionary, "", llm_cfg.dictionary_max_candidates);
+        prompt::filter_dictionary_candidates(&dictionary, "", cfg.llm.dictionary_max_candidates);
 
     // Render user prompt from template with test content
     let test_asr = "so umm i installed this program called koe on my computer and like, \
@@ -1243,7 +1255,7 @@ pub unsafe extern "C" fn sp_llm_test(
     let user_prompt = prompt::render_user_prompt(&user_prompt_template, test_asr, &candidates, &[]);
 
     // Build HTTP client with the configured timeout
-    let client = match build_http_client(llm_cfg.timeout_ms) {
+    let client = match build_http_client(cfg.llm.timeout_ms) {
         Ok(c) => c,
         Err(e) => {
             let json = serde_json::json!({
@@ -1274,7 +1286,10 @@ pub unsafe extern "C" fn sp_llm_test(
 
     let (result, elapsed) = rt.block_on(llm::openai_compatible::test_correction(
         client,
-        &llm_cfg,
+        &profile,
+        cfg.llm.temperature,
+        cfg.llm.top_p,
+        cfg.llm.max_output_tokens,
         &system_prompt,
         &user_prompt,
     ));
@@ -1282,6 +1297,184 @@ pub unsafe extern "C" fn sp_llm_test(
 
     let json = match result {
         Ok(_corrected) => serde_json::json!({
+            "success": true,
+            "elapsed_ms": elapsed_ms,
+            "message": "Connection successful!",
+        }),
+        Err(e) => serde_json::json!({
+            "success": false,
+            "elapsed_ms": elapsed_ms,
+            "message": format!("{e}"),
+        }),
+    };
+
+    CString::new(json.to_string())
+        .unwrap_or_default()
+        .into_raw()
+}
+
+/// Return the active LLM profile id and saved profile map as JSON.
+#[no_mangle]
+pub extern "C" fn sp_llm_profiles_json() -> *mut c_char {
+    let json = match config::llm_profiles_payload() {
+        Ok(payload) => serde_json::to_string(&payload).unwrap_or_else(|_| "{}".into()),
+        Err(e) => serde_json::json!({
+            "active_profile": "openai",
+            "profiles": {},
+            "error": e.to_string(),
+        })
+        .to_string(),
+    };
+    CString::new(json).unwrap_or_default().into_raw()
+}
+
+/// Save the active LLM profile id and profile map from JSON.
+///
+/// # Safety
+/// `profiles_json` must be a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn sp_llm_save_profiles_json(profiles_json: *const c_char) -> i32 {
+    let Some(json) = (unsafe { cstr_to_str(profiles_json) }) else {
+        return -1;
+    };
+    let payload: config::LlmProfilesPayload = match serde_json::from_str(json) {
+        Ok(payload) => payload,
+        Err(e) => {
+            log::error!("sp_llm_save_profiles_json: parse: {e}");
+            return -1;
+        }
+    };
+    match config::save_llm_profiles_payload(&payload) {
+        Ok(()) => 0,
+        Err(e) => {
+            log::error!("sp_llm_save_profiles_json: save: {e}");
+            -1
+        }
+    }
+}
+
+/// Test a single LLM profile using the runtime correction path and global prompt settings.
+///
+/// # Safety
+/// `profile_json` must be a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn sp_llm_test_profile_json(profile_json: *const c_char) -> *mut c_char {
+    let Some(json) = (unsafe { cstr_to_str(profile_json) }) else {
+        return CString::new(
+            serde_json::json!({
+                "success": false,
+                "elapsed_ms": 0,
+                "message": "Missing profile JSON",
+            })
+            .to_string(),
+        )
+        .unwrap_or_default()
+        .into_raw();
+    };
+    let profile: config::LlmProfileRuntimeConfig = match serde_json::from_str(json) {
+        Ok(profile) => profile,
+        Err(e) => {
+            return CString::new(
+                serde_json::json!({
+                    "success": false,
+                    "elapsed_ms": 0,
+                    "message": format!("Invalid profile JSON: {e}"),
+                })
+                .to_string(),
+            )
+            .unwrap_or_default()
+            .into_raw();
+        }
+    };
+
+    let cfg = config::load_config().unwrap_or_default();
+    let system_prompt = prompt::load_system_prompt(&config::resolve_system_prompt_path(&cfg));
+    let user_prompt_template =
+        prompt::load_user_prompt_template(&config::resolve_user_prompt_path(&cfg));
+    let dict_path = config::resolve_dictionary_path(&cfg);
+    let dictionary = dictionary::load_dictionary(&dict_path).unwrap_or_default();
+    let candidates =
+        prompt::filter_dictionary_candidates(&dictionary, "", cfg.llm.dictionary_max_candidates);
+    let test_asr = "so umm i installed this program called koe on my computer and like, \
+                     i wanna know, you know, how much CPU and memory its using basically";
+    let user_prompt = prompt::render_user_prompt(&user_prompt_template, test_asr, &candidates, &[]);
+
+    let rt = match Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            return CString::new(
+                serde_json::json!({
+                    "success": false,
+                    "elapsed_ms": 0,
+                    "message": format!("Failed to create async runtime: {e}"),
+                })
+                .to_string(),
+            )
+            .unwrap_or_default()
+            .into_raw();
+        }
+    };
+
+    let request = CorrectionRequest {
+        asr_text: String::new(),
+        dictionary_entries: candidates,
+        system_prompt,
+        user_prompt,
+    };
+    let start = Instant::now();
+    let result = match profile.provider.as_str() {
+        #[cfg(feature = "mlx")]
+        "mlx" => {
+            let model_path = config::resolve_model_dir(&profile.mlx.model)
+                .to_string_lossy()
+                .to_string();
+            let llm = MlxLlmProvider::new(
+                model_path,
+                cfg.llm.temperature,
+                cfg.llm.top_p,
+                cfg.llm.max_output_tokens,
+                cfg.llm.timeout_ms,
+            );
+            rt.block_on(llm.correct(&request))
+        }
+        #[cfg(not(feature = "mlx"))]
+        "mlx" => Err(errors::KoeError::LlmFailed(
+            "MLX LLM support is not enabled in this build".into(),
+        )),
+        _ => {
+            let client = match build_http_client(cfg.llm.timeout_ms) {
+                Ok(c) => c,
+                Err(e) => {
+                    return CString::new(
+                        serde_json::json!({
+                            "success": false,
+                            "elapsed_ms": 0,
+                            "message": format!("Failed to create HTTP client: {e}"),
+                        })
+                        .to_string(),
+                    )
+                    .unwrap_or_default()
+                    .into_raw();
+                }
+            };
+            let llm = OpenAiCompatibleProvider::new(
+                client,
+                profile.base_url,
+                profile.api_key,
+                profile.model,
+                cfg.llm.temperature,
+                cfg.llm.top_p,
+                cfg.llm.max_output_tokens,
+                profile.max_token_parameter,
+                profile.no_reasoning_control,
+            );
+            rt.block_on(llm.correct(&request))
+        }
+    };
+    let elapsed = start.elapsed();
+    let elapsed_ms = elapsed.as_millis() as u64;
+    let json = match result {
+        Ok(_) => serde_json::json!({
             "success": true,
             "elapsed_ms": elapsed_ms,
             "message": "Connection successful!",

--- a/koe-core/src/llm/openai_compatible.rs
+++ b/koe-core/src/llm/openai_compatible.rs
@@ -1,4 +1,4 @@
-use crate::config::{LlmMaxTokenParameter, LlmNoReasoningControl, LlmSection};
+use crate::config::{LlmMaxTokenParameter, LlmNoReasoningControl, LlmProfileRuntimeConfig};
 use crate::errors::{KoeError, Result};
 use crate::llm::{CorrectionRequest, LlmProvider};
 use reqwest::Client;
@@ -53,19 +53,17 @@ impl OpenAiCompatibleProvider {
 
         log::debug!("LLM warmup request to {url}");
 
-        let response = self
-            .client
-            .get(&url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .send()
-            .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    KoeError::LlmTimeout
-                } else {
-                    KoeError::LlmFailed(e.to_string())
-                }
-            })?;
+        let mut builder = self.client.get(&url);
+        if !self.api_key.is_empty() {
+            builder = builder.header("Authorization", format!("Bearer {}", self.api_key));
+        }
+        let response = builder.send().await.map_err(|e| {
+            if e.is_timeout() {
+                KoeError::LlmTimeout
+            } else {
+                KoeError::LlmFailed(e.to_string())
+            }
+        })?;
 
         let status = response.status();
         match response.bytes().await {
@@ -98,20 +96,23 @@ pub fn build_http_client(timeout_ms: u64) -> std::result::Result<Client, reqwest
 /// Always returns elapsed time — even on timeout/error.
 pub async fn test_correction(
     client: Client,
-    llm_config: &LlmSection,
+    profile: &LlmProfileRuntimeConfig,
+    temperature: f64,
+    top_p: f64,
+    max_output_tokens: u32,
     system_prompt: &str,
     user_prompt: &str,
 ) -> (Result<String>, Duration) {
     let llm = OpenAiCompatibleProvider::new(
         client,
-        llm_config.base_url.clone(),
-        llm_config.api_key.clone(),
-        llm_config.model.clone(),
-        llm_config.temperature,
-        llm_config.top_p,
-        llm_config.max_output_tokens,
-        llm_config.max_token_parameter,
-        llm_config.no_reasoning_control,
+        profile.base_url.clone(),
+        profile.api_key.clone(),
+        profile.model.clone(),
+        temperature,
+        top_p,
+        max_output_tokens,
+        profile.max_token_parameter,
+        profile.no_reasoning_control,
     );
 
     let request = CorrectionRequest {
@@ -126,63 +127,91 @@ pub async fn test_correction(
     (result, start.elapsed())
 }
 
+pub fn build_chat_completion_body(
+    profile: &LlmProfileRuntimeConfig,
+    temperature: f64,
+    top_p: f64,
+    max_output_tokens: u32,
+    request: &CorrectionRequest,
+) -> Value {
+    let mut body = json!({
+        "model": profile.model,
+        "temperature": temperature,
+        "top_p": top_p,
+        "messages": [
+            {
+                "role": "system",
+                "content": request.system_prompt,
+            },
+            {
+                "role": "user",
+                "content": request.user_prompt,
+            }
+        ]
+    });
+    let token_field_name = match profile.max_token_parameter {
+        LlmMaxTokenParameter::MaxTokens => "max_tokens",
+        LlmMaxTokenParameter::MaxCompletionTokens => "max_completion_tokens",
+    };
+    body[token_field_name] = json!(max_output_tokens);
+    match profile.no_reasoning_control {
+        LlmNoReasoningControl::ReasoningEffort => {
+            if matches!(
+                profile.max_token_parameter,
+                LlmMaxTokenParameter::MaxCompletionTokens
+            ) {
+                body["reasoning_effort"] = json!("none");
+            }
+        }
+        LlmNoReasoningControl::Thinking => {
+            body["thinking"] = json!({"type": "disabled"});
+        }
+        LlmNoReasoningControl::None => {}
+    }
+    body
+}
+
 #[async_trait::async_trait]
 impl LlmProvider for OpenAiCompatibleProvider {
     async fn correct(&self, request: &CorrectionRequest) -> Result<String> {
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
 
-        let mut body = json!({
-            "model": self.model,
-            "temperature": self.temperature,
-            "top_p": self.top_p,
-            "messages": [
-                {
-                    "role": "system",
-                    "content": request.system_prompt,
-                },
-                {
-                    "role": "user",
-                    "content": request.user_prompt,
-                }
-            ]
-        });
-        let token_field_name = match self.max_token_parameter {
-            LlmMaxTokenParameter::MaxTokens => "max_tokens",
-            LlmMaxTokenParameter::MaxCompletionTokens => "max_completion_tokens",
+        let profile = LlmProfileRuntimeConfig {
+            id: String::new(),
+            name: String::new(),
+            provider: "openai".into(),
+            base_url: self.base_url.clone(),
+            api_key: self.api_key.clone(),
+            model: self.model.clone(),
+            max_token_parameter: self.max_token_parameter,
+            no_reasoning_control: self.no_reasoning_control,
+            mlx: Default::default(),
         };
-        body[token_field_name] = json!(self.max_output_tokens);
-        match self.no_reasoning_control {
-            LlmNoReasoningControl::ReasoningEffort => {
-                if matches!(
-                    self.max_token_parameter,
-                    LlmMaxTokenParameter::MaxCompletionTokens
-                ) {
-                    body["reasoning_effort"] = json!("none");
-                }
-            }
-            LlmNoReasoningControl::Thinking => {
-                body["thinking"] = json!({"type": "disabled"});
-            }
-            LlmNoReasoningControl::None => {}
-        }
+        let body = build_chat_completion_body(
+            &profile,
+            self.temperature,
+            self.top_p,
+            self.max_output_tokens,
+            request,
+        );
 
         log::debug!("LLM request to {url}");
 
-        let response = self
+        let mut builder = self
             .client
             .post(&url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    KoeError::LlmTimeout
-                } else {
-                    KoeError::LlmFailed(e.to_string())
-                }
-            })?;
+            .json(&body);
+        if !self.api_key.is_empty() {
+            builder = builder.header("Authorization", format!("Bearer {}", self.api_key));
+        }
+        let response = builder.send().await.map_err(|e| {
+            if e.is_timeout() {
+                KoeError::LlmTimeout
+            } else {
+                KoeError::LlmFailed(e.to_string())
+            }
+        })?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -215,5 +244,65 @@ impl LlmProvider for OpenAiCompatibleProvider {
             .unwrap_or(cleaned);
 
         Ok(cleaned.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{LlmMaxTokenParameter, LlmNoReasoningControl, LlmProfileRuntimeConfig};
+
+    fn request() -> CorrectionRequest {
+        CorrectionRequest {
+            asr_text: "raw".into(),
+            dictionary_entries: vec![],
+            system_prompt: "system".into(),
+            user_prompt: "user".into(),
+        }
+    }
+
+    #[test]
+    fn apfel_body_uses_max_tokens_without_reasoning_controls() {
+        let profile = LlmProfileRuntimeConfig {
+            id: "apfel".into(),
+            name: "APFEL".into(),
+            provider: "openai".into(),
+            base_url: "http://127.0.0.1:11434/v1".into(),
+            api_key: "".into(),
+            model: "apple-foundationmodel".into(),
+            max_token_parameter: LlmMaxTokenParameter::MaxTokens,
+            no_reasoning_control: LlmNoReasoningControl::None,
+            mlx: Default::default(),
+        };
+
+        let body = build_chat_completion_body(&profile, 0.0, 1.0, 1024, &request());
+
+        assert_eq!(body["model"], "apple-foundationmodel");
+        assert_eq!(body["max_tokens"], 1024);
+        assert!(body.get("max_completion_tokens").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("thinking").is_none());
+    }
+
+    #[test]
+    fn openai_body_keeps_max_completion_tokens_and_reasoning_control() {
+        let profile = LlmProfileRuntimeConfig {
+            id: "openai".into(),
+            name: "OpenAI".into(),
+            provider: "openai".into(),
+            base_url: "https://api.openai.com/v1".into(),
+            api_key: "sk-test".into(),
+            model: "gpt-5.4-nano".into(),
+            max_token_parameter: LlmMaxTokenParameter::MaxCompletionTokens,
+            no_reasoning_control: LlmNoReasoningControl::ReasoningEffort,
+            mlx: Default::default(),
+        };
+
+        let body = build_chat_completion_body(&profile, 0.0, 1.0, 1024, &request());
+
+        assert_eq!(body["model"], "gpt-5.4-nano");
+        assert_eq!(body["max_completion_tokens"], 1024);
+        assert_eq!(body["reasoning_effort"], "none");
+        assert!(body.get("max_tokens").is_none());
     }
 }

--- a/koe-core/src/model_manager.rs
+++ b/koe-core/src/model_manager.rs
@@ -640,6 +640,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test model".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -714,6 +715,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -757,6 +759,7 @@ mod tests {
         let content = b"some model data";
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -824,6 +827,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -870,6 +874,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -938,6 +943,7 @@ mod tests {
         };
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -988,6 +994,7 @@ mod tests {
 
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![
@@ -1044,6 +1051,7 @@ mod tests {
         };
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {
@@ -1107,6 +1115,7 @@ mod tests {
         };
         let manifest = ModelManifest {
             provider: "test".into(),
+            mode: None,
             description: "test".into(),
             repo: "test/model".into(),
             files: vec![ModelFile {


### PR DESCRIPTION
 ## Summary
  This PR introduces a robust LLM profile management system that allows users to configure and
  switch between multiple remote and local models seamlessly. It transitions from a single global
  LLM setting to a dynamic, multi-provider architecture.

  ## Key Features
   - Dynamic Profile Management: Users can now create, name, and delete multiple LLM profiles (e.g., separate profiles for OpenAI, local APFEL/Ollama, or MLX).
   - APFEL Integration: Added a one-click shortcut to set up a profile for "APFEL" (local Apple Foundation Models via Ollama-compatible endpoints).
   - Local MLX Support: Built-in model picker and download management for Apple Silicon-optimized local models.
   - Native UI: Redesigned the "LLM" tab in the Setup Wizard with a new profile selector and controls.
   - Core Refactoring: 
       - Updated the Rust core to handle profile resolution at runtime via a BTreeMap based profile store.
       - Added atomic JSON-based FFI endpoints (sp_llm_profiles_json, etc.) for seamless communication with the native Objective-C shell.
       - Implemented backward-compatible migration logic for existing configurations.

  ## Technical Details
   - FFI: Added support for sp_llm_profiles_json, sp_llm_save_profiles_json, and sp_llm_test_profile_json.
   - Config Schema: Refactored LlmSection to store active_profile and a collection of profiles.
   - Reasoning Control: Improved support for reasoning_effort (OpenAI o-series) and thinking (GLM etc.) at the profile level.

  ## Verification
   - [x] Verified full build with make build.
   - [x] Passed unit tests in koe-core/src/config.rs for profile resolution and default states.
   - [x] Manually verified profile switching, adding, and saving in the native macOS UI.