### PR TITLE
fix(setup): align MLX provider rows and add contributor avatars

### DIFF
--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1058,7 +1058,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     [pane addSubview:self.llmTestResultLabel];
 
     // --- MLX fields (tag 2010-2012 for show/hide, initially hidden) ---
-    CGFloat mlxY = contentHeight - 48 - 52 - rowH - 8 - rowH - rowH;  // same Y as Base URL row
+    CGFloat mlxY = providerDetailStartY;  // same Y as Base URL row
 
     // MLX Model popup + Download button
     NSTextField *llmModelLabel = [self formLabel:@"Model" frame:NSMakeRect(16, mlxY, labelW, 22)];

--- a/README.md
+++ b/README.md
@@ -714,6 +714,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for commit conventions, PR guidelines, an
 
 ## Contributors
 
+[![Contributors](https://contrib.rocks/image?repo=missuo/koe)][contributors]
+
+[contributors]: https://github.com/missuo/koe/graphs/contributors
+
 - Vincent Yang — creator and maintainer
 - luolei — contributor for the 1.0.14 release cycle, including prompt templates, shortcut workflow, and settings/overlay interaction polish
 


### PR DESCRIPTION
## Summary

- fix the MLX setup row positioning so the local model controls align with the shared provider detail rows
- add an automatic contributors avatar section to the README

## Verification

- `cd KoeApp && xcodebuild -project Koe.xcodeproj -scheme Koe -configuration Debug ARCHS=arm64 build`
