### PR TITLE
feat(i18n): add localization infrastructure with en/zh-Hans support

### DIFF
--- a/KoeApp/Koe/AppDelegate/SPAppDelegate.m
+++ b/KoeApp/Koe/AppDelegate/SPAppDelegate.m
@@ -12,6 +12,7 @@
 #import "SPHistoryManager.h"
 #import "SPSetupWizardWindowController.h"
 #import "SPUpdateManager.h"
+#import "SPLocalization.h"
 #import "koe_core.h"
 #import <os/log.h>
 #import <sys/stat.h>
@@ -199,19 +200,19 @@ static BOOL configFlagEnabled(const char *keyPath) {
         [NSApp setMainMenu:mainMenu];
     }
 
-    NSMenuItem *editMenuItem = [[NSMenuItem alloc] initWithTitle:@"Edit" action:nil keyEquivalent:@""];
-    NSMenu *editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
+    NSMenuItem *editMenuItem = [[NSMenuItem alloc] initWithTitle:KoeLocalizedString(@"menu.edit") action:nil keyEquivalent:@""];
+    NSMenu *editMenu = [[NSMenu alloc] initWithTitle:KoeLocalizedString(@"menu.edit")];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
-    [editMenu addItemWithTitle:@"Undo" action:@selector(undo:) keyEquivalent:@"z"];
-    [editMenu addItemWithTitle:@"Redo" action:@selector(redo:) keyEquivalent:@"Z"];
+    [editMenu addItemWithTitle:KoeLocalizedString(@"menu.edit.undo") action:@selector(undo:) keyEquivalent:@"z"];
+    [editMenu addItemWithTitle:KoeLocalizedString(@"menu.edit.redo") action:@selector(redo:) keyEquivalent:@"Z"];
 #pragma clang diagnostic pop
     [editMenu addItem:[NSMenuItem separatorItem]];
-    [editMenu addItemWithTitle:@"Cut" action:@selector(cut:) keyEquivalent:@"x"];
-    [editMenu addItemWithTitle:@"Copy" action:@selector(copy:) keyEquivalent:@"c"];
-    [editMenu addItemWithTitle:@"Paste" action:@selector(paste:) keyEquivalent:@"v"];
-    [editMenu addItemWithTitle:@"Select All" action:@selector(selectAll:) keyEquivalent:@"a"];
+    [editMenu addItemWithTitle:KoeLocalizedString(@"menu.edit.cut") action:@selector(cut:) keyEquivalent:@"x"];
+    [editMenu addItemWithTitle:KoeLocalizedString(@"menu.edit.copy") action:@selector(copy:) keyEquivalent:@"c"];
+    [editMenu addItemWithTitle:KoeLocalizedString(@"menu.edit.paste") action:@selector(paste:) keyEquivalent:@"v"];
+    [editMenu addItemWithTitle:KoeLocalizedString(@"menu.edit.selectAll") action:@selector(selectAll:) keyEquivalent:@"a"];
 
     editMenuItem.submenu = editMenu;
     [mainMenu addItem:editMenuItem];
