### PR TITLE
feat(setup): add LLM timeout + remote model picker

### DIFF
--- a/KoeApp/Koe/Bridge/SPRustBridge.h
+++ b/KoeApp/Koe/Bridge/SPRustBridge.h
@@ -54,6 +54,10 @@ typedef NS_ENUM(NSInteger, SPSessionModeObjC) {
 /// Return supported LLM provider names (e.g. @[@"openai", @"mlx"]).
 - (NSArray<NSString *> *)supportedLlmProviders;
 
+/// Fetch remote model IDs from an OpenAI-compatible `{base_url}/models` endpoint.
+/// Returns dictionary: { success: BOOL, models: NSArray<NSString *>, message: NSString }
+- (NSDictionary *)llmRemoteModelsForBaseURL:(NSString *)baseURL apiKey:(NSString *)apiKey;
+
 /// Scan all models and return array of dictionaries.
 /// Each dict: path, provider, description, repo, total_size, status (0/1/2)
 - (NSArray<NSDictionary *> *)scanModels;

--- a/KoeApp/Koe/Bridge/SPRustBridge.m
+++ b/KoeApp/Koe/Bridge/SPRustBridge.m
@@ -228,6 +228,39 @@ static void bridge_on_rewrite_text_ready(uint64_t token, const char *text) {
     return [result isKindOfClass:[NSArray class]] ? result : @[];
 }
 
+- (NSDictionary *)llmRemoteModelsForBaseURL:(NSString *)baseURL apiKey:(NSString *)apiKey {
+    char *json = sp_llm_list_models_json((baseURL ?: @"").UTF8String, (apiKey ?: @"").UTF8String);
+    if (!json) {
+        return @{
+            @"success": @NO,
+            @"models": @[],
+            @"message": @"No response from core",
+        };
+    }
+
+    NSString *jsonStr = [NSString stringWithUTF8String:json] ?: @"";
+    sp_core_free_string(json);
+
+    NSData *data = [jsonStr dataUsingEncoding:NSUTF8StringEncoding];
+    if (!data) {
+        return @{
+            @"success": @NO,
+            @"models": @[],
+            @"message": @"Invalid model list response encoding",
+        };
+    }
+
+    NSDictionary *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    if (![result isKindOfClass:[NSDictionary class]]) {
+        return @{
+            @"success": @NO,
+            @"models": @[],
+            @"message": @"Invalid model list response payload",
+        };
+    }
+    return result;
+}
+
 - (NSArray<NSDictionary *> *)scanModels {
     char *json = sp_core_scan_models_json();
     if (!json) return @[];

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -21,6 +21,7 @@ static NSString *const kDictionaryFile = @"dictionary.txt";
 static NSString *const kSystemPromptFile = @"system_prompt.txt";
 static NSString *const kTemplateEditablePromptKey = @"__editable_prompt";
 static NSString *const kTemplateOriginalPromptKey = @"__original_prompt";
+static NSString *const kDefaultLlmChatCompletionsPath = @"/chat/completions";
 static NSString *const kOverlayFontFamilyDefault = @"system";
 static NSString *const kOverlayFontFamilySystemLabel = @"System Default";
 static const NSInteger kOverlayFontSizeDefault = 13;
@@ -477,6 +478,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 @property (nonatomic, strong) NSSecureTextField *llmApiKeySecureField;
 @property (nonatomic, strong) NSButton *llmApiKeyToggle;
 @property (nonatomic, strong) NSTextField *llmModelField;
+@property (nonatomic, strong) NSTextField *llmChatCompletionsPathField;
 @property (nonatomic, strong) NSButton *llmTestButton;
 @property (nonatomic, strong) NSTextField *llmTestResultLabel;
 
@@ -999,7 +1001,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     y -= rowH;
     CGFloat providerDetailStartY = y;
 
-    // --- OpenAI fields (tag 2001-2006 for show/hide) ---
+    // --- OpenAI fields (tag 2001-2007 for show/hide) ---
 
     // Base URL
     NSTextField *baseUrlLabel = [self formLabel:@"Base URL" frame:NSMakeRect(16, y, labelW, 22)];
@@ -1039,12 +1041,22 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     [pane addSubview:self.llmModelField];
     y -= rowH + 4;
 
+    // Chat Completions Path
+    NSTextField *chatPathLabel = [self formLabel:@"Chat Path" frame:NSMakeRect(16, y, labelW, 22)];
+    chatPathLabel.tag = 2004;
+    [pane addSubview:chatPathLabel];
+    self.llmChatCompletionsPathField = [self formTextField:NSMakeRect(fieldX, y, fieldW, 22)
+                                                placeholder:kDefaultLlmChatCompletionsPath];
+    self.llmChatCompletionsPathField.tag = 2004;
+    [pane addSubview:self.llmChatCompletionsPathField];
+    y -= rowH;
+
     // Max Token Parameter
     NSTextField *tokenParamLabel = [self formLabel:@"Token Parameter" frame:NSMakeRect(16, y, labelW, 22)];
-    tokenParamLabel.tag = 2004;
+    tokenParamLabel.tag = 2005;
     [pane addSubview:tokenParamLabel];
     self.maxTokenParamPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, 240, 26) pullsDown:NO];
