### PR TITLE
feat(overlay): text diff animation, auto-dismiss, and settings fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable user-facing changes to Koe are documented here.
 - Added overlay rewrite templates with click, hover, and contextual `1-9` shortcuts for fast second-pass rewriting.
 - Added configurable trigger modes so users can choose `hold` or `toggle`.
 - Added custom shortcut recording for trigger shortcuts, including modifier combinations.
+- Added inline character-level diff animation for text correction transitions — deleted chars fade out in soft red, inserted chars highlight in blue-lavender, and adjacent delete+insert pairs merge into clean replacements before settling to the final text.
+- Added automatic overlay dismissal on any key press (except template shortcuts `1-9`) after text is pasted, so users can continue typing without the overlay lingering.
 
 ### Changed
 
@@ -22,6 +24,8 @@ All notable user-facing changes to Koe are documented here.
 - Standardized the settings experience so Controls, LLM, and Templates use more consistent native AppKit switches, segmented controls, spacing, and card surfaces.
 - Reduced the built-in prompt template set to a minimal default starter template for English translation.
 - Changed template rewrites to copy the rewritten result to the clipboard instead of auto-pasting it immediately.
+- Changed ASR test result messages from Chinese to English to match the overall UI language.
+- Changed overlay preview sample text to a more natural conversational example.
 
 ### Fixed
 
@@ -33,6 +37,11 @@ All notable user-facing changes to Koe are documented here.
 - Fixed number shortcut handling so `1-9` template shortcuts no longer leak digits into the focused app.
 - Fixed recorded trigger combinations so modifier shortcuts no longer leak characters like `®` into the focused app.
 - Fixed keyboard and mouse interaction polish for template buttons and overlay selection states.
+- Fixed overlay blocking clicks on the app underneath during linger/dismiss by keeping the main panel click-through at all times.
+- Fixed template editor silently converting file-backed prompts (`system_prompt_path`) to inline prompts — edits are now written back to the referenced file.
+- Fixed diff animation performance for long transcriptions by adding a 500-character threshold (falls back to crossfade) and replacing O(n²) backtracking with O(n) reverse.
+- Fixed ASR test result label being hidden behind configuration fields — now displayed inline next to the Test button.
+- Fixed Save button closing the settings window — Save now only persists changes, users close via the window's close button.
 
 ### Contributors
 

