### PR TITLE
feat(hotkey): add configurable LLM invert modifier for recording

### DIFF
--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -76,7 +76,8 @@ static BOOL configFlagEnabled(const char *keyPath) {
                    self.hotkeyMonitor.altKeyCode != hotkeyConfig.trigger_alt_key_code ||
                    self.hotkeyMonitor.targetModifierFlag != hotkeyConfig.trigger_modifier_flag ||
                    self.hotkeyMonitor.targetMatchKind != hotkeyConfig.trigger_match_kind ||
-                   self.hotkeyMonitor.triggerMode != hotkeyConfig.trigger_mode;
+                   self.hotkeyMonitor.triggerMode != hotkeyConfig.trigger_mode ||
+                   self.hotkeyMonitor.llmInvertModifierFlag != hotkeyConfig.llm_invert_modifier_flag;
 
     if (!changed) return;
 
@@ -89,6 +90,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
     self.hotkeyMonitor.targetModifierFlag = hotkeyConfig.trigger_modifier_flag;
     self.hotkeyMonitor.targetMatchKind = hotkeyConfig.trigger_match_kind;
     self.hotkeyMonitor.triggerMode = hotkeyConfig.trigger_mode;
+    self.hotkeyMonitor.llmInvertModifierFlag = hotkeyConfig.llm_invert_modifier_flag;
 
     if (restartIfNeeded) {
         [self.hotkeyMonitor start];
@@ -255,11 +257,12 @@ static BOOL configFlagEnabled(const char *keyPath) {
     // Read new hotkey config
     struct SPHotkeyConfig newConfig = sp_core_get_hotkey_config();
 
-    NSLog(@"[Koe] Reloaded hotkey config: trigger=%d/%d flag=0x%llx kind=%d",
+    NSLog(@"[Koe] Reloaded hotkey config: trigger=%d/%d flag=0x%llx kind=%d llmInvert=0x%llx",
           newConfig.trigger_key_code,
           newConfig.trigger_alt_key_code,
           (unsigned long long)newConfig.trigger_modifier_flag,
-          newConfig.trigger_match_kind);
+          newConfig.trigger_match_kind,
+          (unsigned long long)newConfig.llm_invert_modifier_flag);
     [self applyHotkeyConfig:newConfig restartMonitorIfNeeded:YES];
     [self.overlayPanel reloadAppearanceFromConfig];
 }
@@ -273,8 +276,8 @@ static BOOL configFlagEnabled(const char *keyPath) {
     }
 }
 
-- (void)hotkeyMonitorDidDetectHoldStart {
-    NSLog(@"[Koe] Hold start detected");
+- (void)hotkeyMonitorDidDetectHoldStartWithLlmInversion:(BOOL)llmInverted {
+    NSLog(@"[Koe] Hold start detected (llmInverted=%@)", llmInverted ? @"YES" : @"NO");
     [self stopNumberKeyMonitoring];
     [self.overlayPanel hideTemplateButtons];
     self.showingError = NO;
@@ -288,7 +291,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
     [self.overlayPanel updateState:@"recording"];
 
     // Start Rust session + audio capture
-    if (![self.rustBridge beginSessionWithMode:SPSessionModeHold]) {
+    if (![self.rustBridge beginSessionWithMode:SPSessionModeHold llmInverted:llmInverted]) {
         [self handleAudioCaptureError:@"Failed to start session"];
         return;
     }
@@ -319,8 +322,8 @@ static BOOL configFlagEnabled(const char *keyPath) {
                    dispatch_get_main_queue(), block);
 }
 
-- (void)hotkeyMonitorDidDetectTapStart {
-    NSLog(@"[Koe] Tap start detected");
+- (void)hotkeyMonitorDidDetectTapStartWithLlmInversion:(BOOL)llmInverted {
+    NSLog(@"[Koe] Tap start detected (llmInverted=%@)", llmInverted ? @"YES" : @"NO");
     [self stopNumberKeyMonitoring];
     [self.overlayPanel hideTemplateButtons];
     self.showingError = NO;
@@ -333,7 +336,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
     [self.statusBarManager updateState:@"recording"];
     [self.overlayPanel updateState:@"recording"];
 
-    if (![self.rustBridge beginSessionWithMode:SPSessionModeToggle]) {
+    if (![self.rustBridge beginSessionWithMode:SPSessionModeToggle llmInverted:llmInverted]) {
         [self handleAudioCaptureError:@"Failed to start session"];
         return;
     }

--- a/KoeApp/Koe/Bridge/SPRustBridge.h
+++ b/KoeApp/Koe/Bridge/SPRustBridge.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSInteger, SPSessionModeObjC) {
 - (void)destroyCore;
 
 /// Begin a new voice input session. Returns YES on success.
-- (BOOL)beginSessionWithMode:(SPSessionModeObjC)mode;
+- (BOOL)beginSessionWithMode:(SPSessionModeObjC)mode llmInverted:(BOOL)llmInverted;
 
 /// Push an audio frame to the Rust core.
 - (void)pushAudioFrame:(const void *)buffer length:(uint32_t)length timestamp:(uint64_t)timestamp;

--- a/KoeApp/Koe/Bridge/SPRustBridge.m
+++ b/KoeApp/Koe/Bridge/SPRustBridge.m
@@ -165,7 +165,7 @@ static void bridge_on_rewrite_text_ready(uint64_t token, const char *text) {
     sp_core_destroy();
 }
 
-- (BOOL)beginSessionWithMode:(SPSessionModeObjC)mode {
+- (BOOL)beginSessionWithMode:(SPSessionModeObjC)mode llmInverted:(BOOL)llmInverted {
     NSRunningApplication *frontApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
     const char *bundleId = frontApp.bundleIdentifier.UTF8String;
     pid_t pid = frontApp.processIdentifier;
@@ -177,6 +177,7 @@ static void bridge_on_rewrite_text_ready(uint64_t token, const char *text) {
         .frontmost_bundle_id = bundleId,
         .frontmost_pid = (int)pid,
         .session_token = _currentSessionToken,
+        .llm_invert_modifier_active = llmInverted,
     };
 
     int32_t result = sp_core_session_begin(context);

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
@@ -2,9 +2,9 @@
 
 /// Delegate protocol for hotkey events
 @protocol SPHotkeyMonitorDelegate <NSObject>
-- (void)hotkeyMonitorDidDetectHoldStart;
+- (void)hotkeyMonitorDidDetectHoldStartWithLlmInversion:(BOOL)llmInverted;
 - (void)hotkeyMonitorDidDetectHoldEnd;
-- (void)hotkeyMonitorDidDetectTapStart;
+- (void)hotkeyMonitorDidDetectTapStartWithLlmInversion:(BOOL)llmInverted;
 - (void)hotkeyMonitorDidDetectTapEnd;
 @end
 
@@ -20,6 +20,9 @@ typedef NS_ENUM(uint8_t, SPHotkeyMatchKind) {
 
 /// Trigger mode: 0 = hold (short press ignored), 1 = toggle (tap to start/stop).
 @property (nonatomic, assign) uint8_t triggerMode;
+
+/// Modifier flag that inverts LLM correction for the current session. 0 disables inversion.
+@property (nonatomic, assign) NSUInteger llmInvertModifierFlag;
 
 /// Primary key code to monitor (default: 63 = Fn/Globe)
 @property (nonatomic, assign) NSInteger targetKeyCode;

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
@@ -25,16 +25,18 @@ typedef NS_ENUM(NSInteger, SPHotkeyState) {
 @property (nonatomic, assign, readwrite) BOOL canConsumeGlobalKeyEvents;
 @property (nonatomic, strong) NSMutableSet<NSNumber *> *suppressedNumberKeyCodes;
 @property (nonatomic, strong) NSMutableSet<NSNumber *> *suppressedHotkeyKeyCodes;
+@property (nonatomic, assign) BOOL pendingLlmInvertModifierActive;
 
 - (void)handleFlagsChangedEvent:(CGEventRef)event;
 - (BOOL)handleNSEvent:(NSEvent *)event;
 - (BOOL)isTargetKeyCode:(NSInteger)keyCode;
 - (BOOL)isModifierOnlyMatchKind:(uint8_t)matchKind;
 - (BOOL)keyModifiers:(NSUInteger)flags matchRequiredModifiers:(NSUInteger)requiredFlags;
+- (BOOL)isLlmInvertModifierActiveForFlags:(NSUInteger)flags;
 - (BOOL)isRecordingState;
 - (BOOL)handleNumberKeyWithKeyCode:(NSInteger)keyCode;
 - (BOOL)consumeSuppressedNumberKeyForKeyCode:(NSInteger)keyCode isKeyUp:(BOOL)isKeyUp;
-- (void)handleTriggerDown;
+- (void)handleTriggerDownWithModifierFlags:(NSUInteger)flags;
 - (void)handleTriggerUp;
 
 @end
@@ -122,7 +124,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
                 monitor.triggerDown = isDown;
                 dispatch_async(dispatch_get_main_queue(), ^{
                     if (isDown) {
-                        [monitor handleTriggerDown];
+                        [monitor handleTriggerDownWithModifierFlags:flags];
                     } else {
                         [monitor handleTriggerUp];
                     }
@@ -160,6 +162,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
         _altKeyCode = 179;         // Globe key on newer keyboards
         _targetModifierFlag = 0x00800000; // NX_SECONDARYFNMASK
         _targetMatchKind = SPHotkeyMatchKindModifierOnly;
+        _llmInvertModifierFlag = NSEventModifierFlagControl;
         _canConsumeGlobalKeyEvents = NO;
         _suppressedNumberKeyCodes = [NSMutableSet set];
         _suppressedHotkeyKeyCodes = [NSMutableSet set];
@@ -257,7 +260,17 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
 }
 
 - (BOOL)keyModifiers:(NSUInteger)flags matchRequiredModifiers:(NSUInteger)requiredFlags {
-    return (flags & SPHotkeyRelevantModifierMask) == requiredFlags;
+    NSUInteger relevantFlags = flags & SPHotkeyRelevantModifierMask;
+    if (relevantFlags == requiredFlags) return YES;
+    if (self.llmInvertModifierFlag == 0) return NO;
+
+    NSUInteger withoutInvertModifier = relevantFlags & ~self.llmInvertModifierFlag;
+    return withoutInvertModifier == requiredFlags;
+}
+
+- (BOOL)isLlmInvertModifierActiveForFlags:(NSUInteger)flags {
+    return self.llmInvertModifierFlag != 0 &&
+           (flags & self.llmInvertModifierFlag) == self.llmInvertModifierFlag;
 }
 
 - (BOOL)isRecordingState {
@@ -314,7 +327,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
             if (keyNow != self.triggerDown) {
                 self.triggerDown = keyNow;
                 if (keyNow) {
-                    [self handleTriggerDown];
+                    [self handleTriggerDownWithModifierFlags:flags];
                 } else {
                     [self handleTriggerUp];
                 }
@@ -349,7 +362,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
             if (isDown != self.triggerDown) {
                 self.triggerDown = isDown;
                 if (isDown) {
-                    [self handleTriggerDown];
+                    [self handleTriggerDownWithModifierFlags:flags];
                 } else {
                     [self handleTriggerUp];
                 }
@@ -385,6 +398,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
 
     [self cancelHoldTimer];
     self.state = SPHotkeyStateIdle;
+    self.pendingLlmInvertModifierActive = NO;
     self.canConsumeGlobalKeyEvents = NO;
     [self.suppressedNumberKeyCodes removeAllObjects];
     [self.suppressedHotkeyKeyCodes removeAllObjects];
@@ -418,7 +432,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
 
     if (triggerNow) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self handleTriggerDown];
+            [self handleTriggerDownWithModifierFlags:(NSUInteger)flags];
         });
     } else {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -427,11 +441,12 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
     }
 }
 
-- (void)handleTriggerDown {
+- (void)handleTriggerDownWithModifierFlags:(NSUInteger)flags {
     if (!self.running) return;
     NSLog(@"[Koe] Trigger DOWN (state=%ld)", (long)self.state);
     switch (self.state) {
         case SPHotkeyStateIdle:
+            self.pendingLlmInvertModifierActive = [self isLlmInvertModifierActiveForFlags:flags];
             self.state = SPHotkeyStatePending;
             [self startHoldTimer];
             break;
@@ -455,9 +470,10 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
             if (self.triggerMode == 1) {
                 // Toggle mode: short press starts recording
                 self.state = SPHotkeyStateRecordingToggle;
-                [self.delegate hotkeyMonitorDidDetectTapStart];
+                [self.delegate hotkeyMonitorDidDetectTapStartWithLlmInversion:self.pendingLlmInvertModifierActive];
             } else {
                 // Hold mode: short press is ignored
+                self.pendingLlmInvertModifierActive = NO;
                 self.state = SPHotkeyStateIdle;
             }
             break;
@@ -468,6 +484,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
             break;
 
         case SPHotkeyStateConsumeKeyUp:
+            self.pendingLlmInvertModifierActive = NO;
             self.state = SPHotkeyStateIdle;
             break;
 
@@ -494,7 +511,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
 - (void)holdTimerFired {
     if (self.state == SPHotkeyStatePending) {
         self.state = SPHotkeyStateRecordingHold;
-        [self.delegate hotkeyMonitorDidDetectHoldStart];
+        [self.delegate hotkeyMonitorDidDetectHoldStartWithLlmInversion:self.pendingLlmInvertModifierActive];
     }
 }
 
@@ -502,6 +519,7 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
     [self cancelHoldTimer];
     self.triggerDown = NO;
     self.state = SPHotkeyStateIdle;
+    self.pendingLlmInvertModifierActive = NO;
     [self.suppressedNumberKeyCodes removeAllObjects];
     [self.suppressedHotkeyKeyCodes removeAllObjects];
 }

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -279,6 +279,20 @@ static NSDictionary<NSString *, NSString *> *comboModifierDisplayNames(void) {
     return displayNames;
 }
 
+static NSSet<NSString *> *llmInvertModifierValues(void) {
+    static NSSet<NSString *> *values;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        values = [NSSet setWithArray:@[@"control", @"option", @"command", @"shift", @"fn", @"none"]];
+    });
+    return values;
+}
+
+static NSString *normalizedLlmInvertModifierValue(NSString *value) {
+    NSString *trimmedValue = [[value ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    return [llmInvertModifierValues() containsObject:trimmedValue] ? trimmedValue : @"control";
+}
+
 static NSString *normalizedHotkeyComboValue(NSString *value) {
     if (![value containsString:@"+"]) return nil;
 
@@ -487,6 +501,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 @property (nonatomic, copy) NSString *recordingHotkeyTarget;
 // Trigger mode
 @property (nonatomic, strong) NSPopUpButton *triggerModePopup;
+@property (nonatomic, strong) NSPopUpButton *llmInvertModifierPopup;
 @property (nonatomic, strong) NSSwitch *startSoundCheckbox;
 @property (nonatomic, strong) NSSwitch *stopSoundCheckbox;
 @property (nonatomic, strong) NSSwitch *errorSoundCheckbox;
@@ -1306,10 +1321,13 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     [self.triggerModePopup itemAtIndex:0].representedObject = @"hold";
     [self.triggerModePopup itemAtIndex:1].representedObject = @"toggle";
 
+    self.llmInvertModifierPopup = [self llmInvertModifierPopupControl];
+
     // ── Trigger card ──
     NSView *triggerCard = [self cardWithTitle:@"Trigger" rows:@[
         [self cardRowWithLabel:@"Trigger Shortcut" control:triggerShortcutControl],
         [self cardRowWithLabel:@"Trigger Mode" control:self.triggerModePopup],
+        [self cardRowWithLabel:@"LLM Modifier" control:self.llmInvertModifierPopup],
     ] width:cardWidth];
 
     // ── Feedback Sounds ──
@@ -1349,6 +1367,17 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     [self addButtonsToPane:pane atY:16 width:paneWidth];
 
     return pane;
+}
+
+- (NSPopUpButton *)llmInvertModifierPopupControl {
+    NSPopUpButton *popup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 220, 26) pullsDown:NO];
+    NSArray<NSString *> *titles = @[@"Control", @"Option", @"Command", @"Shift", @"Fn", @"None"];
+    NSArray<NSString *> *values = @[@"control", @"option", @"command", @"shift", @"fn", @"none"];
+    [popup addItemsWithTitles:titles];
+    for (NSInteger idx = 0; idx < (NSInteger)values.count; idx++) {
+        [popup itemAtIndex:idx].representedObject = values[idx];
+    }
+    return popup;
 }
 
 - (NSPopUpButton *)hotkeyPresetPopup {
@@ -1443,6 +1472,17 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     }
 
     [popup selectItemAtIndex:0];
+}
+
+- (void)selectLlmInvertModifierValue:(NSString *)value {
+    NSString *normalizedValue = normalizedLlmInvertModifierValue(value);
+    for (NSMenuItem *item in self.llmInvertModifierPopup.itemArray) {
+        if ([[item.representedObject description] isEqualToString:normalizedValue]) {
+            [self.llmInvertModifierPopup selectItem:item];
+            return;
+        }
+    }
+    [self.llmInvertModifierPopup selectItemAtIndex:0];
 }
 
 - (void)triggerHotkeyChanged:(id)sender {
@@ -3490,6 +3530,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         } else {
             [self.triggerModePopup selectItemAtIndex:0];
         }
+        [self selectLlmInvertModifierValue:configGet(@"hotkey.llm_invert_modifier")];
 
         NSString *startSound = configGet(@"feedback.start_sound");
         NSString *stopSound = configGet(@"feedback.stop_sound");
@@ -3665,6 +3706,8 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         // Save trigger mode
         NSString *triggerModeValue = [self.triggerModePopup selectedItem].representedObject ?: @"hold";
         saveOk &= configSet(@"hotkey.trigger_mode", triggerModeValue);
+        NSString *llmInvertModifierValue = normalizedLlmInvertModifierValue(self.llmInvertModifierPopup.selectedItem.representedObject ?: @"control");
+        saveOk &= configSet(@"hotkey.llm_invert_modifier", llmInvertModifierValue);
     }
     if (self.overlayFontSizeSlider) {
         NSString *fontFamily = [self selectedOverlayFontFamilyValue];

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ hotkey:
   # or a normalized key combo such as "command+shift+49".
   trigger_key: "fn"
   trigger_mode: "hold"  # "hold" | "toggle"
+  llm_invert_modifier: "control"  # control | option | command | shift | fn | none
 ```
 
 | Option | Key | Notes |
@@ -368,6 +369,11 @@ hotkey:
 
 Hotkey changes take effect automatically within a few seconds. Koe now uses a
 single trigger shortcut model:
+
+Hold the configured `llm_invert_modifier` while starting a recording to invert
+`llm.enabled` for that session only. For example, with the defaults,
+`Control + Fn` skips LLM correction when LLM is normally enabled, or tries LLM
+correction when LLM is normally disabled.
 
 - `hold`: press-and-hold to record, release to stop
 - `toggle`: tap once to start, tap again to stop

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -461,6 +461,11 @@ pub struct HotkeySection {
     /// Trigger mode: "hold" (press-and-hold, default) or "toggle" (tap to start/stop).
     #[serde(default = "default_trigger_mode")]
     pub trigger_mode: String,
+
+    /// Modifier that inverts whether the current session uses LLM correction.
+    /// Options: "control", "option", "command", "shift", "fn", "none".
+    #[serde(default = "default_llm_invert_modifier")]
+    pub llm_invert_modifier: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -495,6 +500,14 @@ impl HotkeySection {
         Self::normalize_trigger_key_name(&self.trigger_key)
     }
 
+    pub fn normalized_llm_invert_modifier(&self) -> String {
+        Self::normalize_llm_invert_modifier_name(&self.llm_invert_modifier)
+    }
+
+    pub fn llm_invert_modifier_flag(&self) -> u64 {
+        Self::llm_invert_modifier_flag_for_name(&self.normalized_llm_invert_modifier())
+    }
+
     fn normalize_trigger_key_name(value: &str) -> String {
         match value {
             "left_option" | "right_option" | "left_command" | "right_command" | "left_control"
@@ -506,6 +519,22 @@ impl HotkeySection {
                 Self::parse_hotkey_combo(value).unwrap().normalized_value
             }
             _ => default_trigger_key(),
+        }
+    }
+
+    fn normalize_llm_invert_modifier_name(value: &str) -> String {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "control" | "option" | "command" | "shift" | "fn" | "none" => {
+                value.trim().to_ascii_lowercase()
+            }
+            _ => default_llm_invert_modifier(),
+        }
+    }
+
+    fn llm_invert_modifier_flag_for_name(value: &str) -> u64 {
+        match value {
+            "none" => 0,
+            modifier => Self::combo_modifier_flag(modifier).unwrap_or(0x0004_0000),
         }
     }
 
@@ -805,6 +834,10 @@ fn default_trigger_key() -> String {
 
 fn default_trigger_mode() -> String {
     "hold".into()
+}
+
+fn default_llm_invert_modifier() -> String {
+    "control".into()
 }
 
 fn default_user_prompt_path() -> String {
@@ -1568,6 +1601,8 @@ hotkey:
   # 触发键：fn | left_option | right_option | left_command | right_command | left_control | right_control
   # 也可以填 macOS keycode 数字来使用非修饰键，例如 122 (F1)、120 (F2)、99 (F3) 等
   trigger_key: "fn"
+  trigger_mode: "hold"                 # hold | toggle
+  llm_invert_modifier: "control"       # control | option | command | shift | fn | none
 
 overlay:
   font_family: "system"
@@ -1630,8 +1665,40 @@ mod tests {
             trigger_key: "nonexistent".into(),
             cancel_key: "left_option".into(),
             trigger_mode: "hold".into(),
+            llm_invert_modifier: "control".into(),
         };
         assert_eq!(h.normalized_trigger_key(), "fn");
+    }
+
+    #[test]
+    fn default_llm_invert_modifier_is_control() {
+        let config = Config::default();
+        assert_eq!(config.hotkey.normalized_llm_invert_modifier(), "control");
+        assert_eq!(config.hotkey.llm_invert_modifier_flag(), 0x0004_0000);
+    }
+
+    #[test]
+    fn invalid_llm_invert_modifier_falls_back_to_control() {
+        let h = HotkeySection {
+            trigger_key: "fn".into(),
+            cancel_key: "".into(),
+            trigger_mode: "hold".into(),
+            llm_invert_modifier: "caps_lock".into(),
+        };
+        assert_eq!(h.normalized_llm_invert_modifier(), "control");
+        assert_eq!(h.llm_invert_modifier_flag(), 0x0004_0000);
+    }
+
+    #[test]
+    fn none_llm_invert_modifier_resolves_to_zero_flag() {
+        let h = HotkeySection {
+            trigger_key: "fn".into(),
+            cancel_key: "".into(),
+            trigger_mode: "hold".into(),
+            llm_invert_modifier: "none".into(),
+        };
+        assert_eq!(h.normalized_llm_invert_modifier(), "none");
+        assert_eq!(h.llm_invert_modifier_flag(), 0);
     }
 
     #[test]
@@ -1644,6 +1711,7 @@ mod tests {
                 trigger_key: "0x7A".into(),
                 cancel_key: "".into(),
                 trigger_mode: "hold".into(),
+                llm_invert_modifier: "control".into(),
             },
             ..Config::default()
         };
@@ -1670,6 +1738,7 @@ mod tests {
             trigger_key: "shift+cmd+49".into(),
             cancel_key: "command+shift+49".into(),
             trigger_mode: "hold".into(),
+            llm_invert_modifier: "control".into(),
         };
         assert_eq!(h.normalized_trigger_key(), "command+shift+49");
     }
@@ -1680,6 +1749,7 @@ mod tests {
             trigger_key: "cmd+shift+49".into(),
             cancel_key: "option+53".into(),
             trigger_mode: "hold".into(),
+            llm_invert_modifier: "control".into(),
         };
         let resolved = h.resolve();
 

--- a/koe-core/src/ffi.rs
+++ b/koe-core/src/ffi.rs
@@ -21,6 +21,9 @@ pub struct SPSessionContext {
     /// Passed back through all session callbacks so the caller can
     /// discard events from superseded sessions.
     pub session_token: u64,
+    /// Whether the configured per-session LLM inversion modifier was active
+    /// when recording started.
+    pub llm_invert_modifier_active: bool,
 }
 
 /// Callback function types that Obj-C registers with Rust.
@@ -177,6 +180,8 @@ pub struct SPHotkeyConfig {
     pub trigger_match_kind: u8,
     /// Trigger mode: 0 = hold (press-and-hold), 1 = toggle (tap to start/stop)
     pub trigger_mode: u8,
+    /// Modifier flag that inverts LLM correction for the current session.
+    pub llm_invert_modifier_flag: u64,
 }
 
 /// Helper to convert a C string pointer to a Rust &str

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -275,6 +275,7 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
     let session = Session::new(context.mode, bundle_id, context.frontmost_pid);
     let session_id = session.id.clone();
     let session_token = context.session_token;
+    let llm_invert_modifier_active = context.llm_invert_modifier_active;
     core.current_session_token = session_token;
     let mode = context.mode;
 
@@ -466,6 +467,7 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
         &core.runtime,
         &session_id,
         &llm_config,
+        llm_invert_modifier_active,
         llm_http_client.clone(),
         llm_warmup_state.clone(),
     );
@@ -482,6 +484,7 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
             asr_provider_name,
             asr,
             llm_config,
+            llm_invert_modifier_active,
             llm_http_client,
             llm_warmup_state,
             dictionary,
@@ -847,6 +850,7 @@ pub extern "C" fn sp_core_get_hotkey_config() -> SPHotkeyConfig {
             trigger_modifier_flag: params.modifier_flag,
             trigger_match_kind: params.match_kind as u8,
             trigger_mode,
+            llm_invert_modifier_flag: core.config.hotkey.llm_invert_modifier_flag(),
         }
     } else {
         SPHotkeyConfig {
@@ -855,6 +859,7 @@ pub extern "C" fn sp_core_get_hotkey_config() -> SPHotkeyConfig {
             trigger_modifier_flag: 0x00800000,
             trigger_match_kind: 0,
             trigger_mode: 0,
+            llm_invert_modifier_flag: 0x0004_0000,
         }
     }
 }
@@ -872,6 +877,7 @@ async fn run_session(
     asr_provider: String,
     mut asr: Box<dyn AsrProvider>,
     llm_config: config::LlmSection,
+    llm_invert_modifier_active: bool,
     llm_http_client: Client,
     llm_warmup_state: Arc<Mutex<LlmWarmupState>>,
     dictionary: Vec<String>,
@@ -1061,7 +1067,7 @@ async fn run_session(
         return;
     }
 
-    let llm_enabled = llm_is_ready(&llm_config);
+    let llm_enabled = llm_enabled_for_session(&llm_config, llm_invert_modifier_active);
 
     let final_text = if llm_enabled {
         {
@@ -1074,7 +1080,7 @@ async fn run_session(
 
         let active_profile = llm_config
             .active_profile_config()
-            .expect("llm_is_ready checked the active LLM profile");
+            .expect("llm_enabled_for_session checked the active LLM profile");
 
         let llm: Box<dyn LlmProvider> = match active_profile.provider.as_str() {
             #[cfg(feature = "mlx")]
@@ -1151,7 +1157,14 @@ async fn run_session(
             }
         }
     } else {
-        if !llm_config.enabled {
+        let effective_llm_enabled = if llm_invert_modifier_active {
+            !llm_config.enabled
+        } else {
+            llm_config.enabled
+        };
+        if !effective_llm_enabled && llm_invert_modifier_active && llm_config.enabled {
+            log::info!("[{session_id}] LLM inverted off for this session, using raw ASR text");
+        } else if !effective_llm_enabled {
             log::info!("[{session_id}] LLM disabled, using raw ASR text");
         } else {
             log::info!("[{session_id}] LLM not configured, using raw ASR text");
@@ -1237,8 +1250,13 @@ fn cleanup_session(session_arc: &Arc<Mutex<Option<Session>>>) {
     *s = None;
 }
 
-fn llm_is_ready(cfg: &config::LlmSection) -> bool {
-    if !cfg.enabled {
+fn llm_enabled_for_session(cfg: &config::LlmSection, llm_invert_modifier_active: bool) -> bool {
+    let enabled = if llm_invert_modifier_active {
+        !cfg.enabled
+    } else {
+        cfg.enabled
+    };
+    if !enabled {
         return false;
     }
     cfg.active_profile_config()
@@ -1250,10 +1268,11 @@ fn start_llm_warmup_if_needed(
     runtime: &Runtime,
     session_id: &str,
     llm_config: &config::LlmSection,
+    llm_invert_modifier_active: bool,
     llm_http_client: Client,
     llm_warmup_state: Arc<Mutex<LlmWarmupState>>,
 ) {
-    if !llm_is_ready(llm_config) {
+    if !llm_enabled_for_session(llm_config, llm_invert_modifier_active) {
         return;
     }
     let active_profile = match llm_config.active_profile_config() {
@@ -2045,6 +2064,41 @@ mod tests {
     #[test]
     fn no_error_no_text_does_not_fail() {
         assert!(!should_fail_session(&None, ""));
+    }
+
+    #[test]
+    fn llm_session_decision_uses_global_enabled_without_inversion() {
+        let mut cfg = Config::default().llm;
+        cfg.enabled = true;
+        assert!(llm_enabled_for_session(&cfg, false));
+    }
+
+    #[test]
+    fn llm_session_decision_skips_llm_when_enabled_and_inverted() {
+        let mut cfg = Config::default().llm;
+        cfg.enabled = true;
+        assert!(!llm_enabled_for_session(&cfg, true));
+    }
+
+    #[test]
+    fn llm_session_decision_enables_llm_when_disabled_and_inverted() {
+        let mut cfg = Config::default().llm;
+        cfg.enabled = false;
+        assert!(llm_enabled_for_session(&cfg, true));
+    }
+
+    #[test]
+    fn llm_session_decision_still_requires_ready_profile() {
+        let mut cfg = Config::default().llm;
+        cfg.enabled = false;
+        cfg.active_profile = "missing".into();
+        assert!(!llm_enabled_for_session(&cfg, true));
+    }
+
+    #[test]
+    fn fallback_hotkey_config_exports_llm_invert_modifier_flag() {
+        let cfg = sp_core_get_hotkey_config();
+        assert_eq!(cfg.llm_invert_modifier_flag, 0x0004_0000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements #15 by adding a configurable modifier key that temporarily
inverts whether the current recording session uses LLM polishing.

The inversion is evaluated when recording starts, applies only to that
session, and does not mutate the persisted `llm.enabled` setting.

## Changes

- add `hotkey.llm_invert_modifier` to Rust config with default `control`
- support `control | option | command | shift | fn | none` and normalize
  invalid values back to `control`
- expose the invert modifier flag through `SPHotkeyConfig`
- extend the session begin context so ObjC can pass the per-session LLM
  inversion state into Rust
- capture the configured modifier in the hotkey monitor and lock the
  inversion state when recording begins
- apply session-level LLM decision logic in `koe-core` without writing
  back to `config.yaml`
- add an `LLM Modifier` setting in the Hotkey / Controls UI
- update README config examples and behavior docs

## Behavior

- normal recording continues to follow `llm.enabled`
- pressing the configured modifier while starting recording flips the
  LLM behavior for that recording only
- when `llm.enabled = true`, the inverted session skips LLM polishing
- when `llm.enabled = false`, the inverted session attempts to use LLM,
  but still requires a valid active LLM profile
- setting the modifier to `none` disables inversion behavior entirely

## Testing

- `cargo test -p koe-core`
- `make generate`
- `cargo build --manifest-path koe-core/Cargo.toml --release --target aarch64-apple-darwin`
- `cd KoeApp && xcodebuild -project Koe.xcodeproj -scheme Koe -configuration Debug ARCHS=arm64 build`

## Notes

- Xcode build succeeds with the existing linker warnings about some Rust
  object files being built with a newer macOS version marker than the
  app deployment target
