### PR TITLE
feat(llm): make chat completions path configurable

### DIFF
--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -21,6 +21,7 @@ static NSString *const kDictionaryFile = @"dictionary.txt";
 static NSString *const kSystemPromptFile = @"system_prompt.txt";
 static NSString *const kTemplateEditablePromptKey = @"__editable_prompt";
 static NSString *const kTemplateOriginalPromptKey = @"__original_prompt";
+static NSString *const kDefaultLlmChatCompletionsPath = @"/chat/completions";
 static NSString *const kOverlayFontFamilyDefault = @"system";
 static NSString *const kOverlayFontFamilySystemLabel = @"System Default";
 static const NSInteger kOverlayFontSizeDefault = 13;
@@ -477,6 +478,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 @property (nonatomic, strong) NSSecureTextField *llmApiKeySecureField;
 @property (nonatomic, strong) NSButton *llmApiKeyToggle;
 @property (nonatomic, strong) NSTextField *llmModelField;
+@property (nonatomic, strong) NSTextField *llmChatCompletionsPathField;
 @property (nonatomic, strong) NSButton *llmTestButton;
 @property (nonatomic, strong) NSTextField *llmTestResultLabel;
 
@@ -999,7 +1001,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     y -= rowH;
     CGFloat providerDetailStartY = y;
 
-    // --- OpenAI fields (tag 2001-2006 for show/hide) ---
+    // --- OpenAI fields (tag 2001-2007 for show/hide) ---
 
     // Base URL
     NSTextField *baseUrlLabel = [self formLabel:@"Base URL" frame:NSMakeRect(16, y, labelW, 22)];
@@ -1039,12 +1041,22 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     [pane addSubview:self.llmModelField];
     y -= rowH + 4;
 
+    // Chat Completions Path
+    NSTextField *chatPathLabel = [self formLabel:@"Chat Path" frame:NSMakeRect(16, y, labelW, 22)];
+    chatPathLabel.tag = 2004;
+    [pane addSubview:chatPathLabel];
+    self.llmChatCompletionsPathField = [self formTextField:NSMakeRect(fieldX, y, fieldW, 22)
+                                                placeholder:kDefaultLlmChatCompletionsPath];
+    self.llmChatCompletionsPathField.tag = 2004;
+    [pane addSubview:self.llmChatCompletionsPathField];
+    y -= rowH;
+
     // Max Token Parameter
     NSTextField *tokenParamLabel = [self formLabel:@"Token Parameter" frame:NSMakeRect(16, y, labelW, 22)];
-    tokenParamLabel.tag = 2004;
+    tokenParamLabel.tag = 2005;
     [pane addSubview:tokenParamLabel];
     self.maxTokenParamPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, 240, 26) pullsDown:NO];