--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -42,6 +42,8 @@ static BOOL configFlagEnabled(const char *keyPath) {
 }
 
 - (void)showPromptTemplateButtonsIfNeededOrDismiss {
+    [self startAnyKeyDismissMonitoring];
+
     if (![self shouldShowPromptTemplateButtons]) {
         [self.overlayPanel lingerAndDismiss];
         return;
@@ -279,6 +281,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
 - (void)hotkeyMonitorDidDetectHoldStartWithLlmInversion:(BOOL)llmInverted {
     NSLog(@"[Koe] Hold start detected (llmInverted=%@)", llmInverted ? @"YES" : @"NO");
     [self stopNumberKeyMonitoring];
+    [self stopAnyKeyDismissMonitoring];
     [self.overlayPanel hideTemplateButtons];
     self.showingError = NO;
     [self cancelPendingSessionEnd];
@@ -325,6 +328,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
 - (void)hotkeyMonitorDidDetectTapStartWithLlmInversion:(BOOL)llmInverted {
     NSLog(@"[Koe] Tap start detected (llmInverted=%@)", llmInverted ? @"YES" : @"NO");
     [self stopNumberKeyMonitoring];
+    [self stopAnyKeyDismissMonitoring];
     [self.overlayPanel hideTemplateButtons];
     self.showingError = NO;
     [self cancelPendingSessionEnd];
@@ -607,6 +611,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
 
     if (![self shouldShowPromptTemplateButtons]) {
         [self stopNumberKeyMonitoring];
+        [self stopAnyKeyDismissMonitoring];
         [self.overlayPanel hideTemplateButtons];
     }
 
@@ -621,6 +626,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
 - (void)overlayPanel:(id)panel didSelectTemplateAtIndex:(NSInteger)templateIndex {
     NSLog(@"[Koe] Template selected: index %ld", (long)templateIndex);
     [self stopNumberKeyMonitoring];
+    [self stopAnyKeyDismissMonitoring];
     [self.clipboardManager cancelPendingRestore];
 
     // Show rewriting state
@@ -659,6 +665,26 @@ static BOOL configFlagEnabled(const char *keyPath) {
 - (void)stopNumberKeyMonitoring {
     self.hotkeyMonitor.numberKeyHandler = nil;
     NSLog(@"[Koe] Template selector hidden");
+}
+
+#pragma mark - Any-Key Dismiss Monitoring
+
+- (void)startAnyKeyDismissMonitoring {
+    __weak typeof(self) weakSelf = self;
+    self.hotkeyMonitor.anyKeyDismissHandler = ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+
+        NSLog(@"[Koe] Key press detected — dismissing overlay immediately");
+        [strongSelf stopNumberKeyMonitoring];
+        [strongSelf stopAnyKeyDismissMonitoring];
+        [strongSelf.overlayPanel dismissToIdle];
+    };
+    NSLog(@"[Koe] Any-key dismiss monitoring active");
+}
+
+- (void)stopAnyKeyDismissMonitoring {
+    self.hotkeyMonitor.anyKeyDismissHandler = nil;
 }
 
 @end

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.h
@@ -54,4 +54,9 @@ typedef NS_ENUM(uint8_t, SPHotkeyMatchKind) {
 /// Return YES to consume the key event so it does not continue to the target app.
 @property (nonatomic, copy) BOOL (^numberKeyHandler)(NSInteger number);
 
+/// Optional block called when any non-template key is pressed (any key except 1-9).
+/// The key event is NOT consumed — it always passes through to the target app.
+/// Used to dismiss the overlay when the user resumes typing after text insertion.
+@property (nonatomic, copy) void (^anyKeyDismissHandler)(void);
+
 @end

--- a/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
+++ b/KoeApp/Koe/Hotkey/SPHotkeyMonitor.m
@@ -106,6 +106,15 @@ static CGEventRef hotkeyEventCallback(CGEventTapProxy proxy,
             return monitor.canConsumeGlobalKeyEvents ? NULL : event;
         }
 
+        // Any keyDown (not handled by number keys above) dismisses the overlay.
+        // The event is NOT consumed — it passes through to the target app.
+        if (type == kCGEventKeyDown && monitor.anyKeyDismissHandler) {
+            void (^handler)(void) = monitor.anyKeyDismissHandler;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                handler();
+            });
+        }
+
         BOOL handlesModifierOnlyTrigger =
             [monitor isModifierOnlyMatchKind:monitor.targetMatchKind] &&
             [monitor isTargetKeyCode:keyCode];

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.h
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.h
@@ -26,6 +26,9 @@
 /// Dismiss the overlay after a dynamic linger period based on text length.
 - (void)lingerAndDismiss;
 
+/// Dismiss the overlay immediately (with exit animation, no linger delay).
+- (void)dismissToIdle;
+
 /// Reload overlay typography and bottom position from config.yaml.
 - (void)reloadAppearanceFromConfig;
 

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -54,6 +54,7 @@ static const NSTimeInterval kTextCrossfadeDuration = 0.25;
 // Diff animation
 static const NSTimeInterval kDiffHighlightDuration = 0.8;  // How long to show diff highlights
 static const NSTimeInterval kDiffFadeSteps = 8;             // Animation steps for fading
+static const NSInteger kDiffMaxCharacters = 500;            // Beyond this, fall back to crossfade
 
 // ── Word Diff Algorithm ─────────────────────────────────────
 
@@ -109,28 +110,31 @@ static NSArray<SPDiffEntry *> *SPComputeCharDiff(NSString *oldText, NSString *ne
         }
     }
 
-    // Backtrack to produce per-character ops
-    NSMutableArray<SPDiffEntry *> *raw = [NSMutableArray array];
+    // Backtrack to produce per-character ops (append in reverse, then reverse once)
+    NSMutableArray<SPDiffEntry *> *raw = [NSMutableArray arrayWithCapacity:m + n];
     NSInteger i = m, j = n;
     while (i > 0 || j > 0) {
         if (i > 0 && j > 0 && [oldText characterAtIndex:i - 1] == [newText characterAtIndex:j - 1]) {
-            [raw insertObject:[SPDiffEntry entryWithOp:SPDiffOpEqual
-                                                 text:[oldText substringWithRange:NSMakeRange(i - 1, 1)]]
-                      atIndex:0];
+            [raw addObject:[SPDiffEntry entryWithOp:SPDiffOpEqual
+                                               text:[oldText substringWithRange:NSMakeRange(i - 1, 1)]]];
             i--; j--;
         } else if (j > 0 && (i == 0 || dp[i * (n + 1) + (j - 1)] >= dp[(i - 1) * (n + 1) + j])) {
-            [raw insertObject:[SPDiffEntry entryWithOp:SPDiffOpInsert
-                                                 text:[newText substringWithRange:NSMakeRange(j - 1, 1)]]
-                      atIndex:0];
+            [raw addObject:[SPDiffEntry entryWithOp:SPDiffOpInsert
+                                               text:[newText substringWithRange:NSMakeRange(j - 1, 1)]]];
             j--;
         } else {
-            [raw insertObject:[SPDiffEntry entryWithOp:SPDiffOpDelete
-                                                 text:[oldText substringWithRange:NSMakeRange(i - 1, 1)]]
-                      atIndex:0];
+            [raw addObject:[SPDiffEntry entryWithOp:SPDiffOpDelete
+                                               text:[oldText substringWithRange:NSMakeRange(i - 1, 1)]]];
             i--;
         }
     }
     free(dp);
+
+    // Reverse to get forward order
+    NSUInteger count = raw.count;
+    for (NSUInteger lo = 0, hi = count - 1; lo < hi; lo++, hi--) {
+        [raw exchangeObjectAtIndex:lo withObjectAtIndex:hi];
+    }
 
     // Merge consecutive entries with the same op
     NSMutableArray<SPDiffEntry *> *merged = [NSMutableArray array];
@@ -1356,7 +1360,6 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     }
 
     self.contentView.interimText = text;
-    [self setMainPanelInteractive:YES];
     [self resizeAndCenterAnimated:YES];
     [self.contentView setNeedsDisplay:YES];
 }
@@ -1389,6 +1392,20 @@ static NSArray<SPDiffEntry *> *SPMergeReplacements(NSArray<SPDiffEntry *> *diff)
 }
 
 - (void)startDiffAnimationFrom:(NSString *)oldText to:(NSString *)newText {
+    // Guard: fall back to crossfade for long texts to avoid O(m*n) stall on main thread
+    if (oldText.length > kDiffMaxCharacters || newText.length > kDiffMaxCharacters) {
+        CATransition *transition = [CATransition animation];
+        transition.type = kCATransitionFade;
+        transition.duration = kTextCrossfadeDuration;
+        transition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+        [self.contentView.textScrollView.layer addAnimation:transition forKey:@"textCrossfade"];
+        self.contentView.interimText = newText;
+        [self setMainPanelInteractive:NO];
+        [self resizeAndCenterAnimated:YES];
+        [self.contentView setNeedsDisplay:YES];
+        return;
+    }
+
     NSArray<SPDiffEntry *> *rawDiff = SPComputeCharDiff(oldText, newText);
     NSArray<SPDiffEntry *> *diff = SPMergeReplacements(rawDiff);
 
@@ -1399,7 +1416,6 @@ static NSArray<SPDiffEntry *> *SPMergeReplacements(NSArray<SPDiffEntry *> *diff)
     }
     if (!hasDiff) {
         self.contentView.interimText = newText;
-        [self setMainPanelInteractive:YES];
         [self resizeAndCenterAnimated:YES];
         [self.contentView setNeedsDisplay:YES];
         return;
@@ -1419,7 +1435,6 @@ static NSArray<SPDiffEntry *> *SPMergeReplacements(NSArray<SPDiffEntry *> *diff)
     [self.contentView.textView.textStorage setAttributedString:diffStr];
     [self.contentView updateTextLayout];
     self.contentView.interimText = [diffStr string];
-    [self setMainPanelInteractive:YES];
     [self resizeAndCenterAnimated:YES];
     [self.contentView setNeedsDisplay:YES];
 
@@ -1568,16 +1583,16 @@ static NSArray<SPDiffEntry *> *SPMergeReplacements(NSArray<SPDiffEntry *> *diff)
 
 - (void)lingerAndDismiss {
     [self clearLingerTimer];
-    [self setMainPanelInteractive:YES];
+    // Keep the main panel click-through during linger — it should not block
+    // clicks on the app underneath. Template buttons (separate panel) handle
+    // their own mouse events independently.
+    [self setMainPanelInteractive:NO];
 
-    // Keep the confirmation short by default, but allow hover to pin it.
     NSString *displayText = self.contentView.interimText ?: self.contentView.statusText ?: @"";
     NSUInteger charCount = displayText.length;
     NSTimeInterval linger = fmin(fmax(charCount * 0.015, kMinLingerDuration), kMaxLingerDuration);
     self.remainingLingerDuration = linger;
-    if (![self isHoveringOverlay]) {
-        [self scheduleDismissAfter:linger];
-    }
+    [self scheduleDismissAfter:linger];
 }
 
 - (NSArray<NSNumber *> *)resolvedShortcutNumbersForTemplates:(NSArray<NSDictionary *> *)templates {
@@ -1615,7 +1630,6 @@ static NSArray<SPDiffEntry *> *SPMergeReplacements(NSArray<SPDiffEntry *> *diff)
     self.templateShortcutNumbers = [self resolvedShortcutNumbersForTemplates:templates];
     self.showingTemplates = YES;
     self.templateBarHovered = NO;
-    [self setMainPanelInteractive:YES];
 
     // Remove old button bar
     [self.buttonBarPanel orderOut:nil];

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -49,6 +49,7 @@ static const CGFloat kBaseShadowRadius = 4.0;
 static const CGFloat kEntranceShadowOpacity = 0.17;
 static const CGFloat kEntranceShadowRadius = 8.0;
 static const NSTimeInterval kRippleDuration = 0.42;
+static const NSTimeInterval kTextCrossfadeDuration = 0.25;
 
 static NSColor *SPOverlaySurfaceTintColor(void) {
     return [NSColor colorWithSRGBRed:0.07 green:0.065 blue:0.03 alpha:0.34];
@@ -444,6 +445,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) CGFloat        cornerRadius;
 @property (nonatomic, assign) CGFloat        iconAreaWidth;
 @property (nonatomic, assign) CGFloat        textViewportHeight;
+@property (nonatomic, readonly) NSScrollView *textScrollView;
 - (void)updateTextAttributes;
 - (void)refreshDisplayedTextAnimated:(BOOL)animated;
 @end
@@ -1235,6 +1237,17 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 }
 
 - (void)updateDisplayText:(NSString *)text {
+    BOOL hasExistingText = self.contentView.interimText.length > 0 || self.contentView.statusText.length > 0;
+    BOOL textChanged = ![text isEqualToString:self.contentView.interimText];
+
+    if (hasExistingText && textChanged) {
+        CATransition *transition = [CATransition animation];
+        transition.type = kCATransitionFade;
+        transition.duration = kTextCrossfadeDuration;
+        transition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+        [self.contentView.textScrollView.layer addAnimation:transition forKey:@"textCrossfade"];
+    }
+
     self.contentView.interimText = text;
     [self setMainPanelInteractive:YES];
     [self resizeAndCenterAnimated:YES];

--- a/KoeApp/Koe/Overlay/SPOverlayPanel.m
+++ b/KoeApp/Koe/Overlay/SPOverlayPanel.m
@@ -51,6 +51,100 @@ static const CGFloat kEntranceShadowRadius = 8.0;
 static const NSTimeInterval kRippleDuration = 0.42;
 static const NSTimeInterval kTextCrossfadeDuration = 0.25;
 
+// Diff animation
+static const NSTimeInterval kDiffHighlightDuration = 0.8;  // How long to show diff highlights
+static const NSTimeInterval kDiffFadeSteps = 8;             // Animation steps for fading
+
+// ── Word Diff Algorithm ─────────────────────────────────────
+
+typedef NS_ENUM(NSInteger, SPDiffOp) {
+    SPDiffOpEqual,
+    SPDiffOpDelete,
+    SPDiffOpInsert,
+    SPDiffOpReplace,  // Adjacent delete+insert merged: only new text shown
+};
+
+@interface SPDiffEntry : NSObject
+@property (nonatomic, assign) SPDiffOp op;
+@property (nonatomic, copy) NSString *text;
++ (instancetype)entryWithOp:(SPDiffOp)op text:(NSString *)text;
+@end
+
+@implementation SPDiffEntry
++ (instancetype)entryWithOp:(SPDiffOp)op text:(NSString *)text {
+    SPDiffEntry *e = [[SPDiffEntry alloc] init];
+    e.op = op;
+    e.text = text;
+    return e;
+}
+@end
+
+/// Compute character-level diff using LCS, then merge consecutive same-op runs.
+/// Works for CJK text (no whitespace delimiters) and English alike.
+static NSArray<SPDiffEntry *> *SPComputeCharDiff(NSString *oldText, NSString *newText) {
+    NSInteger m = oldText.length;
+    NSInteger n = newText.length;
+
+    // Use a flat C array for the DP table — much faster than nested NSArrays.
+    // dp[(i)*(n+1) + j] = LCS length for oldText[0..i-1] vs newText[0..j-1]
+    int16_t *dp = calloc((m + 1) * (n + 1), sizeof(int16_t));
+    if (!dp) {
+        // Fallback: treat entire text as replaced
+        NSMutableArray *fallback = [NSMutableArray array];
+        if (oldText.length) [fallback addObject:[SPDiffEntry entryWithOp:SPDiffOpDelete text:oldText]];
+        if (newText.length) [fallback addObject:[SPDiffEntry entryWithOp:SPDiffOpInsert text:newText]];
+        return fallback;
+    }
+
+    for (NSInteger i = 1; i <= m; i++) {
+        unichar oc = [oldText characterAtIndex:i - 1];
+        for (NSInteger j = 1; j <= n; j++) {
+            if (oc == [newText characterAtIndex:j - 1]) {
+                dp[i * (n + 1) + j] = dp[(i - 1) * (n + 1) + (j - 1)] + 1;
+            } else {
+                int16_t a = dp[(i - 1) * (n + 1) + j];
+                int16_t b = dp[i * (n + 1) + (j - 1)];
+                dp[i * (n + 1) + j] = (a > b) ? a : b;
+            }
+        }
+    }
+
+    // Backtrack to produce per-character ops
+    NSMutableArray<SPDiffEntry *> *raw = [NSMutableArray array];
+    NSInteger i = m, j = n;
+    while (i > 0 || j > 0) {
+        if (i > 0 && j > 0 && [oldText characterAtIndex:i - 1] == [newText characterAtIndex:j - 1]) {
+            [raw insertObject:[SPDiffEntry entryWithOp:SPDiffOpEqual
+                                                 text:[oldText substringWithRange:NSMakeRange(i - 1, 1)]]
+                      atIndex:0];
+            i--; j--;
+        } else if (j > 0 && (i == 0 || dp[i * (n + 1) + (j - 1)] >= dp[(i - 1) * (n + 1) + j])) {
+            [raw insertObject:[SPDiffEntry entryWithOp:SPDiffOpInsert
+                                                 text:[newText substringWithRange:NSMakeRange(j - 1, 1)]]
+                      atIndex:0];
+            j--;
+        } else {
+            [raw insertObject:[SPDiffEntry entryWithOp:SPDiffOpDelete
+                                                 text:[oldText substringWithRange:NSMakeRange(i - 1, 1)]]
+                      atIndex:0];
+            i--;
+        }
+    }
+    free(dp);
+
+    // Merge consecutive entries with the same op
+    NSMutableArray<SPDiffEntry *> *merged = [NSMutableArray array];
+    for (SPDiffEntry *entry in raw) {
+        SPDiffEntry *last = merged.lastObject;
+        if (last && last.op == entry.op) {
+            last.text = [last.text stringByAppendingString:entry.text];
+        } else {
+            [merged addObject:[SPDiffEntry entryWithOp:entry.op text:entry.text]];
+        }
+    }
+    return merged;
+}
+
 static NSColor *SPOverlaySurfaceTintColor(void) {
     return [NSColor colorWithSRGBRed:0.07 green:0.065 blue:0.03 alpha:0.34];
 }
@@ -446,6 +540,9 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) CGFloat        iconAreaWidth;
 @property (nonatomic, assign) CGFloat        textViewportHeight;
 @property (nonatomic, readonly) NSScrollView *textScrollView;
+/// When YES, refreshDisplayedTextAnimated: will not overwrite textStorage
+/// (the diff animation manages the attributed string directly).
+@property (nonatomic, assign) BOOL diffAnimationActive;
 - (void)updateTextAttributes;
 - (void)refreshDisplayedTextAnimated:(BOOL)animated;
 @end
@@ -581,7 +678,9 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
     NSClipView *clipView = self.textScrollView.contentView;
     CGFloat oldOffsetY = clipView.bounds.origin.y;
 
-    [self.textView.textStorage setAttributedString:[[NSAttributedString alloc] initWithString:displayText attributes:attrs]];
+    if (!self.diffAnimationActive) {
+        [self.textView.textStorage setAttributedString:[[NSAttributedString alloc] initWithString:displayText attributes:attrs]];
+    }
     [self updateTextLayout];
 
     [self.textView.layoutManager ensureLayoutForTextContainer:self.textView.textContainer];
@@ -769,6 +868,9 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 @property (nonatomic, assign) NSInteger configuredMaxVisibleLines;
 @property (nonatomic, assign, getter=isPreviewActive) BOOL previewActive;
 @property (nonatomic, strong) CAShapeLayer *recordingRippleLayer;
+@property (nonatomic, strong) NSTimer *diffAnimationTimer;
+@property (nonatomic, assign) NSInteger diffAnimationStep;
+@property (nonatomic, copy) NSString *diffFinalText;
 
 @end
 
@@ -1127,6 +1229,7 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 }
 
 - (void)dismissToIdle {
+    [self cancelDiffAnimation];
     [self clearLingerTimer];
     self.sessionMaxWidth = 0;
     self.sessionMaxHeight = 0;
@@ -1162,7 +1265,11 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
         [self restoreConfiguredAppearanceIfNeeded];
     }
 