@@ -446,7 +447,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
 
 - (void)sendWarningNotification:(NSString *)message {
     UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-    content.title = @"Koe Warning";
+    content.title = KoeLocalizedString(@"notification.warning.title");
     content.body = message;
     content.sound = nil;
 
@@ -465,7 +466,7 @@ static BOOL configFlagEnabled(const char *keyPath) {
 
 - (void)sendErrorNotification:(NSString *)message {
     UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-    content.title = @"Koe Error";
+    content.title = KoeLocalizedString(@"notification.error.title");
     content.body = message;
     content.sound = nil; // Already playing error cue
 

--- a/KoeApp/Koe/Info.plist
+++ b/KoeApp/Koe/Info.plist
@@ -4,6 +4,11 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>zh-Hans</string>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/KoeApp/Koe/Localization/SPLocalization.h
+++ b/KoeApp/Koe/Localization/SPLocalization.h
@@ -1,0 +1,54 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// User-facing language preference stored in NSUserDefaults.
+/// - nil / empty / "system" → follow macOS system language
+/// - "en" → force English
+/// - "zh-Hans" → force Simplified Chinese
+extern NSString *const SPLocalizationLanguageKey;
+
+/// Posted when the user changes the interface language in settings.
+/// Observers should refresh any cached localized strings.
+extern NSNotificationName const SPLocalizationLanguageDidChangeNotification;
+
+/// Returns a localized string for the given key using the user's language
+/// preference. Falls back to English if the preferred language is not
+/// available in the app bundle.
+///
+/// Usage:  KoeLocalizedString(@"statusBar.menu.quit")
+#define KoeLocalizedString(key) [SPLocalization localizedStringForKey:(key)]
+
+/// Convenience macro with a comment (ignored at runtime, useful for
+/// extraction tools and translators).
+#define KoeLocalizedStringWithComment(key, comment) [SPLocalization localizedStringForKey:(key)]
+
+@interface SPLocalization : NSObject
+
+/// Returns the localized string for the given key, respecting the user's
+/// language preference stored in NSUserDefaults.
++ (NSString *)localizedStringForKey:(NSString *)key;
+
+/// Returns the NSBundle for the user's preferred language.
+/// Re-evaluated each time the preference changes.
++ (NSBundle *)localizedBundle;
+
+/// Returns the current effective language code ("en", "zh-Hans", etc.).
++ (NSString *)effectiveLanguage;
+
+/// Returns YES if the current preference is "follow system".
++ (BOOL)isFollowingSystem;
+
+/// Sets the user's language preference and posts
+/// SPLocalizationLanguageDidChangeNotification.
+/// Pass nil or "system" to revert to follow-system.
++ (void)setPreferredLanguage:(nullable NSString *)languageCode;
+
+/// Invalidates the cached bundle so the next call to localizedBundle
+/// re-resolves the language. Called automatically when the preference
+/// changes.
++ (void)invalidateCache;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/KoeApp/Koe/Localization/SPLocalization.m
+++ b/KoeApp/Koe/Localization/SPLocalization.m
@@ -1,0 +1,100 @@
+#import "SPLocalization.h"
+
+NSString *const SPLocalizationLanguageKey = @"KoeInterfaceLanguage";
+NSNotificationName const SPLocalizationLanguageDidChangeNotification = @"SPLocalizationLanguageDidChange";
+
+@implementation SPLocalization
+
+static NSBundle *_cachedBundle = nil;
+static NSString *_cachedLanguage = nil;
+
++ (NSBundle *)localizedBundle {
+    @synchronized (self) {
+        if (_cachedBundle) return _cachedBundle;
+
+        NSString *language = [self effectiveLanguage];
+        _cachedBundle = [self bundleForLanguage:language];
+        return _cachedBundle;
+    }
+}
+
++ (NSString *)effectiveLanguage {
+    @synchronized (self) {
+        if (_cachedLanguage) return _cachedLanguage;
+
+        NSString *preferred = [[NSUserDefaults standardUserDefaults] stringForKey:SPLocalizationLanguageKey];
+
+        if (!preferred || preferred.length == 0 ||
+            [preferred caseInsensitiveCompare:@"system"] == NSOrderedSame) {
+            _cachedLanguage = [self resolveSystemLanguage];
+        } else {
+            _cachedLanguage = [self validateLanguage:preferred] ? preferred : @"en";
+        }
+        return _cachedLanguage;
+    }
+}
+
++ (BOOL)isFollowingSystem {
+    NSString *preferred = [[NSUserDefaults standardUserDefaults] stringForKey:SPLocalizationLanguageKey];
+    return (!preferred || preferred.length == 0 ||
+            [preferred caseInsensitiveCompare:@"system"] == NSOrderedSame);
+}
+
++ (void)setPreferredLanguage:(nullable NSString *)languageCode {
+    if (!languageCode || languageCode.length == 0) {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:SPLocalizationLanguageKey];
+    } else {
+        [[NSUserDefaults standardUserDefaults] setObject:languageCode forKey:SPLocalizationLanguageKey];
+    }
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    [self invalidateCache];
+    [[NSNotificationCenter defaultCenter] postNotificationName:SPLocalizationLanguageDidChangeNotification
+                                                        object:nil];
+}
+
++ (void)invalidateCache {
+    @synchronized (self) {
+        _cachedBundle = nil;
+        _cachedLanguage = nil;
+    }
+}
+
++ (NSString *)localizedStringForKey:(NSString *)key {
+    return NSLocalizedStringFromTableInBundle(key, nil, [self localizedBundle], nil);
+}
+
+#pragma mark - Private
+
++ (NSString *)resolveSystemLanguage {
+    NSArray<NSString *> *preferred = [NSBundle mainBundle].preferredLocalizations;
+    if (preferred.count > 0) {
+        NSString *lang = preferred.firstObject;
+        if ([self validateLanguage:lang]) return lang;
+    }
+    return @"en";
+}
+
++ (BOOL)validateLanguage:(NSString *)language {
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"Localizable"
+                                                    ofType:@"strings"
+                                               inDirectory:nil
+                                           forLocalization:language];
+    if (path) return YES;
+
+    // Also check for .xcstrings-derived bundles
+    NSString *lproj = [NSString stringWithFormat:@"%@.lproj", language];
+    NSString *lprojPath = [[NSBundle mainBundle] pathForResource:lproj ofType:nil];
+    return lprojPath != nil;
+}
+
++ (NSBundle *)bundleForLanguage:(NSString *)language {
+    NSString *path = [[NSBundle mainBundle] pathForResource:language ofType:@"lproj"];
+    if (path) {
+        NSBundle *bundle = [NSBundle bundleWithPath:path];
+        if (bundle) return bundle;
+    }
+    // Fallback to main bundle (which uses the development language, en)
+    return [NSBundle mainBundle];
+}
+
+@end

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1,6 +1,7 @@
 #import "SPSetupWizardWindowController.h"
 #import "SPOverlayPanel.h"
 #import "SPRustBridge.h"
+#import "SPLocalization.h"
 #import <Cocoa/Cocoa.h>
 #import <Carbon/Carbon.h>
 #import <Speech/Speech.h>
@@ -2273,7 +2274,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 
 - (NSView *)buildAboutPane {
     CGFloat paneWidth = 600;
-    CGFloat contentHeight = 300;
+    CGFloat contentHeight = 380;
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
     [self applySettingsPaneBackgroundToView:pane];
 
@@ -2301,7 +2302,43 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     desc.alignment = NSTextAlignmentCenter;
     desc.frame = NSMakeRect(60, y - 10, paneWidth - 120, 40);
     [pane addSubview:desc];
-    y -= 60;
+    y -= 56;
+
+    // ─── Interface Language ──────────────────────────────────────────
+    CGFloat labelWidth = 140;
+    CGFloat fieldX = 24 + labelWidth + 8;
+    CGFloat fieldWidth = paneWidth - fieldX - 32;
+
+    NSTextField *langLabel = [self formLabel:KoeLocalizedString(@"settings.language.title")
+                                      frame:NSMakeRect(24, y, labelWidth, 20)];
+    [pane addSubview:langLabel];
+
+    NSPopUpButton *langPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, MIN(fieldWidth, 200), 26) pullsDown:NO];
+    [langPopup addItemWithTitle:KoeLocalizedString(@"settings.language.followSystem")];
+    [langPopup addItemWithTitle:@"English"];
+    [langPopup addItemWithTitle:@"简体中文"];
+
+    NSString *currentLang = [SPLocalization effectiveLanguage];
+    BOOL isFollowing = [SPLocalization isFollowingSystem];
+    if (isFollowing) {
+        [langPopup selectItemAtIndex:0];
+    } else if ([currentLang isEqualToString:@"en"]) {
+        [langPopup selectItemAtIndex:1];
+    } else if ([currentLang isEqualToString:@"zh-Hans"]) {
+        [langPopup selectItemAtIndex:2];
+    } else {
+        [langPopup selectItemAtIndex:0];
+    }
+
+    langPopup.target = self;
+    langPopup.action = @selector(languagePopupChanged:);
+    [pane addSubview:langPopup];
+    y -= 24;
+
+    NSTextField *langNote = [self descriptionLabel:KoeLocalizedString(@"settings.language.restartRequired")];
+    langNote.frame = NSMakeRect(fieldX, y - 6, fieldWidth, 32);
+    [pane addSubview:langNote];
+    y -= 40;
 
     // GitHub button
     NSButton *githubButton = [NSButton buttonWithTitle:@"GitHub Repository" target:self action:@selector(openGitHub:)];
@@ -2328,6 +2365,24 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     [pane addSubview:license];
 
     return pane;