-    self.maxTokenParamPopup.tag = 2004;
+    self.maxTokenParamPopup.tag = 2005;
     [self.maxTokenParamPopup addItemsWithTitles:@[
         @"max_completion_tokens",
         @"max_tokens",
@@ -1057,7 +1069,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     // Hint text
     NSTextField *tokenHint = [self descriptionLabel:@"GPT-4o and older models use max_tokens. GPT-5 and reasoning models (o1/o3) use max_completion_tokens."];
     tokenHint.frame = NSMakeRect(fieldX, y - 2, fieldW, 32);
-    tokenHint.tag = 2005;
+    tokenHint.tag = 2006;
     [pane addSubview:tokenHint];
     y -= 44;
 
@@ -1065,7 +1077,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     self.llmTestButton = [NSButton buttonWithTitle:@"Test Connection" target:self action:@selector(testLlmConnection:)];
     self.llmTestButton.bezelStyle = NSBezelStyleRounded;
     self.llmTestButton.frame = NSMakeRect(fieldX, y, 130, 28);
-    self.llmTestButton.tag = 2006;
+    self.llmTestButton.tag = 2007;
     [pane addSubview:self.llmTestButton];
     y -= 32;
 
@@ -1074,7 +1086,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     self.llmTestResultLabel.frame = NSMakeRect(fieldX, y - 36, fieldW, 42);
     self.llmTestResultLabel.font = [NSFont systemFontOfSize:12];
     self.llmTestResultLabel.selectable = YES;
-    self.llmTestResultLabel.tag = 2006;
+    self.llmTestResultLabel.tag = 2007;
     [pane addSubview:self.llmTestResultLabel];
 
     // --- MLX fields (tag 2010-2012 for show/hide, initially hidden) ---
@@ -3225,6 +3237,10 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     NSMutableDictionary *copy = [profile mutableCopy] ?: [NSMutableDictionary dictionary];
     NSDictionary *mlx = copy[@"mlx"];
     copy[@"mlx"] = [mlx isKindOfClass:[NSDictionary class]] ? [mlx mutableCopy] : [@{@"model": @"mlx/Qwen3-0.6B-4bit"} mutableCopy];
+    NSString *chatPath = [copy[@"chat_completions_path"] isKindOfClass:[NSString class]] ? copy[@"chat_completions_path"] : @"";
+    if (chatPath.length == 0) {
+        copy[@"chat_completions_path"] = kDefaultLlmChatCompletionsPath;
+    }
     return copy;
 }
 
@@ -3235,6 +3251,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         @"base_url": @"https://api.openai.com/v1",
         @"api_key": @"",
         @"model": @"gpt-5.4-nano",
+        @"chat_completions_path": kDefaultLlmChatCompletionsPath,
         @"max_token_parameter": @"max_completion_tokens",
         @"no_reasoning_control": @"reasoning_effort",
         @"mlx": @{@"model": @"mlx/Qwen3-0.6B-4bit"},
@@ -3248,6 +3265,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         @"base_url": @"http://127.0.0.1:11434/v1",
         @"api_key": @"",
         @"model": @"apple-foundationmodel",
+        @"chat_completions_path": kDefaultLlmChatCompletionsPath,
         @"max_token_parameter": @"max_tokens",
         @"no_reasoning_control": @"none",
         @"mlx": @{@"model": @"mlx/Qwen3-0.6B-4bit"},
@@ -3316,6 +3334,8 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     NSString *apiKey = self.llmApiKeyToggle.tag == 1 ? self.llmApiKeyField.stringValue : self.llmApiKeySecureField.stringValue;
     profile[@"api_key"] = apiKey ?: @"";
     profile[@"model"] = self.llmModelField.stringValue ?: @"";
+    NSString *chatPath = [[self.llmChatCompletionsPathField.stringValue ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+    profile[@"chat_completions_path"] = (chatPath.length > 0) ? chatPath : kDefaultLlmChatCompletionsPath;
     profile[@"max_token_parameter"] = self.maxTokenParamPopup.selectedItem.representedObject ?: @"max_completion_tokens";
     if (!profile[@"no_reasoning_control"]) {
         profile[@"no_reasoning_control"] = [provider isEqualToString:@"mlx"] ? @"none" : @"reasoning_effort";
@@ -3351,6 +3371,9 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     self.llmApiKeyToggle.image = [NSImage imageWithSystemSymbolName:@"eye.slash" accessibilityDescription:@"Show"];
     self.llmApiKeyToggle.tag = 0;
     self.llmModelField.stringValue = [profile[@"model"] isKindOfClass:[NSString class]] ? profile[@"model"] : @"";
+    NSString *chatPath = [profile[@"chat_completions_path"] isKindOfClass:[NSString class]]
+        ? profile[@"chat_completions_path"] : kDefaultLlmChatCompletionsPath;
+    self.llmChatCompletionsPathField.stringValue = chatPath.length > 0 ? chatPath : kDefaultLlmChatCompletionsPath;
 
     NSString *maxTokenParam = [profile[@"max_token_parameter"] isKindOfClass:[NSString class]]
         ? profile[@"max_token_parameter"] : @"max_completion_tokens";
@@ -3823,9 +3846,9 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     BOOL isOpenAI = [provider isEqualToString:@"openai"];
     BOOL isMlx = [provider isEqualToString:@"mlx"];
 
-    // Toggle OpenAI fields (tag 2001-2006)
+    // Toggle OpenAI fields (tag 2001-2007)
     [self setHidden:!isOpenAI
- forViewsWithTagInRange:NSMakeRange(2001, 6)
+ forViewsWithTagInRange:NSMakeRange(2001, 7)
              inView:self.currentPaneView];
     // Eye toggle doesn't use tag for show/hide (tag is used for 0/1 state)
     self.llmApiKeyToggle.hidden = !isOpenAI;
@@ -3840,6 +3863,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     self.llmApiKeyField.enabled = enabled;
     self.llmApiKeySecureField.enabled = enabled;
     self.llmModelField.enabled = enabled;
+    self.llmChatCompletionsPathField.enabled = enabled;
     self.maxTokenParamPopup.enabled = enabled;
     self.llmTestButton.enabled = enabled;
 

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -272,6 +272,8 @@ pub struct LlmProfileConfig {
     pub api_key: String,
     #[serde(default)]
     pub model: String,
+    #[serde(default = "default_llm_chat_completions_path")]
+    pub chat_completions_path: String,
     #[serde(default = "default_llm_max_token_parameter")]
     pub max_token_parameter: LlmMaxTokenParameter,
     #[serde(default)]
@@ -289,6 +291,8 @@ pub struct LlmProfileRuntimeConfig {
     pub base_url: String,
     pub api_key: String,
     pub model: String,
+    #[serde(default = "default_llm_chat_completions_path")]
+    pub chat_completions_path: String,
     pub max_token_parameter: LlmMaxTokenParameter,
     pub no_reasoning_control: LlmNoReasoningControl,
     pub mlx: MlxLlmConfig,
@@ -323,6 +327,7 @@ impl LlmProfileConfig {
             base_url: self.base_url.clone(),
             api_key: self.api_key.clone(),
             model: self.model.clone(),
+            chat_completions_path: self.chat_completions_path.clone(),
             max_token_parameter: self.max_token_parameter,
             no_reasoning_control: self.no_reasoning_control,
             mlx: self.mlx.clone(),
@@ -362,6 +367,7 @@ impl Default for LlmProfileConfig {
             base_url: String::new(),
             api_key: String::new(),
             model: String::new(),
+            chat_completions_path: default_llm_chat_completions_path(),
             max_token_parameter: default_llm_max_token_parameter(),
             no_reasoning_control: LlmNoReasoningControl::default(),
             mlx: MlxLlmConfig::default(),
@@ -773,6 +779,9 @@ fn default_llm_max_token_parameter() -> LlmMaxTokenParameter {
 fn default_llm_provider() -> String {
     "openai".into()
 }
+fn default_llm_chat_completions_path() -> String {
+    "/chat/completions".into()
+}
 fn default_llm_active_profile() -> String {
     "openai".into()
 }
@@ -786,6 +795,7 @@ fn default_llm_profiles() -> BTreeMap<String, LlmProfileConfig> {
             base_url: "http://127.0.0.1:11434/v1".into(),
             api_key: String::new(),
             model: "apple-foundationmodel".into(),
+            chat_completions_path: default_llm_chat_completions_path(),
             max_token_parameter: LlmMaxTokenParameter::MaxTokens,
             no_reasoning_control: LlmNoReasoningControl::None,
             mlx: MlxLlmConfig::default(),
@@ -799,6 +809,7 @@ fn default_llm_profiles() -> BTreeMap<String, LlmProfileConfig> {
             base_url: String::new(),
             api_key: String::new(),
             model: String::new(),
+            chat_completions_path: default_llm_chat_completions_path(),
             max_token_parameter: LlmMaxTokenParameter::MaxTokens,
             no_reasoning_control: LlmNoReasoningControl::None,
             mlx: MlxLlmConfig::default(),
@@ -812,6 +823,7 @@ fn default_llm_profiles() -> BTreeMap<String, LlmProfileConfig> {
             base_url: "https://api.openai.com/v1".into(),
             api_key: String::new(),
             model: "gpt-5.4-nano".into(),
+            chat_completions_path: default_llm_chat_completions_path(),
             max_token_parameter: LlmMaxTokenParameter::MaxCompletionTokens,
             no_reasoning_control: LlmNoReasoningControl::ReasoningEffort,
             mlx: MlxLlmConfig::default(),
@@ -1573,6 +1585,7 @@ llm:
       base_url: "https://api.openai.com/v1"
       api_key: ""          # or use ${LLM_API_KEY}
       model: "gpt-5.4-nano"
+      chat_completions_path: "/chat/completions"  # relative path appended to base_url
       max_token_parameter: "max_completion_tokens"
       no_reasoning_control: "reasoning_effort"
     apfel:
@@ -1581,6 +1594,7 @@ llm:
       base_url: "http://127.0.0.1:11434/v1"
       api_key: ""
       model: "apple-foundationmodel"
+      chat_completions_path: "/chat/completions"  # customize for non-standard OpenAI-compatible endpoints
       max_token_parameter: "max_tokens"
       no_reasoning_control: "none"
     mlx:
@@ -1815,6 +1829,7 @@ mod tests {
         assert_eq!(apfel.base_url, "http://127.0.0.1:11434/v1");
         assert_eq!(apfel.api_key, "");
         assert_eq!(apfel.model, "apple-foundationmodel");
+        assert_eq!(apfel.chat_completions_path, "/chat/completions");
         assert!(matches!(
             apfel.max_token_parameter,
             LlmMaxTokenParameter::MaxTokens
@@ -1839,7 +1854,26 @@ mod tests {
         assert_eq!(active.base_url, "http://127.0.0.1:11434/v1");
         assert_eq!(active.api_key, "");
         assert_eq!(active.model, "apple-foundationmodel");
+        assert_eq!(active.chat_completions_path, "/chat/completions");
         assert!(active.is_ready());
+    }
+
+    #[test]
+    fn llm_profile_runtime_config_missing_chat_path_defaults_to_chat_completions() {
+        let profile: LlmProfileRuntimeConfig = serde_json::from_value(serde_json::json!({
+            "id": "openai",
+            "name": "OpenAI",
+            "provider": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "",
+            "model": "gpt-5.4-nano",
+            "max_token_parameter": "max_completion_tokens",
+            "no_reasoning_control": "reasoning_effort",
+            "mlx": {"model": "mlx/Qwen3-0.6B-4bit"}
+        }))
+        .unwrap();
+
+        assert_eq!(profile.chat_completions_path, "/chat/completions");
     }
 
     #[test]

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -767,6 +767,7 @@ pub unsafe extern "C" fn sp_core_rewrite_with_template(
             _ => Box::new(OpenAiCompatibleProvider::new(
                 llm_http_client,
                 active_profile.base_url.clone(),
+                active_profile.chat_completions_path.clone(),
                 active_profile.api_key.clone(),
                 active_profile.model.clone(),
                 llm_config.temperature,
@@ -1100,6 +1101,7 @@ async fn run_session(
             _ => Box::new(OpenAiCompatibleProvider::new(
                 llm_http_client,
                 active_profile.base_url,
+                active_profile.chat_completions_path,
                 active_profile.api_key,
                 active_profile.model,
                 llm_config.temperature,
@@ -1320,6 +1322,7 @@ fn start_llm_warmup_if_needed(
         let llm = OpenAiCompatibleProvider::new(
             llm_http_client,
             warmup_profile.base_url,
+            warmup_profile.chat_completions_path,
             warmup_profile.api_key,
             warmup_profile.model,
             warmup_cfg.temperature,
@@ -1531,6 +1534,7 @@ pub unsafe extern "C" fn sp_llm_test(
         base_url,
         api_key,
         model,
+        chat_completions_path: "/chat/completions".into(),
         max_token_parameter,
         no_reasoning_control: config::LlmNoReasoningControl::ReasoningEffort,
         mlx: Default::default(),
@@ -1757,6 +1761,7 @@ pub unsafe extern "C" fn sp_llm_test_profile_json(profile_json: *const c_char) -
             let llm = OpenAiCompatibleProvider::new(
                 client,
                 profile.base_url,
+                profile.chat_completions_path,
                 profile.api_key,
                 profile.model,
                 cfg.llm.temperature,

--- a/koe-core/src/llm/openai_compatible.rs
+++ b/koe-core/src/llm/openai_compatible.rs
@@ -12,6 +12,7 @@ pub const LLM_HTTP_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 pub struct OpenAiCompatibleProvider {
     client: Client,
     base_url: String,
+    chat_completions_path: String,
     api_key: String,
     model: String,
     temperature: f64,
@@ -26,6 +27,7 @@ impl OpenAiCompatibleProvider {
     pub fn new(
         client: Client,
         base_url: String,
+        chat_completions_path: String,
         api_key: String,
         model: String,
         temperature: f64,
@@ -37,6 +39,7 @@ impl OpenAiCompatibleProvider {
         Self {
             client,
             base_url,
+            chat_completions_path,
             api_key,
             model,
             temperature,
@@ -80,6 +83,18 @@ impl OpenAiCompatibleProvider {
     }
 }
 
+fn build_chat_completions_url(base_url: &str, chat_completions_path: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    let normalized_path = chat_completions_path.trim();
+    let effective_path = if normalized_path.is_empty() {
+        "/chat/completions"
+    } else {
+        normalized_path
+    };
+    let path = effective_path.trim_start_matches('/');
+    format!("{base}/{path}")
+}
+
 pub fn build_http_client(timeout_ms: u64) -> std::result::Result<Client, reqwest::Error> {
     Client::builder()
         .timeout(Duration::from_millis(timeout_ms))
@@ -106,6 +121,7 @@ pub async fn test_correction(
     let llm = OpenAiCompatibleProvider::new(
         client,
         profile.base_url.clone(),
+        profile.chat_completions_path.clone(),
         profile.api_key.clone(),
         profile.model.clone(),
         temperature,
@@ -174,7 +190,7 @@ pub fn build_chat_completion_body(
 #[async_trait::async_trait]
 impl LlmProvider for OpenAiCompatibleProvider {
     async fn correct(&self, request: &CorrectionRequest) -> Result<String> {
-        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+        let url = build_chat_completions_url(&self.base_url, &self.chat_completions_path);
 
         let profile = LlmProfileRuntimeConfig {
             id: String::new(),
@@ -183,6 +199,7 @@ impl LlmProvider for OpenAiCompatibleProvider {
             base_url: self.base_url.clone(),
             api_key: self.api_key.clone(),
             model: self.model.clone(),
+            chat_completions_path: self.chat_completions_path.clone(),
             max_token_parameter: self.max_token_parameter,
             no_reasoning_control: self.no_reasoning_control,
             mlx: Default::default(),
@@ -270,6 +287,7 @@ mod tests {
             base_url: "http://127.0.0.1:11434/v1".into(),
             api_key: "".into(),
             model: "apple-foundationmodel".into(),
+            chat_completions_path: "/chat/completions".into(),
             max_token_parameter: LlmMaxTokenParameter::MaxTokens,
             no_reasoning_control: LlmNoReasoningControl::None,
             mlx: Default::default(),
@@ -293,6 +311,7 @@ mod tests {
             base_url: "https://api.openai.com/v1".into(),
             api_key: "sk-test".into(),
             model: "gpt-5.4-nano".into(),
+            chat_completions_path: "/chat/completions".into(),
             max_token_parameter: LlmMaxTokenParameter::MaxCompletionTokens,
             no_reasoning_control: LlmNoReasoningControl::ReasoningEffort,
             mlx: Default::default(),
@@ -304,5 +323,17 @@ mod tests {
         assert_eq!(body["max_completion_tokens"], 1024);
         assert_eq!(body["reasoning_effort"], "none");
         assert!(body.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn chat_completion_url_avoids_double_slashes() {
+        let url = build_chat_completions_url("https://api.openai.com/v1/", "/chat/completions");
+        assert_eq!(url, "https://api.openai.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn chat_completion_url_accepts_path_without_leading_slash() {
+        let url = build_chat_completions_url("https://api.openai.com/v1", "chat/completions");
+        assert_eq!(url, "https://api.openai.com/v1/chat/completions");
     }
 }


### PR DESCRIPTION
## Summary
- add configurable chat_completions_path for OpenAI-compatible LLM profiles
- replace hardcoded /chat/completions with normalized base_url + chat_completions_path
- add Setup Wizard Chat Path field and persist it in profile payload

## Test
- cargo test -p koe-core openai_compatible -- --nocapture
- cargo test -p koe-core llm_profile_runtime_config_missing_chat_path_defaults_to_chat_completions -- --nocapture
- cargo test -p koe-core default_llm_config_includes_openai_apfel_and_mlx_profiles -- --nocapture
- cargo test -p koe-core active_profile_config_resolves_apfel_profile -- --nocapture
- cargo test -p koe-core config_default_includes_single_translation_template -- --nocapture