-    // Cancel any pending linger dismiss from a previous session
+    // Cancel diff animation only when starting a new recording (not pasting/lingering)
+    if ([state hasPrefix:@"recording"] || [state isEqualToString:@"correcting"] ||
+        [state isEqualToString:@"error"] || [state isEqualToString:@"idle"]) {
+        [self cancelDiffAnimation];
+    }
     [self clearLingerTimer];
     [self setMainPanelInteractive:NO];
     self.mainPanelHovered = NO;
@@ -1237,21 +1344,161 @@ typedef NS_ENUM(NSInteger, SPOverlayMode) {
 }
 
 - (void)updateDisplayText:(NSString *)text {
-    BOOL hasExistingText = self.contentView.interimText.length > 0 || self.contentView.statusText.length > 0;
-    BOOL textChanged = ![text isEqualToString:self.contentView.interimText];
+    [self cancelDiffAnimation];
+
+    NSString *oldText = self.contentView.interimText ?: @"";
+    BOOL hasExistingText = oldText.length > 0;
+    BOOL textChanged = ![text isEqualToString:oldText];
 
     if (hasExistingText && textChanged) {
-        CATransition *transition = [CATransition animation];
-        transition.type = kCATransitionFade;
-        transition.duration = kTextCrossfadeDuration;
-        transition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
-        [self.contentView.textScrollView.layer addAnimation:transition forKey:@"textCrossfade"];
+        [self startDiffAnimationFrom:oldText to:text];
+        return;
     }
 
     self.contentView.interimText = text;
     [self setMainPanelInteractive:YES];
     [self resizeAndCenterAnimated:YES];
     [self.contentView setNeedsDisplay:YES];
+}
+
+- (void)cancelDiffAnimation {
+    [self.diffAnimationTimer invalidate];
+    self.diffAnimationTimer = nil;
+    self.diffFinalText = nil;
+    self.diffAnimationStep = 0;
+    self.contentView.diffAnimationActive = NO;
+}
+
+/// Merge adjacent Delete+Insert pairs into Replace ops (shows only the new text).
+/// This makes typo corrections cleaner: "了" → "啦" shows "啦" highlighted, not "了̶啦".
+static NSArray<SPDiffEntry *> *SPMergeReplacements(NSArray<SPDiffEntry *> *diff) {
+    NSMutableArray<SPDiffEntry *> *result = [NSMutableArray array];
+    NSUInteger count = diff.count;
+    for (NSUInteger i = 0; i < count; i++) {
+        SPDiffEntry *entry = diff[i];
+        if (entry.op == SPDiffOpDelete && i + 1 < count && diff[i + 1].op == SPDiffOpInsert) {
+            // Merge: skip deleted text, mark inserted text as replacement
+            SPDiffEntry *insertEntry = diff[i + 1];
+            [result addObject:[SPDiffEntry entryWithOp:SPDiffOpReplace text:insertEntry.text]];
+            i++; // skip the Insert entry (already consumed)
+        } else {
+            [result addObject:entry];
+        }
+    }
+    return result;
+}
+
+- (void)startDiffAnimationFrom:(NSString *)oldText to:(NSString *)newText {
+    NSArray<SPDiffEntry *> *rawDiff = SPComputeCharDiff(oldText, newText);
+    NSArray<SPDiffEntry *> *diff = SPMergeReplacements(rawDiff);
+
+    // Check if there's actually a diff (not all equal)
+    BOOL hasDiff = NO;
+    for (SPDiffEntry *entry in diff) {
+        if (entry.op != SPDiffOpEqual) { hasDiff = YES; break; }
+    }
+    if (!hasDiff) {
+        self.contentView.interimText = newText;
+        [self setMainPanelInteractive:YES];
+        [self resizeAndCenterAnimated:YES];
+        [self.contentView setNeedsDisplay:YES];
+        return;
+    }
+
+    self.diffFinalText = newText;
+
+    // Phase 1: Show inline diff with highlights
+    NSFont *font = [self contentFont];
+    NSDictionary *baseAttrs = SPOverlayTextAttributes(font);
+    NSMutableAttributedString *diffStr = [self buildDiffAttributedString:diff
+                                                              baseAttrs:baseAttrs
+                                                               progress:0.0];
+
+    // Show the diff-highlighted text
+    self.contentView.diffAnimationActive = YES;
+    [self.contentView.textView.textStorage setAttributedString:diffStr];
+    [self.contentView updateTextLayout];
+    self.contentView.interimText = [diffStr string];
+    [self setMainPanelInteractive:YES];
+    [self resizeAndCenterAnimated:YES];
+    [self.contentView setNeedsDisplay:YES];
+
+    // Phase 2: Gradually transition to clean final text
+    self.diffAnimationStep = 0;
+    __weak typeof(self) weakSelf = self;
+    self.diffAnimationTimer = [NSTimer scheduledTimerWithTimeInterval:(kDiffHighlightDuration / kDiffFadeSteps)
+                                                              repeats:YES
+                                                                block:^(NSTimer *timer) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { [timer invalidate]; return; }
+        [strongSelf diffAnimationTick:diff];
+    }];
+}
+
+/// Build an attributed string for the diff at a given animation progress (0.0 → 1.0).
+- (NSMutableAttributedString *)buildDiffAttributedString:(NSArray<SPDiffEntry *> *)diff
+                                               baseAttrs:(NSDictionary *)baseAttrs
+                                                progress:(CGFloat)progress {
+    // Deleted text: muted soft red, fading to transparent
+    NSColor *deleteColor = [NSColor colorWithRed:1.0 green:0.62 blue:0.58 alpha:0.55 * (1.0 - progress)];
+    // Inserted text: soft blue-lavender accent, transitioning to normal white
+    NSColor *insertColor = [NSColor colorWithRed:0.68 + 0.32 * progress
+                                           green:0.78 + 0.22 * progress
+                                            blue:1.0 - 0.08 * progress
+                                           alpha:0.92];
+    // Replaced text (typo/word swap): slightly warmer accent
+    NSColor *replaceColor = [NSColor colorWithRed:0.72 + 0.28 * progress
+                                            green:0.82 + 0.18 * progress
+                                             blue:0.98 - 0.06 * progress
+                                            alpha:0.92];
+
+    NSMutableAttributedString *str = [[NSMutableAttributedString alloc] init];
+    for (SPDiffEntry *entry in diff) {
+        NSMutableDictionary *attrs = [baseAttrs mutableCopy];
+        switch (entry.op) {
+            case SPDiffOpEqual:
+                break;
+            case SPDiffOpDelete:
+                attrs[NSForegroundColorAttributeName] = deleteColor;
+                break;
+            case SPDiffOpInsert:
+                attrs[NSForegroundColorAttributeName] = insertColor;
+                break;
+            case SPDiffOpReplace:
+                attrs[NSForegroundColorAttributeName] = replaceColor;
+                break;
+        }
+        [str appendAttributedString:[[NSAttributedString alloc] initWithString:entry.text attributes:attrs]];
+    }
+    return str;
+}
+
+- (void)diffAnimationTick:(NSArray<SPDiffEntry *> *)diff {
+    self.diffAnimationStep++;
+
+    if (self.diffAnimationStep >= (NSInteger)kDiffFadeSteps) {
+        // Animation complete: show clean final text
+        NSString *finalText = self.diffFinalText ?: self.contentView.interimText;
+        [self cancelDiffAnimation];
+
+        CATransition *transition = [CATransition animation];
+        transition.type = kCATransitionFade;
+        transition.duration = kTextCrossfadeDuration;
+        transition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+        [self.contentView.textScrollView.layer addAnimation:transition forKey:@"textCrossfade"];
+
+        self.contentView.interimText = finalText;
+        [self resizeAndCenterAnimated:YES];
+        [self.contentView setNeedsDisplay:YES];
+        return;
+    }
+
+    CGFloat progress = (CGFloat)self.diffAnimationStep / (CGFloat)kDiffFadeSteps;
+    NSDictionary *baseAttrs = SPOverlayTextAttributes([self contentFont]);
+    NSMutableAttributedString *str = [self buildDiffAttributedString:diff
+                                                          baseAttrs:baseAttrs
+                                                           progress:progress];
+    [self.contentView.textView.textStorage setAttributedString:str];
 }
 
 - (void)reloadAppearanceFromConfig {

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -32,7 +32,7 @@ static const BOOL kOverlayLimitVisibleLinesDefault = YES;
 static const NSInteger kOverlayMaxVisibleLinesDefault = 3;
 static const NSInteger kOverlayMaxVisibleLinesMin = 3;
 static const NSInteger kOverlayMaxVisibleLinesMax = 5;
-static NSString *const kOverlayPreviewSampleText = @"今天下午三点我们先开评审会，然后把设计方案、PR 评论和接口联调一起过一遍；如果我这段话持续很久，也希望底部实时字幕保持稳定，不要遮住文字边缘，同时完整保留整段转写内容。";
+static NSString *const kOverlayPreviewSampleText = @"刚试了一下这个语音输入，感觉还挺好用的，说完话自动就把文字整理好了，标点符号也帮你加上了，比打字快多了哈哈。";
 
 // Toolbar item identifiers
 static NSToolbarItemIdentifier const kToolbarASR = @"asr";
@@ -4131,7 +4131,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
 - (void)testDoubaoImeConnection {
     self.asrTestButton.enabled = NO;
-    self.asrTestResultLabel.stringValue = @"测试中...";
+    self.asrTestResultLabel.stringValue = @"Testing...";
     self.asrTestResultLabel.textColor = [NSColor secondaryLabelColor];
 
     // Test by connecting to the DoubaoIME WebSocket endpoint
@@ -4159,15 +4159,15 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         if (wsTask.state == NSURLSessionTaskStateRunning) {
             [wsTask cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure reason:nil];
             strongSelf.asrTestButton.enabled = YES;
-            strongSelf.asrTestResultLabel.stringValue = @"连接成功 (设备注册将在首次使用时自动完成)";
+            strongSelf.asrTestResultLabel.stringValue = @"Connected (device registration will complete on first use)";
             strongSelf.asrTestResultLabel.textColor = [NSColor systemGreenColor];
         } else if (wsTask.state == NSURLSessionTaskStateCompleted) {
             strongSelf.asrTestButton.enabled = YES;
             if (wsTask.error) {
-                strongSelf.asrTestResultLabel.stringValue = [NSString stringWithFormat:@"连接失败：%@", wsTask.error.localizedDescription];
+                strongSelf.asrTestResultLabel.stringValue = [NSString stringWithFormat:@"Connection failed: %@", wsTask.error.localizedDescription];
                 strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
             } else {
-                strongSelf.asrTestResultLabel.stringValue = @"连接成功 (设备注册将在首次使用时自动完成)";
+                strongSelf.asrTestResultLabel.stringValue = @"Connected (device registration will complete on first use)";
                 strongSelf.asrTestResultLabel.textColor = [NSColor systemGreenColor];
             }
         }
@@ -4180,13 +4180,13 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     NSString *accessKey = self.asrAccessKeyToggle.tag == 1 ? self.asrAccessKeyField.stringValue : self.asrAccessKeySecureField.stringValue;
 
     if (appKey.length == 0 || accessKey.length == 0) {
-        self.asrTestResultLabel.stringValue = @"请先填写 App Key 和 Access Key";
+        self.asrTestResultLabel.stringValue = @"Please fill in App Key and Access Key first";
         self.asrTestResultLabel.textColor = [NSColor systemOrangeColor];
         return;
     }
 
     self.asrTestButton.enabled = NO;
-    self.asrTestResultLabel.stringValue = @"测试中...";
+    self.asrTestResultLabel.stringValue = @"Testing...";
     self.asrTestResultLabel.textColor = [NSColor secondaryLabelColor];
 
     // Create WebSocket connection test
@@ -4234,27 +4234,27 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
                 if ([errorMsg containsString:@"401"] || [errorMsg containsString:@"403"] ||
                     [error.localizedFailureReason containsString:@"401"] || statusCode == 401) {
-                    strongSelf.asrTestResultLabel.stringValue = @"认证失败：请检查 App Key 和 Access Key 是否正确";
+                    strongSelf.asrTestResultLabel.stringValue = @"Auth failed: please check App Key and Access Key";
                 } else if ([errorMsg containsString:@"time"] || error.code == NSURLErrorTimedOut) {
-                    strongSelf.asrTestResultLabel.stringValue = @"连接超时：请检查网络连接";
+                    strongSelf.asrTestResultLabel.stringValue = @"Connection timed out: please check your network";
                 } else if ([errorMsg containsString:@"bad response"] ||
                            [errorMsg containsString:@"Bad response"] ||
                            statusCode == 400 || statusCode == 403) {
                     // HTTP error during WebSocket handshake (e.g. 400 Bad Request)
-                    strongSelf.asrTestResultLabel.stringValue = @"认证失败：请检查 App Key 和 Access Key 是否正确";
+                    strongSelf.asrTestResultLabel.stringValue = @"Auth failed: please check App Key and Access Key";
                 } else if ([errorMsg containsString:@"unable"] ||
                            [errorMsg containsString:@"Unable"] ||
                            [errorMsg containsString:@"Cannot connect"] ||
                            [errorMsg containsString:@"Network"]) {
-                    strongSelf.asrTestResultLabel.stringValue = @"网络连接失败：请检查网络设置";
+                    strongSelf.asrTestResultLabel.stringValue = @"Network error: please check your network settings";
                 } else {
-                    strongSelf.asrTestResultLabel.stringValue = @"连接失败：请检查配置信息是否正确";
+                    strongSelf.asrTestResultLabel.stringValue = @"Connection failed: please check your configuration";
                 }
                 strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
                 return;
             }
 
-            strongSelf.asrTestResultLabel.stringValue = @"连接成功";
+            strongSelf.asrTestResultLabel.stringValue = @"Connected";
             strongSelf.asrTestResultLabel.textColor = [NSColor systemGreenColor];
         });
     }];