+}
+
+- (void)languagePopupChanged:(NSPopUpButton *)sender {
+    NSString *newLang = nil;
+    switch (sender.indexOfSelectedItem) {
+        case 0: newLang = nil; break;      // Follow System
+        case 1: newLang = @"en"; break;
+        case 2: newLang = @"zh-Hans"; break;
+        default: newLang = nil; break;
+    }
+    [SPLocalization setPreferredLanguage:newLang];
+
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.alertStyle = NSAlertStyleInformational;
+    alert.messageText = KoeLocalizedString(@"settings.language.restartTitle");
+    alert.informativeText = KoeLocalizedString(@"settings.language.restartMessage");
+    [alert addButtonWithTitle:KoeLocalizedString(@"settings.language.restartButton")];
+    [alert runModal];
 }
 
 - (void)openGitHub:(id)sender {

--- a/KoeApp/Koe/StatusBar/SPStatusBarManager.m
+++ b/KoeApp/Koe/StatusBar/SPStatusBarManager.m
@@ -2,6 +2,7 @@
 #import "SPPermissionManager.h"
 #import "SPAudioDeviceManager.h"
 #import "SPHistoryManager.h"
+#import "SPLocalization.h"
 #import "koe_core.h"
 #import <Cocoa/Cocoa.h>
 #import <Carbon/Carbon.h>
@@ -256,14 +257,14 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
     NSString *version = info[@"CFBundleShortVersionString"] ?: @"?";
     NSString *build = info[@"CFBundleVersion"] ?: @"?";
-    NSString *statusTitle = [NSString stringWithFormat:@"Ready — v%@ (%@)", version, build];
+    NSString *statusTitle = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.status.ready"), version, build];
     self.statusMenuItem = [[NSMenuItem alloc] initWithTitle:statusTitle
                                                     action:nil
                                              keyEquivalent:@""];
     self.statusMenuItem.enabled = NO;
     [menu addItem:self.statusMenuItem];
 
-    self.hotkeyDisplayItem = [[NSMenuItem alloc] initWithTitle:@"Shortcut: Fn"
+    self.hotkeyDisplayItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:KoeLocalizedString(@"statusBar.shortcut.format"), @"Fn"]
                                                         action:nil
                                                  keyEquivalent:@""];
     self.hotkeyDisplayItem.enabled = NO;
@@ -273,7 +274,7 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
 
     // Statistics section
     NSMenuItem *statsHeader = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