-    self.maxTokenParamPopup.tag = 2004;
+    self.maxTokenParamPopup.tag = 2005;
     [self.maxTokenParamPopup addItemsWithTitles:@[
         @"max_completion_tokens",
         @"max_tokens",
@@ -1057,7 +1069,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     // Hint text
     NSTextField *tokenHint = [self descriptionLabel:@"GPT-4o and older models use max_tokens. GPT-5 and reasoning models (o1/o3) use max_completion_tokens."];
     tokenHint.frame = NSMakeRect(fieldX, y - 2, fieldW, 32);
-    tokenHint.tag = 2005;
+    tokenHint.tag = 2006;
     [pane addSubview:tokenHint];
     y -= 44;
 
@@ -1065,7 +1077,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     self.llmTestButton = [NSButton buttonWithTitle:@"Test Connection" target:self action:@selector(testLlmConnection:)];
     self.llmTestButton.bezelStyle = NSBezelStyleRounded;
     self.llmTestButton.frame = NSMakeRect(fieldX, y, 130, 28);
-    self.llmTestButton.tag = 2006;
+    self.llmTestButton.tag = 2007;
     [pane addSubview:self.llmTestButton];
     y -= 32;
 
@@ -1074,7 +1086,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     self.llmTestResultLabel.frame = NSMakeRect(fieldX, y - 36, fieldW, 42);
     self.llmTestResultLabel.font = [NSFont systemFontOfSize:12];
     self.llmTestResultLabel.selectable = YES;
-    self.llmTestResultLabel.tag = 2006;
+    self.llmTestResultLabel.tag = 2007;
     [pane addSubview:self.llmTestResultLabel];
 
     // --- MLX fields (tag 2010-2012 for show/hide, initially hidden) ---
@@ -3225,6 +3237,10 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     NSMutableDictionary *copy = [profile mutableCopy] ?: [NSMutableDictionary dictionary];
     NSDictionary *mlx = copy[@"mlx"];
     copy[@"mlx"] = [mlx isKindOfClass:[NSDictionary class]] ? [mlx mutableCopy] : [@{@"model": @"mlx/Qwen3-0.6B-4bit"} mutableCopy];
+    NSString *chatPath = [copy[@"chat_completions_path"] isKindOfClass:[NSString class]] ? copy[@"chat_completions_path"] : @"";
+    if (chatPath.length == 0) {
+        copy[@"chat_completions_path"] = kDefaultLlmChatCompletionsPath;
+    }
     return copy;
 }
 
@@ -3235,6 +3251,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         @"base_url": @"https://api.openai.com/v1",
         @"api_key": @"",
         @"model": @"gpt-5.4-nano",
+        @"chat_completions_path": kDefaultLlmChatCompletionsPath,
         @"max_token_parameter": @"max_completion_tokens",
         @"no_reasoning_control": @"reasoning_effort",
         @"mlx": @{@"model": @"mlx/Qwen3-0.6B-4bit"},
@@ -3248,6 +3265,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         @"base_url": @"http://127.0.0.1:11434/v1",
         @"api_key": @"",
         @"model": @"apple-foundationmodel",
+        @"chat_completions_path": kDefaultLlmChatCompletionsPath,
         @"max_token_parameter": @"max_tokens",
         @"no_reasoning_control": @"none",
         @"mlx": @{@"model": @"mlx/Qwen3-0.6B-4bit"},
@@ -3316,6 +3334,8 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     NSString *apiKey = self.llmApiKeyToggle.tag == 1 ? self.llmApiKeyField.stringValue : self.llmApiKeySecureField.stringValue;
     profile[@"api_key"] = apiKey ?: @"";
     profile[@"model"] = self.llmModelField.stringValue ?: @"";
+    NSString *chatPath = [[self.llmChatCompletionsPathField.stringValue ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+    profile[@"chat_completions_path"] = (chatPath.length > 0) ? chatPath : kDefaultLlmChatCompletionsPath;
     profile[@"max_token_parameter"] = self.maxTokenParamPopup.selectedItem.representedObject ?: @"max_completion_tokens";
     if (!profile[@"no_reasoning_control"]) {
         profile[@"no_reasoning_control"] = [provider isEqualToString:@"mlx"] ? @"none" : @"reasoning_effort";
@@ -3351,6 +3371,9 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     self.llmApiKeyToggle.image = [NSImage imageWithSystemSymbolName:@"eye.slash" accessibilityDescription:@"Show"];
     self.llmApiKeyToggle.tag = 0;
     self.llmModelField.stringValue = [profile[@"model"] isKindOfClass:[NSString class]] ? profile[@"model"] : @"";
+    NSString *chatPath = [profile[@"chat_completions_path"] isKindOfClass:[NSString class]]
+        ? profile[@"chat_completions_path"] : kDefaultLlmChatCompletionsPath;
+    self.llmChatCompletionsPathField.stringValue = chatPath.length > 0 ? chatPath : kDefaultLlmChatCompletionsPath;
 
     NSString *maxTokenParam = [profile[@"max_token_parameter"] isKindOfClass:[NSString class]]
         ? profile[@"max_token_parameter"] : @"max_completion_tokens";
@@ -3823,9 +3846,9 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     BOOL isOpenAI = [provider isEqualToString:@"openai"];
     BOOL isMlx = [provider isEqualToString:@"mlx"];
 
-    // Toggle OpenAI fields (tag 2001-2006)
+    // Toggle OpenAI fields (tag 2001-2007)
     [self setHidden:!isOpenAI
- forViewsWithTagInRange:NSMakeRange(2001, 6)
+ forViewsWithTagInRange:NSMakeRange(2001, 7)
              inView:self.currentPaneView];
     // Eye toggle doesn't use tag for show/hide (tag is used for 0/1 state)
     self.llmApiKeyToggle.hidden = !isOpenAI;
@@ -3840,6 +3863,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     self.llmApiKeyField.enabled = enabled;
     self.llmApiKeySecureField.enabled = enabled;
     self.llmModelField.enabled = enabled;
+    self.llmChatCompletionsPathField.enabled = enabled;
     self.maxTokenParamPopup.enabled = enabled;
     self.llmTestButton.enabled = enabled;
 

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -22,6 +22,7 @@ static NSString *const kSystemPromptFile = @"system_prompt.txt";
 static NSString *const kTemplateEditablePromptKey = @"__editable_prompt";
 static NSString *const kTemplateOriginalPromptKey = @"__original_prompt";
 static NSString *const kDefaultLlmChatCompletionsPath = @"/chat/completions";
+static NSString *const kDefaultLlmTimeoutMs = @"8000";
 static NSString *const kOverlayFontFamilyDefault = @"system";
 static NSString *const kOverlayFontFamilySystemLabel = @"System Default";
 static const NSInteger kOverlayFontSizeDefault = 13;
@@ -128,6 +129,20 @@ static NSString *normalizedOverlayFontFamilyValue(NSString *value) {
 
 static BOOL overlayUsesSystemFontFamily(NSString *value) {
     return [normalizedOverlayFontFamilyValue(value) caseInsensitiveCompare:kOverlayFontFamilyDefault] == NSOrderedSame;
+}
+
+static NSString *normalizedLlmTimeoutValue(NSString *value) {
+    NSString *trimmed = [[value ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+    if (trimmed.length == 0) return kDefaultLlmTimeoutMs;
+
+    NSCharacterSet *nonDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+    if ([trimmed rangeOfCharacterFromSet:nonDigits].location != NSNotFound) {
+        return nil;
+    }
+
+    unsigned long long parsed = trimmed.longLongValue;
+    if (parsed == 0) return nil;
+    return [NSString stringWithFormat:@"%llu", parsed];
 }
 
 static NSFont *overlayFontForFamily(NSString *fontFamily, CGFloat fontSize) {
@@ -472,12 +487,17 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 @property (nonatomic, strong) NSButton *llmAddProfileButton;
 @property (nonatomic, strong) NSButton *llmAddApfelProfileButton;
 @property (nonatomic, strong) NSButton *llmDeleteProfileButton;
+@property (nonatomic, strong) NSTextField *llmProfileNameField;
 @property (nonatomic, strong) NSPopUpButton *llmProviderPopup;
 @property (nonatomic, strong) NSTextField *llmBaseUrlField;
+@property (nonatomic, strong) NSTextField *llmTimeoutField;
 @property (nonatomic, strong) NSTextField *llmApiKeyField;
 @property (nonatomic, strong) NSSecureTextField *llmApiKeySecureField;
 @property (nonatomic, strong) NSButton *llmApiKeyToggle;
 @property (nonatomic, strong) NSTextField *llmModelField;
+@property (nonatomic, strong) NSButton *llmToggleModelPickerButton;
+@property (nonatomic, strong) NSPopUpButton *llmRemoteModelPopup;
+@property (nonatomic, strong) NSButton *llmRefreshModelsButton;
 @property (nonatomic, strong) NSTextField *llmChatCompletionsPathField;
 @property (nonatomic, strong) NSButton *llmTestButton;
 @property (nonatomic, strong) NSTextField *llmTestResultLabel;
@@ -494,6 +514,8 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 @property (nonatomic, strong) NSTextField *llmModelProgressSizeLabel;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableDictionary *> *llmProfiles;
 @property (nonatomic, copy) NSString *activeLlmProfileId;
+@property (nonatomic, assign) BOOL llmRemoteModelPickerExpanded;
+@property (nonatomic, assign) BOOL llmRemoteModelPickerRowVisible;
 
 // Hotkey
 @property (nonatomic, strong) NSPopUpButton *hotkeyPopup;
@@ -933,7 +955,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     CGFloat contentX = 24.0;
     CGFloat contentW = paneWidth - 48.0;
 
-    CGFloat contentHeight = 580;
+    CGFloat contentHeight = 660;
     NSView *pane = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, paneWidth, contentHeight)];
     [self applySettingsPaneBackgroundToView:pane];
 
@@ -983,6 +1005,20 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     [pane addSubview:self.llmDeleteProfileButton];
     y -= rowH;
 
+    // Profile name
+    [pane addSubview:[self formLabel:@"Profile Name" frame:NSMakeRect(16, y, labelW, 22)]];
+    self.llmProfileNameField = [self formTextField:NSMakeRect(fieldX, y, fieldW, 22) placeholder:@"OpenAI Compatible"];
+    self.llmProfileNameField.delegate = self;
+    [pane addSubview:self.llmProfileNameField];
+    y -= rowH;
+
+    // Timeout (global)
+    [pane addSubview:[self formLabel:@"Timeout (ms)" frame:NSMakeRect(16, y, labelW, 22)]];
+    self.llmTimeoutField = [self formTextField:NSMakeRect(fieldX, y, 120, 22) placeholder:kDefaultLlmTimeoutMs];
+    self.llmTimeoutField.delegate = self;
+    [pane addSubview:self.llmTimeoutField];
+    y -= rowH;
+
     // Provider
     [pane addSubview:[self formLabel:@"Provider" frame:NSMakeRect(16, y, labelW, 22)]];
     self.llmProviderPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, fieldW, 26) pullsDown:NO];
@@ -1001,7 +1037,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     y -= rowH;
     CGFloat providerDetailStartY = y;
 
-    // --- OpenAI fields (tag 2001-2007 for show/hide) ---
+    // --- OpenAI fields (tag 2001-2008 for show/hide) ---
 
     // Base URL
     NSTextField *baseUrlLabel = [self formLabel:@"Base URL" frame:NSMakeRect(16, y, labelW, 22)];
@@ -1033,30 +1069,60 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     y -= rowH;
 
     // Model (text field for OpenAI)
+    CGFloat modelPickerButtonW = 74;
+    CGFloat modelFieldW = fieldW - modelPickerButtonW - 6;
     NSTextField *modelLabel = [self formLabel:@"Model" frame:NSMakeRect(16, y, labelW, 22)];
     modelLabel.tag = 2003;
     [pane addSubview:modelLabel];
-    self.llmModelField = [self formTextField:NSMakeRect(fieldX, y, fieldW, 22) placeholder:@"gpt-5.4-nano"];
+    self.llmModelField = [self formTextField:NSMakeRect(fieldX, y, modelFieldW, 22) placeholder:@"gpt-5.4-nano"];
     self.llmModelField.tag = 2003;
     [pane addSubview:self.llmModelField];
+    self.llmToggleModelPickerButton = [NSButton buttonWithTitle:@"Choose"
+                                                          target:self
+                                                          action:@selector(toggleLlmRemoteModelPicker:)];
+    self.llmToggleModelPickerButton.frame = NSMakeRect(fieldX + modelFieldW + 6, y - 2, modelPickerButtonW, 26);
+    self.llmToggleModelPickerButton.bezelStyle = NSBezelStyleRounded;
+    self.llmToggleModelPickerButton.tag = 2003;
+    [pane addSubview:self.llmToggleModelPickerButton];
+    y -= rowH;
+
+    // Model List (OpenAI /models)
+    NSTextField *modelListLabel = [self formLabel:@"Model List" frame:NSMakeRect(16, y, labelW, 22)];
+    modelListLabel.tag = 2004;
+    [pane addSubview:modelListLabel];
+    self.llmRemoteModelPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, fieldW - 74, 26) pullsDown:NO];
+    self.llmRemoteModelPopup.tag = 2004;
+    [self.llmRemoteModelPopup addItemWithTitle:@"No models loaded"];
+    self.llmRemoteModelPopup.enabled = NO;
+    [self.llmRemoteModelPopup setTarget:self];
+    [self.llmRemoteModelPopup setAction:@selector(llmRemoteModelChanged:)];
+    [pane addSubview:self.llmRemoteModelPopup];
+    self.llmRefreshModelsButton = [NSButton buttonWithTitle:@"Refresh" target:self action:@selector(refreshLlmRemoteModels:)];
+    self.llmRefreshModelsButton.frame = NSMakeRect(fieldX + fieldW - 66, y - 2, 66, 26);
+    self.llmRefreshModelsButton.bezelStyle = NSBezelStyleRounded;
+    self.llmRefreshModelsButton.tag = 2004;
+    [pane addSubview:self.llmRefreshModelsButton];
+    self.llmRemoteModelPickerExpanded = NO;
+    self.llmRemoteModelPickerRowVisible = YES;
+    [self setHidden:YES forViewsWithTagInRange:NSMakeRange(2004, 1) inView:pane];
     y -= rowH + 4;
 
     // Chat Completions Path
     NSTextField *chatPathLabel = [self formLabel:@"Chat Path" frame:NSMakeRect(16, y, labelW, 22)];
-    chatPathLabel.tag = 2004;
+    chatPathLabel.tag = 2005;
     [pane addSubview:chatPathLabel];
     self.llmChatCompletionsPathField = [self formTextField:NSMakeRect(fieldX, y, fieldW, 22)
                                                 placeholder:kDefaultLlmChatCompletionsPath];
-    self.llmChatCompletionsPathField.tag = 2004;
+    self.llmChatCompletionsPathField.tag = 2005;
     [pane addSubview:self.llmChatCompletionsPathField];
     y -= rowH;
 
     // Max Token Parameter
     NSTextField *tokenParamLabel = [self formLabel:@"Token Parameter" frame:NSMakeRect(16, y, labelW, 22)];
-    tokenParamLabel.tag = 2005;
+    tokenParamLabel.tag = 2006;
     [pane addSubview:tokenParamLabel];
     self.maxTokenParamPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(fieldX, y - 2, 240, 26) pullsDown:NO];
-    self.maxTokenParamPopup.tag = 2005;
+    self.maxTokenParamPopup.tag = 2006;
     [self.maxTokenParamPopup addItemsWithTitles:@[
         @"max_completion_tokens",
         @"max_tokens",
@@ -1069,7 +1135,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     // Hint text
     NSTextField *tokenHint = [self descriptionLabel:@"GPT-4o and older models use max_tokens. GPT-5 and reasoning models (o1/o3) use max_completion_tokens."];
     tokenHint.frame = NSMakeRect(fieldX, y - 2, fieldW, 32);
-    tokenHint.tag = 2006;
+    tokenHint.tag = 2007;
     [pane addSubview:tokenHint];
     y -= 44;
 
@@ -1077,7 +1143,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     self.llmTestButton = [NSButton buttonWithTitle:@"Test Connection" target:self action:@selector(testLlmConnection:)];
     self.llmTestButton.bezelStyle = NSBezelStyleRounded;
     self.llmTestButton.frame = NSMakeRect(fieldX, y, 130, 28);
-    self.llmTestButton.tag = 2007;
+    self.llmTestButton.tag = 2008;
     [pane addSubview:self.llmTestButton];
     y -= 32;
 
@@ -1086,7 +1152,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     self.llmTestResultLabel.frame = NSMakeRect(fieldX, y - 36, fieldW, 42);
     self.llmTestResultLabel.font = [NSFont systemFontOfSize:12];
     self.llmTestResultLabel.selectable = YES;
-    self.llmTestResultLabel.tag = 2007;
+    self.llmTestResultLabel.tag = 2008;
     [pane addSubview:self.llmTestResultLabel];
 
     // --- MLX fields (tag 2010-2012 for show/hide, initially hidden) ---
@@ -2082,6 +2148,16 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 }
 
 - (void)controlTextDidChange:(NSNotification *)notification {
+    if (notification.object == self.llmProfileNameField) {
+        NSMutableDictionary *profile = [self activeLlmProfile];
+        if (!profile) return;
+        NSString *profileName = [[self.llmProfileNameField.stringValue ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+        profile[@"name"] = profileName ?: @"";
+        [self populateLlmProfilePopup];
+        self.llmTestResultLabel.stringValue = @"";
+        return;
+    }
+
     if (self.suppressTemplateSync) return;
     if (notification.object != self.templateNameField) return;
     if (self.selectedTemplateIndex < 0 || self.selectedTemplateIndex >= (NSInteger)self.templatesData.count) return;
@@ -2092,6 +2168,20 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     NSIndexSet *rows = [NSIndexSet indexSetWithIndex:(NSUInteger)self.selectedTemplateIndex];
     NSIndexSet *columns = [NSIndexSet indexSetWithIndex:0];
     [self.templatesTableView reloadDataForRowIndexes:rows columnIndexes:columns];
+}
+
+- (BOOL)control:(NSControl *)control
+        textView:(NSTextView *)textView
+shouldChangeTextInRange:(NSRange)affectedCharRange
+ replacementString:(NSString *)replacementString {
+    if (control != self.llmTimeoutField) {
+        return YES;
+    }
+    if (replacementString == nil || replacementString.length == 0) {
+        return YES;
+    }
+    NSCharacterSet *nonDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+    return [replacementString rangeOfCharacterFromSet:nonDigits].location == NSNotFound;
 }
 
 - (void)textDidChange:(NSNotification *)notification {
@@ -3329,6 +3419,8 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     if (!profile) return;
 
     NSString *provider = self.llmProviderPopup.selectedItem.representedObject ?: @"openai";
+    NSString *profileName = [[self.llmProfileNameField.stringValue ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] copy];
+    profile[@"name"] = profileName ?: @"";
     profile[@"provider"] = provider;
     profile[@"base_url"] = self.llmBaseUrlField.stringValue ?: @"";
     NSString *apiKey = self.llmApiKeyToggle.tag == 1 ? self.llmApiKeyField.stringValue : self.llmApiKeySecureField.stringValue;
@@ -3370,6 +3462,8 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     self.llmApiKeyField.hidden = YES;
     self.llmApiKeyToggle.image = [NSImage imageWithSystemSymbolName:@"eye.slash" accessibilityDescription:@"Show"];
     self.llmApiKeyToggle.tag = 0;
+    NSString *profileName = [profile[@"name"] isKindOfClass:[NSString class]] ? profile[@"name"] : @"";
+    self.llmProfileNameField.stringValue = profileName.length > 0 ? profileName : (self.activeLlmProfileId ?: @"");
     self.llmModelField.stringValue = [profile[@"model"] isKindOfClass:[NSString class]] ? profile[@"model"] : @"";
     NSString *chatPath = [profile[@"chat_completions_path"] isKindOfClass:[NSString class]]
         ? profile[@"chat_completions_path"] : kDefaultLlmChatCompletionsPath;
@@ -3396,6 +3490,8 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
             }
         }
         [self updateLlmModelStatusLabel];
+    } else if (self.llmRemoteModelPickerExpanded) {
+        [self refreshLlmRemoteModels:nil];
     }
 
     [self updateLlmFieldsEnabled];
@@ -3534,6 +3630,8 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     } else if ([identifier isEqualToString:kToolbarLLM]) {
         NSString *enabled = configGet(@"llm.enabled");
         self.llmEnabledCheckbox.state = ([enabled isEqualToString:@"false"]) ? NSControlStateValueOff : NSControlStateValueOn;
+        NSString *timeoutMs = normalizedLlmTimeoutValue(configGet(@"llm.timeout_ms"));
+        self.llmTimeoutField.stringValue = timeoutMs ?: kDefaultLlmTimeoutMs;
 
         [self loadLlmProfilesFromCore];
         self.llmTestResultLabel.stringValue = @"";
@@ -3724,6 +3822,13 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     if (self.llmEnabledCheckbox) {
         NSString *enabledStr = (self.llmEnabledCheckbox.state == NSControlStateValueOn) ? @"true" : @"false";
         saveOk &= configSet(@"llm.enabled", enabledStr);
+        NSString *timeoutMs = normalizedLlmTimeoutValue(self.llmTimeoutField.stringValue);
+        if (!timeoutMs) {
+            [self showAlert:@"Invalid LLM timeout"
+                       info:@"Timeout (ms) must be a positive integer."];
+            return;
+        }
+        saveOk &= configSet(@"llm.timeout_ms", timeoutMs);
 
         [self syncActiveLlmProfileFromFields];
         NSDictionary *payload = @{
@@ -3834,21 +3939,52 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     [self updateLlmFieldsEnabled];
 }
 
+- (void)toggleLlmRemoteModelPicker:(id)sender {
+    self.llmRemoteModelPickerExpanded = !self.llmRemoteModelPickerExpanded;
+    if (self.llmRemoteModelPickerExpanded) {
+        [self updateLlmFieldsEnabled];
+        [self refreshLlmRemoteModels:nil];
+    } else {
+        [self updateLlmFieldsEnabled];
+    }
+}
+
+- (void)setLlmRemoteModelPickerRowVisible:(BOOL)visible {
+    if (_llmRemoteModelPickerRowVisible == visible) {
+        return;
+    }
+    _llmRemoteModelPickerRowVisible = visible;
+
+    // Keep the model picker row height in sync with layout built in buildLlmPane.
+    CGFloat pickerRowHeight = 36.0; // rowH (32) + extra gap (4)
+    CGFloat deltaY = visible ? -pickerRowHeight : pickerRowHeight;
+
+    // Move all OpenAI controls below model picker row.
+    for (NSView *view in self.currentPaneView.subviews) {
+        if (view.tag >= 2005 && view.tag <= 2008) {
+            NSRect frame = view.frame;
+            frame.origin.y += deltaY;
+            view.frame = frame;
+        }
+    }
+}
+
 - (void)updateLlmFieldsEnabled {
     BOOL enabled = (self.llmEnabledCheckbox.state == NSControlStateValueOn);
     self.llmProfilePopup.enabled = enabled;
     self.llmAddProfileButton.enabled = enabled;
     self.llmAddApfelProfileButton.enabled = enabled;
     self.llmDeleteProfileButton.enabled = enabled && self.llmProfiles.count > 1;
+    self.llmProfileNameField.enabled = enabled;
     self.llmProviderPopup.enabled = enabled;
 
     NSString *provider = self.llmProviderPopup.selectedItem.representedObject ?: @"openai";
     BOOL isOpenAI = [provider isEqualToString:@"openai"];
     BOOL isMlx = [provider isEqualToString:@"mlx"];
 
-    // Toggle OpenAI fields (tag 2001-2007)
+    // Toggle OpenAI fields (tag 2001-2008)
     [self setHidden:!isOpenAI
- forViewsWithTagInRange:NSMakeRange(2001, 7)
+ forViewsWithTagInRange:NSMakeRange(2001, 8)
              inView:self.currentPaneView];
     // Eye toggle doesn't use tag for show/hide (tag is used for 0/1 state)
     self.llmApiKeyToggle.hidden = !isOpenAI;
@@ -3859,10 +3995,22 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
         self.llmApiKeySecureField.hidden = showPlain;
     }
 
+    self.llmTimeoutField.enabled = enabled;
     self.llmBaseUrlField.enabled = enabled;
     self.llmApiKeyField.enabled = enabled;
     self.llmApiKeySecureField.enabled = enabled;
     self.llmModelField.enabled = enabled;
+    self.llmToggleModelPickerButton.hidden = !isOpenAI;
+    self.llmToggleModelPickerButton.enabled = enabled && isOpenAI;
+    [self.llmToggleModelPickerButton setTitle:(self.llmRemoteModelPickerExpanded ? @"Hide" : @"Choose")];
+    BOOL showRemoteModelPicker = isOpenAI && self.llmRemoteModelPickerExpanded;
+    [self setLlmRemoteModelPickerRowVisible:showRemoteModelPicker];
+    [self setHidden:!showRemoteModelPicker
+ forViewsWithTagInRange:NSMakeRange(2004, 1)
+             inView:self.currentPaneView];
+    BOOL hasSelectableRemoteModel = (self.llmRemoteModelPopup.selectedItem.representedObject != nil);
+    self.llmRemoteModelPopup.enabled = enabled && showRemoteModelPicker && hasSelectableRemoteModel;
+    self.llmRefreshModelsButton.enabled = enabled && showRemoteModelPicker;
     self.llmChatCompletionsPathField.enabled = enabled;
     self.maxTokenParamPopup.enabled = enabled;
     self.llmTestButton.enabled = enabled;
@@ -3885,11 +4033,108 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType, const char 
     [self updateLlmFieldsEnabled];
     NSString *provider = self.llmProviderPopup.selectedItem.representedObject ?: @"openai";
     if ([provider isEqualToString:@"mlx"]) {
+        self.llmRemoteModelPickerExpanded = NO;
         [self populateLlmLocalModelPopup];
         [self updateLlmModelStatusLabel];
+    } else if ([provider isEqualToString:@"openai"] && self.llmRemoteModelPickerExpanded) {
+        [self refreshLlmRemoteModels:nil];
     }
+    [self updateLlmFieldsEnabled];
     [self syncActiveLlmProfileFromFields];
     self.llmTestResultLabel.stringValue = @"";
+}
+
+- (void)populateLlmRemoteModelPopupWithModels:(NSArray<NSString *> *)models selectedModel:(NSString *)selectedModel {
+    [self.llmRemoteModelPopup removeAllItems];
+
+    if (models.count == 0) {
+        [self.llmRemoteModelPopup addItemWithTitle:@"No models available"];
+        self.llmRemoteModelPopup.lastItem.representedObject = nil;
+        self.llmRemoteModelPopup.enabled = NO;
+        return;
+    }
+
+    for (NSString *modelId in models) {
+        [self.llmRemoteModelPopup addItemWithTitle:modelId];
+        self.llmRemoteModelPopup.lastItem.representedObject = modelId;
+    }
+
+    if (selectedModel.length > 0) {
+        for (NSInteger i = 0; i < self.llmRemoteModelPopup.numberOfItems; i++) {
+            if ([[self.llmRemoteModelPopup itemAtIndex:i].representedObject isEqualToString:selectedModel]) {
+                [self.llmRemoteModelPopup selectItemAtIndex:i];
+                break;
+            }
+        }
+    }
+    self.llmRemoteModelPopup.enabled = (self.llmEnabledCheckbox.state == NSControlStateValueOn);
+}
+
+- (void)llmRemoteModelChanged:(id)sender {
+    NSString *model = self.llmRemoteModelPopup.selectedItem.representedObject;
+    if (model.length > 0) {
+        self.llmModelField.stringValue = model;
+        [self syncActiveLlmProfileFromFields];
+        self.llmTestResultLabel.stringValue = @"";
+    }
+}
+
+- (void)refreshLlmRemoteModels:(id)sender {
+    NSString *provider = self.llmProviderPopup.selectedItem.representedObject ?: @"openai";
+    if (![provider isEqualToString:@"openai"]) return;
+    [self updateLlmFieldsEnabled];
+
+    NSString *baseURL = [self.llmBaseUrlField.stringValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    NSString *apiKey = self.llmApiKeyToggle.tag == 1 ? self.llmApiKeyField.stringValue : self.llmApiKeySecureField.stringValue;
+    NSString *currentModel = [self.llmModelField.stringValue copy] ?: @"";
+    if (baseURL.length == 0) {
+        [self.llmRemoteModelPopup removeAllItems];
+        [self.llmRemoteModelPopup addItemWithTitle:@"Enter Base URL first"];
+        self.llmRemoteModelPopup.enabled = NO;
+        return;
+    }
+
+    [self.llmRemoteModelPopup removeAllItems];
+    [self.llmRemoteModelPopup addItemWithTitle:@"Loading models..."];
+    self.llmRemoteModelPopup.enabled = NO;
+    self.llmRefreshModelsButton.enabled = NO;
+
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) return;
+
+        NSDictionary *result = [strongSelf.rustBridge llmRemoteModelsForBaseURL:baseURL apiKey:apiKey];
+        BOOL success = [result[@"success"] boolValue];
+        NSArray *modelsRaw = [result[@"models"] isKindOfClass:[NSArray class]] ? result[@"models"] : @[];
+        NSMutableArray<NSString *> *models = [NSMutableArray arrayWithCapacity:modelsRaw.count];
+        for (id item in modelsRaw) {
+            if ([item isKindOfClass:[NSString class]] && [item length] > 0) {
+                [models addObject:item];
+            }
+        }
+        NSString *message = [result[@"message"] isKindOfClass:[NSString class]] ? result[@"message"] : @"";
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            typeof(self) innerSelf = weakSelf;
+            if (!innerSelf) return;
+            NSString *activeProvider = innerSelf.llmProviderPopup.selectedItem.representedObject ?: @"openai";
+            if (![activeProvider isEqualToString:@"openai"]) return;
+
+            innerSelf.llmRefreshModelsButton.enabled = (innerSelf.llmEnabledCheckbox.state == NSControlStateValueOn);
+            if (success) {
+                [innerSelf populateLlmRemoteModelPopupWithModels:models selectedModel:currentModel];
+            } else {
+                [innerSelf.llmRemoteModelPopup removeAllItems];
+                [innerSelf.llmRemoteModelPopup addItemWithTitle:@"Load failed"];
+                innerSelf.llmRemoteModelPopup.enabled = NO;
+                if (message.length > 0) {
+                    innerSelf.llmTestResultLabel.stringValue = [NSString stringWithFormat:@"Model list: %@", message];
+                    innerSelf.llmTestResultLabel.textColor = [NSColor systemOrangeColor];
+                }
+            }
+        });
+    });
 }
 
 - (void)populateLlmLocalModelPopup {

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -272,6 +272,8 @@ pub struct LlmProfileConfig {
     pub api_key: String,
     #[serde(default)]
     pub model: String,
+    #[serde(default = "default_llm_chat_completions_path")]
+    pub chat_completions_path: String,
     #[serde(default = "default_llm_max_token_parameter")]
     pub max_token_parameter: LlmMaxTokenParameter,
     #[serde(default)]
@@ -289,6 +291,8 @@ pub struct LlmProfileRuntimeConfig {
     pub base_url: String,
     pub api_key: String,
     pub model: String,
+    #[serde(default = "default_llm_chat_completions_path")]
+    pub chat_completions_path: String,
     pub max_token_parameter: LlmMaxTokenParameter,
     pub no_reasoning_control: LlmNoReasoningControl,
     pub mlx: MlxLlmConfig,
@@ -323,6 +327,7 @@ impl LlmProfileConfig {
             base_url: self.base_url.clone(),
             api_key: self.api_key.clone(),
             model: self.model.clone(),
+            chat_completions_path: self.chat_completions_path.clone(),
             max_token_parameter: self.max_token_parameter,
             no_reasoning_control: self.no_reasoning_control,
             mlx: self.mlx.clone(),
@@ -362,6 +367,7 @@ impl Default for LlmProfileConfig {
             base_url: String::new(),
             api_key: String::new(),
             model: String::new(),
+            chat_completions_path: default_llm_chat_completions_path(),
             max_token_parameter: default_llm_max_token_parameter(),
             no_reasoning_control: LlmNoReasoningControl::default(),
             mlx: MlxLlmConfig::default(),
@@ -773,6 +779,9 @@ fn default_llm_max_token_parameter() -> LlmMaxTokenParameter {
 fn default_llm_provider() -> String {
     "openai".into()
 }
+fn default_llm_chat_completions_path() -> String {
+    "/chat/completions".into()
+}
 fn default_llm_active_profile() -> String {
     "openai".into()
 }
@@ -786,6 +795,7 @@ fn default_llm_profiles() -> BTreeMap<String, LlmProfileConfig> {
             base_url: "http://127.0.0.1:11434/v1".into(),
             api_key: String::new(),
             model: "apple-foundationmodel".into(),
+            chat_completions_path: default_llm_chat_completions_path(),
             max_token_parameter: LlmMaxTokenParameter::MaxTokens,
             no_reasoning_control: LlmNoReasoningControl::None,
             mlx: MlxLlmConfig::default(),
@@ -799,6 +809,7 @@ fn default_llm_profiles() -> BTreeMap<String, LlmProfileConfig> {
             base_url: String::new(),
             api_key: String::new(),
             model: String::new(),
+            chat_completions_path: default_llm_chat_completions_path(),
             max_token_parameter: LlmMaxTokenParameter::MaxTokens,
             no_reasoning_control: LlmNoReasoningControl::None,
             mlx: MlxLlmConfig::default(),
@@ -812,6 +823,7 @@ fn default_llm_profiles() -> BTreeMap<String, LlmProfileConfig> {
             base_url: "https://api.openai.com/v1".into(),
             api_key: String::new(),
             model: "gpt-5.4-nano".into(),
+            chat_completions_path: default_llm_chat_completions_path(),
             max_token_parameter: LlmMaxTokenParameter::MaxCompletionTokens,
             no_reasoning_control: LlmNoReasoningControl::ReasoningEffort,
             mlx: MlxLlmConfig::default(),
@@ -1573,6 +1585,7 @@ llm:
       base_url: "https://api.openai.com/v1"
       api_key: ""          # or use ${LLM_API_KEY}
       model: "gpt-5.4-nano"
+      chat_completions_path: "/chat/completions"  # relative path appended to base_url
       max_token_parameter: "max_completion_tokens"
       no_reasoning_control: "reasoning_effort"
     apfel:
@@ -1581,6 +1594,7 @@ llm:
       base_url: "http://127.0.0.1:11434/v1"
       api_key: ""
       model: "apple-foundationmodel"
+      chat_completions_path: "/chat/completions"  # customize for non-standard OpenAI-compatible endpoints
       max_token_parameter: "max_tokens"
       no_reasoning_control: "none"
     mlx:
@@ -1815,6 +1829,7 @@ mod tests {
         assert_eq!(apfel.base_url, "http://127.0.0.1:11434/v1");
         assert_eq!(apfel.api_key, "");
         assert_eq!(apfel.model, "apple-foundationmodel");
+        assert_eq!(apfel.chat_completions_path, "/chat/completions");
         assert!(matches!(
             apfel.max_token_parameter,
             LlmMaxTokenParameter::MaxTokens
@@ -1839,7 +1854,26 @@ mod tests {
         assert_eq!(active.base_url, "http://127.0.0.1:11434/v1");
         assert_eq!(active.api_key, "");
         assert_eq!(active.model, "apple-foundationmodel");
+        assert_eq!(active.chat_completions_path, "/chat/completions");
         assert!(active.is_ready());
+    }
+
+    #[test]
+    fn llm_profile_runtime_config_missing_chat_path_defaults_to_chat_completions() {
+        let profile: LlmProfileRuntimeConfig = serde_json::from_value(serde_json::json!({
+            "id": "openai",
+            "name": "OpenAI",
+            "provider": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "",
+            "model": "gpt-5.4-nano",
+            "max_token_parameter": "max_completion_tokens",
+            "no_reasoning_control": "reasoning_effort",
+            "mlx": {"model": "mlx/Qwen3-0.6B-4bit"}
+        }))
+        .unwrap();
+
+        assert_eq!(profile.chat_completions_path, "/chat/completions");
     }
 
     #[test]

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -19,7 +19,8 @@ use crate::ffi::{
 #[cfg(feature = "mlx")]
 use crate::llm::mlx::MlxLlmProvider;
 use crate::llm::openai_compatible::{
-    build_http_client, OpenAiCompatibleProvider, LLM_HTTP_POOL_IDLE_TIMEOUT,
+    build_http_client, list_models as llm_list_models, OpenAiCompatibleProvider,
+    LLM_HTTP_POOL_IDLE_TIMEOUT,
 };
 use crate::llm::{CorrectionRequest, LlmProvider};
 use crate::session::{Session, SessionState};
@@ -1605,6 +1606,92 @@ pub unsafe extern "C" fn sp_llm_test(
         Err(e) => serde_json::json!({
             "success": false,
             "elapsed_ms": elapsed_ms,
+            "message": format!("{e}"),
+        }),
+    };
+
+    CString::new(json.to_string())
+        .unwrap_or_default()
+        .into_raw()
+}
+
+/// List remote models from OpenAI-compatible `{base_url}/models`.
+///
+/// Returns a heap-allocated JSON string:
+///   `{"success": true,  "models": ["gpt-5.4-mini"], "message": "..."}`
+///   `{"success": false, "models": [],               "message": "..."}`
+///
+/// # Safety
+/// Pointer parameters must be valid null-terminated C strings (or null).
+/// Caller must free the returned pointer with `sp_core_free_string()`.
+#[no_mangle]
+pub unsafe extern "C" fn sp_llm_list_models_json(
+    base_url: *const c_char,
+    api_key: *const c_char,
+) -> *mut c_char {
+    let base_url = unsafe { cstr_to_str(base_url) }
+        .unwrap_or_default()
+        .to_string();
+    let api_key = unsafe { cstr_to_str(api_key) }
+        .unwrap_or_default()
+        .to_string();
+
+    if base_url.trim().is_empty() {
+        return CString::new(
+            serde_json::json!({
+                "success": false,
+                "models": [],
+                "message": "Base URL is required",
+            })
+            .to_string(),
+        )
+        .unwrap_or_default()
+        .into_raw();
+    }
+
+    let cfg = config::load_config().unwrap_or_default();
+    let client = match build_http_client(cfg.llm.timeout_ms) {
+        Ok(c) => c,
+        Err(e) => {
+            return CString::new(
+                serde_json::json!({
+                    "success": false,
+                    "models": [],
+                    "message": format!("Failed to create HTTP client: {e}"),
+                })
+                .to_string(),
+            )
+            .unwrap_or_default()
+            .into_raw();
+        }
+    };
+
+    let rt = match Runtime::new() {
+        Ok(rt) => rt,
+        Err(e) => {
+            return CString::new(
+                serde_json::json!({
+                    "success": false,
+                    "models": [],
+                    "message": format!("Failed to create async runtime: {e}"),
+                })
+                .to_string(),
+            )
+            .unwrap_or_default()
+            .into_raw();
+        }
+    };
+
+    let result = rt.block_on(llm_list_models(client, &base_url, &api_key));
+    let json = match result {
+        Ok(models) => serde_json::json!({
+            "success": true,
+            "models": models,
+            "message": "Models fetched",
+        }),
+        Err(e) => serde_json::json!({
+            "success": false,
+            "models": [],
             "message": format!("{e}"),
         }),
     };

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -767,6 +767,7 @@ pub unsafe extern "C" fn sp_core_rewrite_with_template(
             _ => Box::new(OpenAiCompatibleProvider::new(
                 llm_http_client,
                 active_profile.base_url.clone(),
+                active_profile.chat_completions_path.clone(),
                 active_profile.api_key.clone(),
                 active_profile.model.clone(),
                 llm_config.temperature,
@@ -1100,6 +1101,7 @@ async fn run_session(
             _ => Box::new(OpenAiCompatibleProvider::new(
                 llm_http_client,
                 active_profile.base_url,
+                active_profile.chat_completions_path,
                 active_profile.api_key,
                 active_profile.model,
                 llm_config.temperature,
@@ -1320,6 +1322,7 @@ fn start_llm_warmup_if_needed(
         let llm = OpenAiCompatibleProvider::new(
             llm_http_client,
             warmup_profile.base_url,
+            warmup_profile.chat_completions_path,
             warmup_profile.api_key,
             warmup_profile.model,
             warmup_cfg.temperature,
@@ -1531,6 +1534,7 @@ pub unsafe extern "C" fn sp_llm_test(
         base_url,
         api_key,
         model,
+        chat_completions_path: "/chat/completions".into(),
         max_token_parameter,
         no_reasoning_control: config::LlmNoReasoningControl::ReasoningEffort,
         mlx: Default::default(),
@@ -1757,6 +1761,7 @@ pub unsafe extern "C" fn sp_llm_test_profile_json(profile_json: *const c_char) -
             let llm = OpenAiCompatibleProvider::new(
                 client,
                 profile.base_url,
+                profile.chat_completions_path,
                 profile.api_key,
                 profile.model,
                 cfg.llm.temperature,

--- a/koe-core/src/llm/openai_compatible.rs
+++ b/koe-core/src/llm/openai_compatible.rs
@@ -95,6 +95,62 @@ fn build_chat_completions_url(base_url: &str, chat_completions_path: &str) -> St
     format!("{base}/{path}")
 }
 
+fn build_models_url(base_url: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    format!("{base}/models")
+}
+
+fn parse_model_ids(response: &Value) -> Result<Vec<String>> {
+    let data = response
+        .get("data")
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| KoeError::LlmFailed("missing data array in /models response".into()))?;
+
+    let mut ids = Vec::new();
+    for item in data {
+        let Some(id) = item.get("id").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        let trimmed = id.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !ids.iter().any(|existing| existing == trimmed) {
+            ids.push(trimmed.to_string());
+        }
+    }
+    Ok(ids)
+}
+
+pub async fn list_models(client: Client, base_url: &str, api_key: &str) -> Result<Vec<String>> {
+    let url = build_models_url(base_url);
+    log::debug!("LLM models request to {url}");
+
+    let mut builder = client.get(&url);
+    if !api_key.is_empty() {
+        builder = builder.header("Authorization", format!("Bearer {}", api_key));
+    }
+    let response = builder.send().await.map_err(|e| {
+        if e.is_timeout() {
+            KoeError::LlmTimeout
+        } else {
+            KoeError::LlmFailed(e.to_string())
+        }
+    })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(KoeError::LlmFailed(format!("HTTP {status}: {text}")));
+    }
+
+    let json: Value = response
+        .json()
+        .await
+        .map_err(|e| KoeError::LlmFailed(format!("parse /models response: {e}")))?;
+    parse_model_ids(&json)
+}
+
 pub fn build_http_client(timeout_ms: u64) -> std::result::Result<Client, reqwest::Error> {
     Client::builder()
         .timeout(Duration::from_millis(timeout_ms))
@@ -335,5 +391,37 @@ mod tests {
     fn chat_completion_url_accepts_path_without_leading_slash() {
         let url = build_chat_completions_url("https://api.openai.com/v1", "chat/completions");
         assert_eq!(url, "https://api.openai.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn parse_model_ids_accepts_standard_openai_response() {
+        let json = serde_json::json!({
+            "data": [
+                {"id": "gpt-5.4-mini"},
+                {"id": "gpt-5.4-nano"}
+            ]
+        });
+        let ids = parse_model_ids(&json).unwrap();
+        assert_eq!(ids, vec!["gpt-5.4-mini", "gpt-5.4-nano"]);
+    }
+
+    #[test]
+    fn parse_model_ids_allows_empty_data() {
+        let json = serde_json::json!({
+            "data": []
+        });
+        let ids = parse_model_ids(&json).unwrap();
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn parse_model_ids_rejects_missing_data() {
+        let json = serde_json::json!({
+            "object": "list"
+        });
+        let err = parse_model_ids(&json).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("missing data array in /models response"));
     }
 }

--- a/koe-core/src/llm/openai_compatible.rs
+++ b/koe-core/src/llm/openai_compatible.rs
@@ -12,6 +12,7 @@ pub const LLM_HTTP_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 pub struct OpenAiCompatibleProvider {
     client: Client,
     base_url: String,
+    chat_completions_path: String,
     api_key: String,
     model: String,
     temperature: f64,
@@ -26,6 +27,7 @@ impl OpenAiCompatibleProvider {
     pub fn new(
         client: Client,
         base_url: String,
+        chat_completions_path: String,
         api_key: String,
         model: String,
         temperature: f64,
@@ -37,6 +39,7 @@ impl OpenAiCompatibleProvider {
         Self {
             client,
             base_url,
+            chat_completions_path,
             api_key,
             model,
             temperature,
@@ -80,6 +83,18 @@ impl OpenAiCompatibleProvider {
     }
 }
 
+fn build_chat_completions_url(base_url: &str, chat_completions_path: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    let normalized_path = chat_completions_path.trim();
+    let effective_path = if normalized_path.is_empty() {
+        "/chat/completions"
+    } else {
+        normalized_path
+    };
+    let path = effective_path.trim_start_matches('/');
+    format!("{base}/{path}")
+}
+
 pub fn build_http_client(timeout_ms: u64) -> std::result::Result<Client, reqwest::Error> {
     Client::builder()
         .timeout(Duration::from_millis(timeout_ms))
@@ -106,6 +121,7 @@ pub async fn test_correction(
     let llm = OpenAiCompatibleProvider::new(
         client,
         profile.base_url.clone(),
+        profile.chat_completions_path.clone(),
         profile.api_key.clone(),
         profile.model.clone(),
         temperature,
@@ -174,7 +190,7 @@ pub fn build_chat_completion_body(
 #[async_trait::async_trait]
 impl LlmProvider for OpenAiCompatibleProvider {
     async fn correct(&self, request: &CorrectionRequest) -> Result<String> {
-        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+        let url = build_chat_completions_url(&self.base_url, &self.chat_completions_path);
 
         let profile = LlmProfileRuntimeConfig {
             id: String::new(),
@@ -183,6 +199,7 @@ impl LlmProvider for OpenAiCompatibleProvider {
             base_url: self.base_url.clone(),
             api_key: self.api_key.clone(),
             model: self.model.clone(),
+            chat_completions_path: self.chat_completions_path.clone(),
             max_token_parameter: self.max_token_parameter,
             no_reasoning_control: self.no_reasoning_control,
             mlx: Default::default(),
@@ -270,6 +287,7 @@ mod tests {
             base_url: "http://127.0.0.1:11434/v1".into(),
             api_key: "".into(),
             model: "apple-foundationmodel".into(),
+            chat_completions_path: "/chat/completions".into(),
             max_token_parameter: LlmMaxTokenParameter::MaxTokens,
             no_reasoning_control: LlmNoReasoningControl::None,
             mlx: Default::default(),
@@ -293,6 +311,7 @@ mod tests {
             base_url: "https://api.openai.com/v1".into(),
             api_key: "sk-test".into(),
             model: "gpt-5.4-nano".into(),
+            chat_completions_path: "/chat/completions".into(),
             max_token_parameter: LlmMaxTokenParameter::MaxCompletionTokens,
             no_reasoning_control: LlmNoReasoningControl::ReasoningEffort,
             mlx: Default::default(),
@@ -304,5 +323,17 @@ mod tests {
         assert_eq!(body["max_completion_tokens"], 1024);
         assert_eq!(body["reasoning_effort"], "none");
         assert!(body.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn chat_completion_url_avoids_double_slashes() {
+        let url = build_chat_completions_url("https://api.openai.com/v1/", "/chat/completions");
+        assert_eq!(url, "https://api.openai.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn chat_completion_url_accepts_path_without_leading_slash() {
+        let url = build_chat_completions_url("https://api.openai.com/v1", "chat/completions");
+        assert_eq!(url, "https://api.openai.com/v1/chat/completions");
     }
 }


### PR DESCRIPTION
## Summary
- add editable global llm.timeout_ms field in Setup Wizard LLM pane
- add OpenAI-compatible remote model picker via GET {base_url}/models while keeping manual model input
- add collapsible model picker row and make lower form rows move up/down without blank gap
- add profile name editing field mapped to llm.profiles.<id>.name

## Details
- new core FFI endpoint: sp_llm_list_models_json(base_url, api_key)
- bridge wrapper: llmRemoteModelsForBaseURL:apiKey:
- Setup Wizard now supports:
  - profile rename (name field)
  - timeout numeric input restriction
  - choose/hide model list row with refresh

## Verification
- cargo test -p koe-core llm::openai_compatible::tests -- --nocapture