@@ -4273,7 +4273,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
         if (!strongSelf.asrTestButton.enabled) {
             strongSelf.asrTestButton.enabled = YES;
-            strongSelf.asrTestResultLabel.stringValue = @"连接成功";
+            strongSelf.asrTestResultLabel.stringValue = @"Connected";
             strongSelf.asrTestResultLabel.textColor = [NSColor systemGreenColor];
         }
     });
@@ -4288,7 +4288,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
         [wsTask cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure reason:nil];
         strongSelf.asrTestButton.enabled = YES;
-        strongSelf.asrTestResultLabel.stringValue = @"连接超时：请检查网络连接";
+        strongSelf.asrTestResultLabel.stringValue = @"Connection timed out: please check your network";
         strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
     });
 }
@@ -4298,13 +4298,13 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     NSString *apiKey = self.asrQwenApiKeyToggle.tag == 1 ? self.asrQwenApiKeyField.stringValue : self.asrQwenApiKeySecureField.stringValue;
 
     if (apiKey.length == 0) {
-        self.asrTestResultLabel.stringValue = @"请先填写 API Key";
+        self.asrTestResultLabel.stringValue = @"Please fill in API Key first";
         self.asrTestResultLabel.textColor = [NSColor systemOrangeColor];
         return;
     }
 
     self.asrTestButton.enabled = NO;