-    statsHeader.view = [self headerViewWithTitle:@"Statistics"];
+    statsHeader.view = [self headerViewWithTitle:KoeLocalizedString(@"statusBar.section.statistics")];
     [menu addItem:statsHeader];
 
     self.statsCountItem = [[NSMenuItem alloc] initWithTitle:@"  ..."
@@ -298,69 +299,69 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
 
     // Permissions section
     NSMenuItem *permHeader = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
-    permHeader.view = [self headerViewWithTitle:@"Permissions"];
+    permHeader.view = [self headerViewWithTitle:KoeLocalizedString(@"statusBar.section.permissions")];
     [menu addItem:permHeader];
 
-    self.micPermissionItem = [[NSMenuItem alloc] initWithTitle:@"  Microphone: Checking..."
+    self.micPermissionItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.microphone"), KoeLocalizedString(@"statusBar.permission.checking")]
                                                        action:@selector(openMicrophoneSettings)
                                                 keyEquivalent:@""];
     self.micPermissionItem.target = self;
     self.micPermissionItem.enabled = NO;
     [menu addItem:self.micPermissionItem];
 
-    self.accessibilityPermissionItem = [[NSMenuItem alloc] initWithTitle:@"  Accessibility: Checking..."
+    self.accessibilityPermissionItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.accessibility"), KoeLocalizedString(@"statusBar.permission.checking")]
                                                                  action:@selector(requestAccessibilityPermission)
                                                           keyEquivalent:@""];
     self.accessibilityPermissionItem.target = self;
     self.accessibilityPermissionItem.enabled = NO;
     [menu addItem:self.accessibilityPermissionItem];
 
-    self.inputMonitoringPermissionItem = [[NSMenuItem alloc] initWithTitle:@"  Input Monitoring: Checking..."
+    self.inputMonitoringPermissionItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.inputMonitoring"), KoeLocalizedString(@"statusBar.permission.checking")]
                                                                    action:@selector(openInputMonitoringSettings)
                                                             keyEquivalent:@""];
     self.inputMonitoringPermissionItem.target = self;
     self.inputMonitoringPermissionItem.enabled = NO;
     [menu addItem:self.inputMonitoringPermissionItem];
 
-    self.notificationPermissionItem = [[NSMenuItem alloc] initWithTitle:@"  Notifications: Checking..."
+    self.notificationPermissionItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.notifications"), KoeLocalizedString(@"statusBar.permission.checking")]
                                                                 action:@selector(requestNotificationPermission)
                                                          keyEquivalent:@""];
     self.notificationPermissionItem.target = self;
     self.notificationPermissionItem.enabled = NO;
     [menu addItem:self.notificationPermissionItem];
 
-    self.speechRecognitionPermissionItem = [[NSMenuItem alloc] initWithTitle:@"  Speech Recognition: Checking..."
+    self.speechRecognitionPermissionItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.speechRecognition"), KoeLocalizedString(@"statusBar.permission.checking")]
                                                                      action:nil
                                                               keyEquivalent:@""];
     self.speechRecognitionPermissionItem.enabled = NO;
-    self.speechRecognitionPermissionItem.hidden = YES; // shown only for apple-speech provider
+    self.speechRecognitionPermissionItem.hidden = YES;
     [menu addItem:self.speechRecognitionPermissionItem];
 
     [menu addItem:[NSMenuItem separatorItem]];
 
     // Microphone selection submenu
-    NSMenuItem *microphoneItem = [[NSMenuItem alloc] initWithTitle:@"Microphone"
+    NSMenuItem *microphoneItem = [[NSMenuItem alloc] initWithTitle:KoeLocalizedString(@"statusBar.menu.microphone")
                                                            action:nil
                                                     keyEquivalent:@""];
-    NSMenu *micSubmenu = [[NSMenu alloc] initWithTitle:@"Microphone"];
+    NSMenu *micSubmenu = [[NSMenu alloc] initWithTitle:KoeLocalizedString(@"statusBar.menu.microphone")];
     microphoneItem.submenu = micSubmenu;
     [menu addItem:microphoneItem];
 
     [menu addItem:[NSMenuItem separatorItem]];
 
-    NSMenuItem *setupWizard = [[NSMenuItem alloc] initWithTitle:@"Setup Wizard..."
+    NSMenuItem *setupWizard = [[NSMenuItem alloc] initWithTitle:KoeLocalizedString(@"statusBar.menu.setupWizard")
                                                         action:@selector(openSetupWizard:)
                                                  keyEquivalent:@","];
     setupWizard.target = self;
     [menu addItem:setupWizard];
 
-    NSMenuItem *openConfig = [[NSMenuItem alloc] initWithTitle:@"Open Config Folder..."
+    NSMenuItem *openConfig = [[NSMenuItem alloc] initWithTitle:KoeLocalizedString(@"statusBar.menu.openConfig")
                                                        action:@selector(openConfigFolder:)
                                                 keyEquivalent:@""];
     openConfig.target = self;
     [menu addItem:openConfig];
 
-    NSMenuItem *checkForUpdates = [[NSMenuItem alloc] initWithTitle:@"Check for Updates..."
+    NSMenuItem *checkForUpdates = [[NSMenuItem alloc] initWithTitle:KoeLocalizedString(@"statusBar.menu.checkUpdates")
                                                              action:@selector(checkForUpdates:)
                                                       keyEquivalent:@""];
     checkForUpdates.target = self;
@@ -368,7 +369,7 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
 
     [menu addItem:[NSMenuItem separatorItem]];
 
-    NSMenuItem *loginItem = [[NSMenuItem alloc] initWithTitle:@"Launch at Login"
+    NSMenuItem *loginItem = [[NSMenuItem alloc] initWithTitle:KoeLocalizedString(@"statusBar.menu.launchAtLogin")
                                                       action:@selector(toggleLaunchAtLogin:)
                                                keyEquivalent:@""];
     loginItem.target = self;
@@ -380,7 +381,7 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
 
     [menu addItem:[NSMenuItem separatorItem]];
 
-    NSMenuItem *quit = [[NSMenuItem alloc] initWithTitle:@"Quit Koe"
+    NSMenuItem *quit = [[NSMenuItem alloc] initWithTitle:KoeLocalizedString(@"statusBar.menu.quit")
                                                  action:@selector(quitApp:)
                                           keyEquivalent:@"q"];
     quit.target = self;
@@ -412,20 +413,23 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     BOOL accessibility = [self.permissionManager isAccessibilityGranted];
     BOOL inputMonitoring = [self.permissionManager isInputMonitoringGranted];
 
-    self.micPermissionItem.title = [NSString stringWithFormat:@"  Microphone: %@",
-                                    mic ? @"Granted" : @"Not Granted ▸"];
+    NSString *granted = KoeLocalizedString(@"statusBar.permission.granted");
+    NSString *notGranted = KoeLocalizedString(@"statusBar.permission.notGranted");
+
+    self.micPermissionItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.microphone"),
+                                    mic ? granted : notGranted];
     self.micPermissionItem.enabled = !mic;
-    self.accessibilityPermissionItem.title = [NSString stringWithFormat:@"  Accessibility: %@",
-                                              accessibility ? @"Granted" : @"Not Granted ▸"];
+    self.accessibilityPermissionItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.accessibility"),
+                                              accessibility ? granted : notGranted];
     self.accessibilityPermissionItem.enabled = !accessibility;
-    self.inputMonitoringPermissionItem.title = [NSString stringWithFormat:@"  Input Monitoring: %@",
-                                                inputMonitoring ? @"Granted" : @"Not Granted ▸"];
+    self.inputMonitoringPermissionItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.inputMonitoring"),
+                                                inputMonitoring ? granted : notGranted];
     self.inputMonitoringPermissionItem.enabled = !inputMonitoring;
 
-    [self.permissionManager checkNotificationPermissionWithCompletion:^(BOOL granted) {
-        self.notificationPermissionItem.title = [NSString stringWithFormat:@"  Notifications: %@",
-                                                  granted ? @"Granted" : @"Not Granted ▸"];
-        self.notificationPermissionItem.enabled = !granted;
+    [self.permissionManager checkNotificationPermissionWithCompletion:^(BOOL notifGranted) {
+        self.notificationPermissionItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.notifications"),
+                                                  notifGranted ? granted : notGranted];
+        self.notificationPermissionItem.enabled = !notifGranted;
     }];
 
     // Speech Recognition — only visible when apple-speech provider is configured
@@ -435,8 +439,8 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     self.speechRecognitionPermissionItem.hidden = !isAppleSpeech;
     if (isAppleSpeech) {
         BOOL speechGranted = [self.permissionManager isSpeechRecognitionGranted];
-        self.speechRecognitionPermissionItem.title = [NSString stringWithFormat:@"  Speech Recognition: %@",
-                                                       speechGranted ? @"Granted" : @"Not Granted"];
+        self.speechRecognitionPermissionItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.permission.speechRecognition"),
+                                                       speechGranted ? granted : notGranted];
     }
 }
 
@@ -462,16 +466,16 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     // Count display
     NSMutableArray *parts = [NSMutableArray array];
     if (stats.totalCharCount > 0) {
-        [parts addObject:[NSString stringWithFormat:@"%ld chars", (long)stats.totalCharCount]];
+        [parts addObject:[NSString stringWithFormat:KoeLocalizedString(@"statusBar.stats.chars"), (long)stats.totalCharCount]];
     }
     if (stats.totalWordCount > 0) {
-        [parts addObject:[NSString stringWithFormat:@"%ld words", (long)stats.totalWordCount]];
+        [parts addObject:[NSString stringWithFormat:KoeLocalizedString(@"statusBar.stats.words"), (long)stats.totalWordCount]];
     }
     if (parts.count > 0) {
-        self.statsCountItem.title = [NSString stringWithFormat:@"  Total: %@",
+        self.statsCountItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.stats.total"),
                                      [parts componentsJoinedByString:@" / "]];
     } else {
-        self.statsCountItem.title = @"  Total: No data yet";
+        self.statsCountItem.title = KoeLocalizedString(@"statusBar.stats.totalNone");
     }
 
     // Time + session count
@@ -479,26 +483,24 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     NSInteger min = totalSec / 60;
     NSInteger sec = totalSec % 60;
     if (stats.sessionCount > 0) {
-        self.statsTimeItem.title = [NSString stringWithFormat:@"  Time: %ld min %ld sec | %ld sessions",
+        self.statsTimeItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.stats.time"),
                                     (long)min, (long)sec, (long)stats.sessionCount];
     } else {
-        self.statsTimeItem.title = @"  Time: --";
+        self.statsTimeItem.title = KoeLocalizedString(@"statusBar.stats.timeNone");
     }
 
     // Typing speed
     if (stats.totalDurationMs > 0 && (stats.totalCharCount + stats.totalWordCount) > 0) {
         double minutes = (double)stats.totalDurationMs / 60000.0;
         if (stats.totalCharCount > stats.totalWordCount) {
-            // Primarily Chinese
             double speed = (double)stats.totalCharCount / minutes;
-            self.statsSpeedItem.title = [NSString stringWithFormat:@"  Speed: %.0f chars/min", speed];
+            self.statsSpeedItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.stats.speedChars"), speed];
         } else {
-            // Primarily English
             double speed = (double)stats.totalWordCount / minutes;
-            self.statsSpeedItem.title = [NSString stringWithFormat:@"  Speed: %.0f words/min", speed];
+            self.statsSpeedItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.stats.speedWords"), speed];
         }
     } else {
-        self.statsSpeedItem.title = @"  Speed: --";
+        self.statsSpeedItem.title = KoeLocalizedString(@"statusBar.stats.speedNone");
     }
 }
 
@@ -507,18 +509,24 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     NSString *triggerKey = t ? @(t) : @"fn";
     sp_core_free_string(t);
 
-    self.hotkeyDisplayItem.title = [NSString stringWithFormat:@"Shortcut: %@",
+    self.hotkeyDisplayItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.shortcut.format"),
                                     displayNameForHotkeyValue(triggerKey)];
 }
 
 #pragma mark - Microphone Selection
 
 - (void)refreshMicrophoneSubmenu:(NSMenu *)menu {
-    // Find the Microphone menu item
-    NSInteger micIndex = [menu indexOfItemWithTitle:@"Microphone"];
-    if (micIndex == -1) return;
+    // Find the Microphone menu item by tag instead of title (title is localized)
+    NSMenuItem *micItem = nil;
+    for (NSMenuItem *item in menu.itemArray) {
+        if (item.submenu && [item.submenu.title isEqualToString:KoeLocalizedString(@"statusBar.menu.microphone")]) {
+            micItem = item;
+            break;
+        }
+    }
+    if (!micItem) return;
 
-    NSMenu *submenu = [menu itemAtIndex:micIndex].submenu;
+    NSMenu *submenu = micItem.submenu;
     [submenu removeAllItems];
 
     NSString *selectedUID = self.audioDeviceManager.selectedDeviceUID;
@@ -536,7 +544,7 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     }
 
     // "System Default" option
-    NSMenuItem *defaultItem = [[NSMenuItem alloc] initWithTitle:@"System Default"
+    NSMenuItem *defaultItem = [[NSMenuItem alloc] initWithTitle:KoeLocalizedString(@"statusBar.menu.systemDefault")
                                                         action:@selector(selectAudioDevice:)
                                                  keyEquivalent:@""];
     defaultItem.target = self;
@@ -566,7 +574,7 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
     if (selectedUID && !selectedFound) {
         NSString *deviceName = self.audioDeviceManager.selectedDeviceName ?: selectedUID;
         [submenu addItem:[NSMenuItem separatorItem]];
-        NSMenuItem *unavailableItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:@"%@ (Unavailable)", deviceName]
+        NSMenuItem *unavailableItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:KoeLocalizedString(@"statusBar.menu.unavailable"), deviceName]
                                                                 action:nil
                                                          keyEquivalent:@""];
         unavailableItem.state = NSControlStateValueOn;
