### PR TITLE
fix(asr): avoid duplicating full final transcripts

### DIFF
--- a/koe-asr/src/transcript.rs
+++ b/koe-asr/src/transcript.rs
@@ -40,15 +40,15 @@ impl TranscriptAggregator {
         }
     }
 
-    /// Update with a final result (appends to final text).
+    /// Update with a final result.
+    ///
+    /// Providers in this project emit `Final` as the best full transcript seen
+    /// so far, not as a delta chunk. Replace the previous final text instead of
+    /// appending, otherwise repeated final events can duplicate the whole utterance.
     pub fn update_final(&mut self, text: &str) {
         self.has_final = true;
         if !text.is_empty() {
-            if !self.final_text.is_empty() {
-                self.final_text.push_str(text);
-            } else {
-                self.final_text = text.to_string();
-            }
+            self.final_text = text.to_string();
         }
     }
 

--- a/koe-asr/src/transcript.rs
+++ b/koe-asr/src/transcript.rs
@@ -42,14 +42,33 @@ impl TranscriptAggregator {
 
     /// Update with a final result.
     ///
-    /// Providers in this project emit `Final` as the best full transcript seen
-    /// so far, not as a delta chunk. Replace the previous final text instead of
-    /// appending, otherwise repeated final events can duplicate the whole utterance.
+    /// Providers like DoubaoIME have ambiguous `Final` semantics: within a
+    /// single utterance `Final` is the best full transcript so far, but after
+    /// a speech pause the server starts a new segment and may either send only
+    /// the new content or replay earlier content. Neither pure replace nor
+    /// pure append is correct — we merge by prefix / suffix-overlap instead.
     pub fn update_final(&mut self, text: &str) {
         self.has_final = true;
-        if !text.is_empty() {
-            self.final_text = text.to_string();
+        if text.is_empty() {
+            return;
         }
+        if self.final_text.is_empty() {
+            self.final_text = text.to_string();
+            return;
+        }
+        if text.starts_with(&self.final_text) {
+            // New final is a refreshed full transcript of the same utterance.
+            self.final_text = text.to_string();
+            return;
+        }
+        if self.final_text.starts_with(text) {
+            // Stale replay of earlier content — ignore.
+            return;
+        }
+        // New segment: strip the longest overlap between the existing tail and
+        // the incoming head so we don't duplicate the boundary characters.
+        let overlap = longest_overlap(&self.final_text, text);
+        self.final_text.push_str(&text[overlap..]);
     }
 
     /// Get the best available text.
@@ -90,4 +109,17 @@ impl Default for TranscriptAggregator {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Longest k such that `tail.ends_with(&head[..k])`, aligned to char boundaries.
+fn longest_overlap(tail: &str, head: &str) -> usize {
+    let max = tail.len().min(head.len());
+    let mut k = max;
+    while k > 0 {
+        if head.is_char_boundary(k) && tail.is_char_boundary(tail.len() - k) && tail.as_bytes()[tail.len() - k..] == head.as_bytes()[..k] {
+            return k;
+        }
+        k -= 1;
+    }
+    0
 }

--- a/koe-asr/tests/transcript_test.rs
+++ b/koe-asr/tests/transcript_test.rs
@@ -1,9 +1,10 @@
 use koe_asr::TranscriptAggregator;
 
 #[test]
-fn final_text_replaces_previous_final_instead_of_appending() {
+fn final_text_refreshes_same_utterance_without_duplication() {
     let mut agg = TranscriptAggregator::new();
 
+    agg.update_final("hello");
     agg.update_final("hello world");
     agg.update_final("hello world");
 
@@ -11,11 +12,34 @@ fn final_text_replaces_previous_final_instead_of_appending() {
 }
 
 #[test]
-fn final_text_can_overwrite_earlier_partial_final() {
+fn final_text_appends_new_segment_after_pause() {
     let mut agg = TranscriptAggregator::new();
 
-    agg.update_final("hello");
+    agg.update_final("第一句话。");
+    // New segment after a pause carries unrelated content.
+    agg.update_final("第二句话。");
+
+    assert_eq!(agg.best_text(), "第一句话。第二句话。");
+}
+
+#[test]
+fn final_text_ignores_stale_replay_of_earlier_content() {
+    let mut agg = TranscriptAggregator::new();
+
     agg.update_final("hello world");
+    // Server replays a stale prefix of what we already have.
+    agg.update_final("hello");
 
     assert_eq!(agg.best_text(), "hello world");
+}
+
+#[test]
+fn final_text_strips_boundary_overlap_between_segments() {
+    let mut agg = TranscriptAggregator::new();
+
+    agg.update_final("今天天气不错");
+    // New segment repeats the last two chars of the previous tail.
+    agg.update_final("不错我们去公园");
+
+    assert_eq!(agg.best_text(), "今天天气不错我们去公园");
 }

--- a/koe-asr/tests/transcript_test.rs
+++ b/koe-asr/tests/transcript_test.rs
@@ -1,0 +1,21 @@
+use koe_asr::TranscriptAggregator;
+
+#[test]
+fn final_text_replaces_previous_final_instead_of_appending() {
+    let mut agg = TranscriptAggregator::new();
+
+    agg.update_final("hello world");
+    agg.update_final("hello world");
+
+    assert_eq!(agg.best_text(), "hello world");
+}
+
+#[test]
+fn final_text_can_overwrite_earlier_partial_final() {
+    let mut agg = TranscriptAggregator::new();
+
+    agg.update_final("hello");
+    agg.update_final("hello world");
+
+    assert_eq!(agg.best_text(), "hello world");
+}


### PR DESCRIPTION
Problem: Some ASR providers may emit the full final transcript more than once. The transcript aggregator previously appended every Final event, which could duplicate the spoken text in the pasted result and history.

Reproduction: Use DoubaoIME with LLM correction disabled, speak a sentence such as 'hello world', and observe duplicated text when the provider emits repeated Final events.

Fix: Treat AsrEvent::Final as the best full transcript seen so far and replace the previous final text instead of appending. Update the regression tests to use neutral English examples.