-    self.asrTestResultLabel.stringValue = @"测试中...";
+    self.asrTestResultLabel.stringValue = @"Testing...";
     self.asrTestResultLabel.textColor = [NSColor secondaryLabelColor];
 
     // Create WebSocket connection test
@@ -4349,29 +4349,29 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
                 if ([errorMsg containsString:@"401"] || [errorMsg containsString:@"403"] ||
                     statusCode == 401) {
-                    strongSelf.asrTestResultLabel.stringValue = @"认证失败：请检查 API Key 是否正确";
+                    strongSelf.asrTestResultLabel.stringValue = @"Auth failed: please check your API Key";
                 } else if ([errorMsg containsString:@"time"] || error.code == NSURLErrorTimedOut) {
-                    strongSelf.asrTestResultLabel.stringValue = @"连接超时：请检查网络连接";
+                    strongSelf.asrTestResultLabel.stringValue = @"Connection timed out: please check your network";
                 } else if ([errorMsg containsString:@"bad response"] ||
                            [errorMsg containsString:@"Bad response"]) {
                     // HTTP error during WebSocket handshake
-                    strongSelf.asrTestResultLabel.stringValue = @"认证失败：请检查 API Key 是否正确";
+                    strongSelf.asrTestResultLabel.stringValue = @"Auth failed: please check your API Key";
                 } else if ([errorMsg containsString:@"unable"] ||
                            [errorMsg containsString:@"Unable"] ||
                            [errorMsg containsString:@"Cannot connect"]) {
-                    strongSelf.asrTestResultLabel.stringValue = @"网络连接失败：请检查网络设置";
+                    strongSelf.asrTestResultLabel.stringValue = @"Network error: please check your network settings";
                 } else {
-                    strongSelf.asrTestResultLabel.stringValue = @"连接失败：请检查配置信息是否正确";
+                    strongSelf.asrTestResultLabel.stringValue = @"Connection failed: please check your configuration";
                 }
                 strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
                 return;
             }
 
             if (message) {
-                strongSelf.asrTestResultLabel.stringValue = @"连接成功";
+                strongSelf.asrTestResultLabel.stringValue = @"Connected";
                 strongSelf.asrTestResultLabel.textColor = [NSColor systemGreenColor];
             } else {
-                strongSelf.asrTestResultLabel.stringValue = @"连接失败：未收到服务器响应";
+                strongSelf.asrTestResultLabel.stringValue = @"Connection failed: no response from server";
                 strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
             }
         });