@@ -751,35 +759,35 @@ static NSString *displayNameForHotkeyValue(NSString *value) {
         NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
         NSString *ver = info[@"CFBundleShortVersionString"] ?: @"?";
         NSString *bld = info[@"CFBundleVersion"] ?: @"?";
-        self.statusMenuItem.title = [NSString stringWithFormat:@"Ready — v%@ (%@)", ver, bld];
+        self.statusMenuItem.title = [NSString stringWithFormat:KoeLocalizedString(@"statusBar.status.ready"), ver, bld];
         [self applyIdleIcon];
 
     } else if ([state hasPrefix:@"recording"]) {
-        self.statusMenuItem.title = @"Listening...";
+        self.statusMenuItem.title = KoeLocalizedString(@"statusBar.status.listening");
         [self startRecordingAnimation];
 
     } else if ([state isEqualToString:@"connecting_asr"]) {
-        self.statusMenuItem.title = @"Connecting...";
+        self.statusMenuItem.title = KoeLocalizedString(@"statusBar.status.connecting");
         [self startProcessingAnimation];
 
     } else if ([state isEqualToString:@"finalizing_asr"]) {
-        self.statusMenuItem.title = @"Recognizing...";
+        self.statusMenuItem.title = KoeLocalizedString(@"statusBar.status.recognizing");
         [self startProcessingAnimation];
 
     } else if ([state isEqualToString:@"correcting"]) {
-        self.statusMenuItem.title = @"Thinking...";
+        self.statusMenuItem.title = KoeLocalizedString(@"statusBar.status.thinking");
         [self startProcessingAnimation];
 
     } else if ([state hasPrefix:@"preparing_paste"] || [state isEqualToString:@"pasting"]) {
-        self.statusMenuItem.title = @"Pasting...";
+        self.statusMenuItem.title = KoeLocalizedString(@"statusBar.status.pasting");
         [self applyPasteIcon];
 
     } else if ([state isEqualToString:@"error"] || [state isEqualToString:@"failed"]) {
-        self.statusMenuItem.title = @"Error";
+        self.statusMenuItem.title = KoeLocalizedString(@"statusBar.status.error");
         [self applyErrorIcon];
 
     } else {
-        self.statusMenuItem.title = @"Working...";
+        self.statusMenuItem.title = KoeLocalizedString(@"statusBar.status.working");
         [self startProcessingAnimation];
     }
 }

--- a/KoeApp/Koe/Update/SPUpdateManager.m
+++ b/KoeApp/Koe/Update/SPUpdateManager.m
@@ -1,4 +1,5 @@
 #import "SPUpdateManager.h"
+#import "SPLocalization.h"
 
 static NSString * const kSPUpdateLastCheckDateKey = @"SPUpdateLastCheckDate";
 static NSString * const kSPUpdateSkippedVersionKey = @"SPUpdateSkippedVersion";
