### PR TITLE
fix(logging): restore RUST_LOG env var support in init_logging

### DIFF
--- a/koe-core/src/telemetry.rs
+++ b/koe-core/src/telemetry.rs
@@ -72,7 +72,8 @@ impl SessionMetrics {
 }
 
 pub fn init_logging() {
-    let _ = env_logger::builder()
-        .filter_level(log::LevelFilter::Info)
-        .try_init();
+    let _ = env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("info"),
+    )
+    .try_init();
 }


### PR DESCRIPTION
## Summary

Restore `RUST_LOG` environment variable support in `init_logging()` by replacing hardcoded `filter_level(Info)` with `Builder::from_env()`. Default filter remains `info` when `RUST_LOG` is not set.

## Motivation

The current implementation ignores `RUST_LOG` entirely, contradicting `DESIGN.md` §25.3:

> Rust core uses `env_logger` which outputs to stderr. To view logs, run the app from terminal with `RUST_LOG=info`.

This makes it impossible to enable debug-level logging without modifying source code.

## Changes

- `koe-core/src/telemetry.rs`: `init_logging()` now uses `env_logger::Builder::from_env(Env::default().default_filter_or("info"))` instead of `builder().filter_level(Info)`

## Behavior

| Scenario | Before | After |
|---|---|---|
| No `RUST_LOG` set | info level | info level (unchanged) |
| `RUST_LOG=debug` | info level (ignored) | debug level ✅ |
| `RUST_LOG=koe_core=debug` | info level (ignored) | debug for koe_core only ✅ |

## Testing

- `cargo check --no-default-features -p koe-core` — ✅
- `cargo clippy --no-default-features -p koe-core` — ✅ (1 pre-existing warning, unrelated)
- `cargo test --no-default-features -p koe-core` — ✅ 44 tests pass
- `cargo fmt --check` — ✅