@@ -4386,7 +4386,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
 
         [wsTask cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure reason:nil];
         strongSelf.asrTestButton.enabled = YES;
-        strongSelf.asrTestResultLabel.stringValue = @"连接超时：请检查网络连接";
+        strongSelf.asrTestResultLabel.stringValue = @"Connection timed out: please check your network";
         strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
     });
 }

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -2018,11 +2018,22 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
         ? templateData[@"system_prompt_path"]
         : nil;
 
-    BOOL preservePromptPath = (inlinePrompt.length == 0
-                               && promptPath.length > 0
-                               && [editedPrompt isEqualToString:(originalPrompt ?: @"")]);
-    if (preservePromptPath) {
+    // If this template references an external file, preserve that relationship.
+    // Write changes back to the file rather than silently converting to inline.
+    if (inlinePrompt.length == 0 && promptPath.length > 0) {
+        if (![editedPrompt isEqualToString:(originalPrompt ?: @"")]) {
+            NSString *resolvedPath = promptPath.isAbsolutePath
+                ? promptPath
+                : [configDirPath() stringByAppendingPathComponent:promptPath];
+            NSError *writeError = nil;
+            [editedPrompt writeToFile:resolvedPath atomically:YES encoding:NSUTF8StringEncoding error:&writeError];
+            if (writeError) {
+                NSLog(@"[Koe] Failed to write template file %@: %@", resolvedPath, writeError.localizedDescription);
+            }
+            templateData[kTemplateOriginalPromptKey] = editedPrompt;
+        }
         [templateData removeObjectForKey:@"system_prompt"];
+        self.templateEditorDirty = NO;
         return;
     }
 

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -904,11 +904,16 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     qwenKeyLabel.hidden = YES;
     [pane addSubview:qwenKeyLabel];
 
-    // Test result label
+    // Test result label — positioned inline to the right of the Test button
     self.asrTestResultLabel = [NSTextField wrappingLabelWithString:@""];
-    self.asrTestResultLabel.frame = NSMakeRect(fieldX, 55, fieldW, 42);
+    CGFloat testResultX = NSMaxX(self.asrTestButton.frame) + 8;
+    self.asrTestResultLabel.frame = NSMakeRect(testResultX,
+                                               NSMinY(self.asrTestButton.frame) + 4,
+                                               paneWidth - testResultX - 24,
+                                               20);
     self.asrTestResultLabel.font = [NSFont systemFontOfSize:12];
     self.asrTestResultLabel.selectable = YES;
+    self.asrTestResultLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     [pane addSubview:self.asrTestResultLabel];
 
     // Save / Cancel buttons
@@ -3783,8 +3788,6 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     if ([self.delegate respondsToSelector:@selector(setupWizardDidSaveConfig)]) {
         [self.delegate setupWizardDidSaveConfig];
     }
-
-    [self.window close];
 }
 
 - (void)cancelSetup:(id)sender {


### PR DESCRIPTION
## Summary

Rebased on latest `main` (includes LLM invert modifier, multi-profile, contributor avatars). Supersedes #75.

- **Inline diff animation**: Character-level diff between ASR and LLM-corrected text — deleted chars fade out in soft red, insertions highlight in blue-lavender, adjacent delete+insert pairs merge into clean replacements. Falls back to crossfade beyond 500 chars to avoid main-thread stalls.
- **Auto-dismiss on any key press**: After text is pasted, pressing any key (except template shortcuts 1-9) immediately dismisses the overlay so users can keep typing.
- **Overlay click-through**: Main pill panel stays `ignoresMouseEvents=YES` during linger/dismiss — no longer blocks clicks on the app underneath.
- **Template path preservation**: Editing a file-backed template (`system_prompt_path`) now writes changes back to the file instead of silently converting to inline.
- **Settings polish**: Test result shown inline next to Test button (not hidden behind fields), Save no longer closes the window, ASR test messages in English, preview text updated.

## Test plan

- [ ] Voice input → verify diff animation shows red/blue highlights, then fades to final text
- [ ] After paste, press any key → overlay should dismiss immediately
- [ ] After paste, press 1-9 → template rewrite should trigger (not dismiss)
- [ ] Click on app behind overlay during linger → click should pass through
- [ ] ASR settings → click Test → result shows in English next to the button
- [ ] Settings → click Save → window stays open
- [ ] Edit a file-backed template prompt → save → verify the .txt file is updated (not converted to inline)
- [ ] Long text (>500 chars) → should crossfade instead of diff animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)