@@ -69,9 +70,9 @@ static NSTimeInterval const kSPInitialAutomaticCheckDelay = 8.0;
 - (void)checkForUpdatesUserInitiated:(BOOL)userInitiated {
     if (!self.feedURL) {
         if (userInitiated) {
-            [self showAlertWithTitle:@"Updates Unavailable"
-                     informativeText:@"This build does not have an update feed configured."
-                           buttonOne:@"OK"
+            [self showAlertWithTitle:KoeLocalizedString(@"update.unavailable.title")
+                     informativeText:KoeLocalizedString(@"update.unavailable.message")
+                           buttonOne:KoeLocalizedString(@"update.button.ok")
                            buttonTwo:nil
                          buttonThree:nil
                              handler:nil];
@@ -81,9 +82,9 @@ static NSTimeInterval const kSPInitialAutomaticCheckDelay = 8.0;
 
     if (self.isChecking) {
         if (userInitiated) {
-            [self showAlertWithTitle:@"Already Checking"
-                     informativeText:@"Koe is already checking for updates."
-                           buttonOne:@"OK"
+            [self showAlertWithTitle:KoeLocalizedString(@"update.checking.title")
+                     informativeText:KoeLocalizedString(@"update.checking.message")
+                           buttonOne:KoeLocalizedString(@"update.button.ok")
                            buttonTwo:nil
                          buttonThree:nil
                              handler:nil];
@@ -111,9 +112,9 @@ static NSTimeInterval const kSPInitialAutomaticCheckDelay = 8.0;
     if (error) {
         NSLog(@"[Koe] Update check failed: %@", error.localizedDescription);
         if (userInitiated) {
-            [self showAlertWithTitle:@"Unable to Check for Updates"
-                     informativeText:error.localizedDescription ?: @"The update feed could not be reached."
-                           buttonOne:@"OK"
+            [self showAlertWithTitle:KoeLocalizedString(@"update.failed.title")
+                     informativeText:error.localizedDescription ?: KoeLocalizedString(@"update.failed.title")
+                           buttonOne:KoeLocalizedString(@"update.button.ok")
                            buttonTwo:nil
                          buttonThree:nil
                              handler:nil];
@@ -123,12 +124,12 @@ static NSTimeInterval const kSPInitialAutomaticCheckDelay = 8.0;
 
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
     if ([httpResponse isKindOfClass:[NSHTTPURLResponse class]] && httpResponse.statusCode >= 400) {
-        NSString *message = [NSString stringWithFormat:@"The update feed returned HTTP %ld.", (long)httpResponse.statusCode];
+        NSString *message = [NSString stringWithFormat:KoeLocalizedString(@"update.failed.http"), (long)httpResponse.statusCode];
         NSLog(@"[Koe] Update check failed: %@", message);
         if (userInitiated) {
-            [self showAlertWithTitle:@"Unable to Check for Updates"
+            [self showAlertWithTitle:KoeLocalizedString(@"update.failed.title")
                      informativeText:message
-                           buttonOne:@"OK"
+                           buttonOne:KoeLocalizedString(@"update.button.ok")
                            buttonTwo:nil
                          buttonThree:nil
                              handler:nil];
@@ -141,9 +142,9 @@ static NSTimeInterval const kSPInitialAutomaticCheckDelay = 8.0;
     if (!feed) {
         NSLog(@"[Koe] Update feed parse failed: %@", parseError.localizedDescription);
         if (userInitiated) {
-            [self showAlertWithTitle:@"Invalid Update Feed"
-                     informativeText:parseError.localizedDescription ?: @"The update feed JSON is invalid."
-                           buttonOne:@"OK"
+            [self showAlertWithTitle:KoeLocalizedString(@"update.invalidFeed.title")
+                     informativeText:parseError.localizedDescription ?: KoeLocalizedString(@"update.invalidFeed.title")
+                           buttonOne:KoeLocalizedString(@"update.button.ok")
                            buttonTwo:nil
                          buttonThree:nil
                              handler:nil];
@@ -159,10 +160,10 @@ static NSTimeInterval const kSPInitialAutomaticCheckDelay = 8.0;
     if (minimumSystemVersion.length > 0 &&
         [self compareVersionString:[self currentSystemVersionString] toVersionString:minimumSystemVersion] == NSOrderedAscending) {
         if (userInitiated) {
-            NSString *message = [NSString stringWithFormat:@"Version %@ requires macOS %@ or later.", feedVersion, minimumSystemVersion];
-            [self showAlertWithTitle:@"Update Not Compatible"
+            NSString *message = [NSString stringWithFormat:KoeLocalizedString(@"update.notCompatible.message"), feedVersion, minimumSystemVersion];
+            [self showAlertWithTitle:KoeLocalizedString(@"update.notCompatible.title")
                      informativeText:message
-                           buttonOne:@"OK"
+                           buttonOne:KoeLocalizedString(@"update.button.ok")
                            buttonTwo:nil
                          buttonThree:nil
                              handler:nil];
@@ -173,11 +174,11 @@ static NSTimeInterval const kSPInitialAutomaticCheckDelay = 8.0;
     if (![self isFeedVersion:feedVersion build:feedBuild newerThanCurrentVersion:[self currentAppVersionString]
                        build:[self currentAppBuildNumber]]) {
         if (userInitiated) {
-            NSString *message = [NSString stringWithFormat:@"Koe %@ (%ld) is currently the newest version available.",
+            NSString *message = [NSString stringWithFormat:KoeLocalizedString(@"update.upToDate.message"),
                                  [self currentAppVersionString], (long)[self currentAppBuildNumber]];
-            [self showAlertWithTitle:@"You're Up to Date"
+            [self showAlertWithTitle:KoeLocalizedString(@"update.upToDate.title")
                      informativeText:message
-                           buttonOne:@"OK"
+                           buttonOne:KoeLocalizedString(@"update.button.ok")
                            buttonTwo:nil
                          buttonThree:nil
                              handler:nil];
@@ -250,23 +251,22 @@ static NSTimeInterval const kSPInitialAutomaticCheckDelay = 8.0;
     NSInteger feedBuild = [self integerValueFromObject:feed[@"build"]];
     NSString *notesText = [self notesTextFromFeed:feed];
 
-    NSMutableString *message = [NSMutableString stringWithFormat:@"Koe %@",
+    NSMutableString *message = [NSMutableString stringWithFormat:KoeLocalizedString(@"update.available.message"),
                                 feedVersion];
     if (feedBuild > 0) {
-        [message appendFormat:@" (%ld)", (long)feedBuild];
+        [message appendFormat:KoeLocalizedString(@"update.available.buildSuffix"), (long)feedBuild];
     }
-    [message appendString:@" is available.\n\n"];
-    [message appendFormat:@"You have %@ (%ld).",
+    [message appendFormat:KoeLocalizedString(@"update.available.body"),
      [self currentAppVersionString], (long)[self currentAppBuildNumber]];
     if (notesText.length > 0) {
         [message appendFormat:@"\n\n%@", notesText];
     }
 
-    NSString *thirdButton = userInitiated ? nil : @"Skip This Version";
-    [self showAlertWithTitle:@"Update Available"
+    NSString *thirdButton = userInitiated ? nil : KoeLocalizedString(@"update.button.skip");
+    [self showAlertWithTitle:KoeLocalizedString(@"update.available.title")
              informativeText:message
-                   buttonOne:@"Download"
-                   buttonTwo:@"Later"
+                   buttonOne:KoeLocalizedString(@"update.button.download")
+                   buttonTwo:KoeLocalizedString(@"update.button.later")
                  buttonThree:thirdButton
                      handler:^(NSModalResponse response) {
         if (response == NSAlertFirstButtonReturn) {

--- a/KoeApp/Koe/en.lproj/Localizable.strings
+++ b/KoeApp/Koe/en.lproj/Localizable.strings
@@ -1,0 +1,99 @@
+/* Koe — English localization */
+
+/* ─── Status Bar ─── */
+"statusBar.status.ready" = "Ready — v%@ (%@)";
+"statusBar.status.listening" = "Listening...";
+"statusBar.status.connecting" = "Connecting...";
+"statusBar.status.recognizing" = "Recognizing...";
+"statusBar.status.thinking" = "Thinking...";
+"statusBar.status.pasting" = "Pasting...";
+"statusBar.status.error" = "Error";
+"statusBar.status.working" = "Working...";
+
+"statusBar.shortcut.format" = "Shortcut: %@";
+
+"statusBar.section.statistics" = "Statistics";
+"statusBar.stats.total" = "  Total: %@";
+"statusBar.stats.totalNone" = "  Total: No data yet";
+"statusBar.stats.chars" = "%ld chars";
+"statusBar.stats.words" = "%ld words";
+"statusBar.stats.time" = "  Time: %ld min %ld sec | %ld sessions";
+"statusBar.stats.timeNone" = "  Time: --";
+"statusBar.stats.speedChars" = "  Speed: %.0f chars/min";
+"statusBar.stats.speedWords" = "  Speed: %.0f words/min";
+"statusBar.stats.speedNone" = "  Speed: --";
+
+"statusBar.section.permissions" = "Permissions";
+"statusBar.permission.checking" = "Checking...";
+"statusBar.permission.granted" = "Granted";
+"statusBar.permission.notGranted" = "Not Granted ▸";
+"statusBar.permission.microphone" = "  Microphone: %@";
+"statusBar.permission.accessibility" = "  Accessibility: %@";
+"statusBar.permission.inputMonitoring" = "  Input Monitoring: %@";
+"statusBar.permission.notifications" = "  Notifications: %@";
+"statusBar.permission.speechRecognition" = "  Speech Recognition: %@";
+
+"statusBar.menu.microphone" = "Microphone";
+"statusBar.menu.systemDefault" = "System Default";
+"statusBar.menu.unavailable" = "%@ (Unavailable)";
+
+"statusBar.menu.setupWizard" = "Setup Wizard...";
+"statusBar.menu.openConfig" = "Open Config Folder...";
+"statusBar.menu.checkUpdates" = "Check for Updates...";
+"statusBar.menu.launchAtLogin" = "Launch at Login";
+"statusBar.menu.quit" = "Quit Koe";
+
+/* ─── Update Manager ─── */
+"update.unavailable.title" = "Updates Unavailable";
+"update.unavailable.message" = "This build does not have an update feed configured.";
+"update.checking.title" = "Already Checking";
+"update.checking.message" = "Koe is already checking for updates.";
+"update.failed.title" = "Unable to Check for Updates";
+"update.failed.http" = "The update feed returned HTTP %ld.";
+"update.invalidFeed.title" = "Invalid Update Feed";
+"update.notCompatible.title" = "Update Not Compatible";
+"update.notCompatible.message" = "Version %@ requires macOS %@ or later.";
+"update.upToDate.title" = "You're Up to Date";
+"update.upToDate.message" = "Koe %@ (%ld) is currently the newest version available.";
+"update.available.title" = "Update Available";
+"update.available.message" = "Koe %@";
+"update.available.buildSuffix" = " (%ld)";
+"update.available.body" = " is available.\n\nYou have %@ (%ld).";
+"update.button.download" = "Download";
+"update.button.later" = "Later";
+"update.button.skip" = "Skip This Version";
+"update.button.ok" = "OK";
+
+/* ─── Notifications ─── */
+"notification.error.title" = "Koe Error";
+"notification.warning.title" = "Koe Warning";
+
+/* ─── Permissions Alerts ─── */
+"permission.microphone.title" = "Microphone Access Required";
+"permission.microphone.message" = "Koe needs microphone access to capture your speech for voice input.\n\nPlease grant Microphone permission in System Settings → Privacy & Security → Microphone.";
+"permission.accessibility.title" = "Accessibility Access Required";
+"permission.accessibility.message" = "Koe needs Accessibility permission to paste corrected text into your active app.\n\nWithout this, text will be copied to the clipboard but not auto-pasted.\n\nPlease grant access in System Settings → Privacy & Security → Accessibility.";
+"permission.inputMonitoring.title" = "Input Monitoring Required";
+"permission.inputMonitoring.message" = "Koe needs Input Monitoring permission to detect the trigger hotkey globally.\n\nWithout this, Koe cannot start recording when you press the hotkey.\n\nPlease grant access in System Settings → Privacy & Security → Input Monitoring.";
+"permission.speechRecognition.title" = "Speech Recognition Access Required";
+"permission.speechRecognition.message" = "Koe needs Speech Recognition permission to use on-device speech recognition (Apple Speech).\n\nPlease grant access when prompted, or enable it in System Settings → Privacy & Security → Speech Recognition.";
+"permission.button.openSettings" = "Open Settings";
+"permission.button.dismiss" = "Dismiss";
+"permission.button.dontRemind" = "Don't Remind Again";
+
+/* ─── Language Settings ─── */
+"settings.language.title" = "Interface Language";
+"settings.language.followSystem" = "Follow System";
+"settings.language.restartRequired" = "Some UI elements require restarting Koe to fully apply the language change.";
+"settings.language.restartTitle" = "Language Changed";
+"settings.language.restartMessage" = "The interface language has been changed. Some elements may require restarting Koe to update.";
+"settings.language.restartButton" = "OK";
+
+/* ─── Edit Menu ─── */
+"menu.edit" = "Edit";
+"menu.edit.undo" = "Undo";
+"menu.edit.redo" = "Redo";
+"menu.edit.cut" = "Cut";
+"menu.edit.copy" = "Copy";
+"menu.edit.paste" = "Paste";
+"menu.edit.selectAll" = "Select All";

--- a/KoeApp/Koe/zh-Hans.lproj/Localizable.strings
+++ b/KoeApp/Koe/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,99 @@
+/* Koe — 简体中文本地化 */
+
+/* ─── 状态栏 ─── */
+"statusBar.status.ready" = "就绪 — v%@ (%@)";
+"statusBar.status.listening" = "正在录音...";
+"statusBar.status.connecting" = "正在连接...";
+"statusBar.status.recognizing" = "正在识别...";
+"statusBar.status.thinking" = "正在校正...";
+"statusBar.status.pasting" = "正在粘贴...";
+"statusBar.status.error" = "出错";
+"statusBar.status.working" = "处理中...";
+
+"statusBar.shortcut.format" = "快捷键：%@";
+
+"statusBar.section.statistics" = "使用统计";
+"statusBar.stats.total" = "  累计：%@";
+"statusBar.stats.totalNone" = "  累计：暂无数据";
+"statusBar.stats.chars" = "%ld 字符";
+"statusBar.stats.words" = "%ld 词";
+"statusBar.stats.time" = "  时间：%ld 分 %ld 秒 | %ld 次";
+"statusBar.stats.timeNone" = "  时间：--";
+"statusBar.stats.speedChars" = "  速度：%.0f 字符/分钟";
+"statusBar.stats.speedWords" = "  速度：%.0f 词/分钟";
+"statusBar.stats.speedNone" = "  速度：--";
+
+"statusBar.section.permissions" = "权限";
+"statusBar.permission.checking" = "检查中...";
+"statusBar.permission.granted" = "已授权";
+"statusBar.permission.notGranted" = "未授权 ▸";
+"statusBar.permission.microphone" = "  麦克风：%@";
+"statusBar.permission.accessibility" = "  辅助功能：%@";
+"statusBar.permission.inputMonitoring" = "  输入监控：%@";
+"statusBar.permission.notifications" = "  通知：%@";
+"statusBar.permission.speechRecognition" = "  语音识别：%@";
+
+"statusBar.menu.microphone" = "麦克风";
+"statusBar.menu.systemDefault" = "系统默认";
+"statusBar.menu.unavailable" = "%@（不可用）";
+
+"statusBar.menu.setupWizard" = "设置向导...";
+"statusBar.menu.openConfig" = "打开配置文件夹...";
+"statusBar.menu.checkUpdates" = "检查更新...";
+"statusBar.menu.launchAtLogin" = "开机启动";
+"statusBar.menu.quit" = "退出 Koe";
+
+/* ─── 更新管理 ─── */
+"update.unavailable.title" = "无法检查更新";
+"update.unavailable.message" = "此版本没有配置更新源。";
+"update.checking.title" = "正在检查";
+"update.checking.message" = "Koe 正在检查更新。";
+"update.failed.title" = "无法检查更新";
+"update.failed.http" = "更新源返回了 HTTP %ld。";
+"update.invalidFeed.title" = "无效的更新源";
+"update.notCompatible.title" = "更新不兼容";
+"update.notCompatible.message" = "版本 %@ 需要 macOS %@ 或更高版本。";
+"update.upToDate.title" = "已是最新版本";
+"update.upToDate.message" = "Koe %@（%ld）已经是最新版本。";
+"update.available.title" = "有可用更新";
+"update.available.message" = "Koe %@";
+"update.available.buildSuffix" = "（%ld）";
+"update.available.body" = " 可供更新。\n\n当前版本：%@（%ld）。";
+"update.button.download" = "下载";
+"update.button.later" = "稍后";
+"update.button.skip" = "跳过此版本";
+"update.button.ok" = "好";
+
+/* ─── 通知 ─── */
+"notification.error.title" = "Koe 出错";
+"notification.warning.title" = "Koe 警告";
+
+/* ─── 权限弹窗 ─── */
+"permission.microphone.title" = "需要麦克风权限";
+"permission.microphone.message" = "Koe 需要麦克风权限来采集语音进行语音输入。\n\n请前往 系统设置 → 隐私与安全性 → 麦克风 中授权。";
+"permission.accessibility.title" = "需要辅助功能权限";
+"permission.accessibility.message" = "Koe 需要辅助功能权限来将校正后的文字粘贴到当前应用。\n\n未授权时，文字会复制到剪贴板但无法自动粘贴。\n\n请前往 系统设置 → 隐私与安全性 → 辅助功能 中授权。";
+"permission.inputMonitoring.title" = "需要输入监控权限";
+"permission.inputMonitoring.message" = "Koe 需要输入监控权限来全局检测触发快捷键。\n\n未授权时，按下快捷键无法触发录音。\n\n请前往 系统设置 → 隐私与安全性 → 输入监控 中授权。";
+"permission.speechRecognition.title" = "需要语音识别权限";
+"permission.speechRecognition.message" = "Koe 需要语音识别权限来使用设备端语音识别（Apple Speech）。\n\n请在弹窗中授权，或前往 系统设置 → 隐私与安全性 → 语音识别 中开启。";
+"permission.button.openSettings" = "打开设置";
+"permission.button.dismiss" = "关闭";
+"permission.button.dontRemind" = "不再提醒";
+
+/* ─── 语言设置 ─── */
+"settings.language.title" = "界面语言";
+"settings.language.followSystem" = "跟随系统";
+"settings.language.restartRequired" = "部分界面元素需要重启 Koe 才能完全应用语言更改。";
+"settings.language.restartTitle" = "语言已更改";
+"settings.language.restartMessage" = "界面语言已更改。部分元素可能需要重启 Koe 才能更新。";
+"settings.language.restartButton" = "好";
+
+/* ─── 编辑菜单 ─── */
+"menu.edit" = "编辑";
+"menu.edit.undo" = "撤销";
+"menu.edit.redo" = "重做";
+"menu.edit.cut" = "剪切";
+"menu.edit.copy" = "拷贝";
+"menu.edit.paste" = "粘贴";
+"menu.edit.selectAll" = "全选";


### PR DESCRIPTION
## Summary

Add complete internationalization (i18n) infrastructure to Koe with English and Simplified Chinese support. All hardcoded English strings in the status bar, update manager, notifications, and edit menu are replaced with localized string lookups. A language setting is added to the Setup Wizard's About pane.

## Motivation

Koe's entire UI is currently hardcoded in English. Chinese-speaking users (the primary audience for a Chinese/English mixed dictation tool) see English-only menus, alerts, and notifications. This PR establishes the localization foundation and provides full zh-Hans translations for the first batch of modules.

## Changes

### New files
- `KoeApp/Koe/Localization/SPLocalization.h/.m` — runtime language bundle switching utility
  - `KoeLocalizedString(key)` macro for convenient access
  - Supports "Follow System", "English", "简体中文" modes
  - Language preference stored in `NSUserDefaults` (`KoeInterfaceLanguage`)
  - Posts `SPLocalizationLanguageDidChangeNotification` on change
- `KoeApp/Koe/en.lproj/Localizable.strings` — 99 English string keys
- `KoeApp/Koe/zh-Hans.lproj/Localizable.strings` — corresponding Chinese translations

### Modified files
- `KoeApp/Koe/Info.plist` — added `CFBundleLocalizations` (`en`, `zh-Hans`)
- `KoeApp/Koe/StatusBar/SPStatusBarManager.m` — all menu items, status text, permission labels, statistics, microphone submenu localized
- `KoeApp/Koe/Update/SPUpdateManager.m` — all alert titles, messages, button labels localized
- `KoeApp/Koe/AppDelegate/SPAppDelegate.m` — notification titles, Edit menu items localized
- `KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m` — Interface Language dropdown added to About pane

## Design Decisions

1. **`NSUserDefaults` over `config.yaml`** — avoids entangling with config hot-reload semantics; language is an app-level UI concern
2. **`.strings` over `.xcstrings`** — plain text files are easier to diff/review and work with all Xcode versions
3. **Key naming convention** — `screen.component.purpose` (e.g., `statusBar.permission.microphone`)
4. **Runtime bundle switching** — `SPLocalization.localizedBundle` resolves the correct `.lproj` at call time; works without app restart for most controls. AppKit system strings still follow macOS language (documented in the UI)

## Language Resolution Order

1. Read `KoeInterfaceLanguage` from `NSUserDefaults`
2. If "system" or absent → `preferredLocalizations` intersected with available `.lproj` → fallback `en`
3. If explicit → validate `.lproj` exists → fallback `en`

## Testing

- Rust codebase unaffected — `cargo test` / `cargo clippy` / `cargo fmt` all pass
- All modified `.m` files verified for balanced braces/brackets/parens
- String key coverage: every key in `en.lproj` has a corresponding entry in `zh-Hans.lproj`