### PR TITLE
feat: add GLM (Zhipu) ASR provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,7 @@ dependencies = [
  "async-trait",
  "audiopus",
  "base64",
+ "bytes",
  "flate2",
  "futures-util",
  "log",
@@ -1023,6 +1024,22 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1337,6 +1354,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1963,6 +1981,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -638,6 +638,9 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 @property(nonatomic, strong) NSSecureTextField *asrQwenApiKeySecureField;
 @property(nonatomic, strong) NSTextField *asrQwenApiKeyField;
 @property(nonatomic, strong) NSButton *asrQwenApiKeyToggle;
+@property(nonatomic, strong) NSSecureTextField *asrGlmApiKeySecureField;
+@property(nonatomic, strong) NSTextField *asrGlmApiKeyField;
+@property(nonatomic, strong) NSButton *asrGlmApiKeyToggle;
 @property(nonatomic, strong) NSButton *asrTestButton;
 @property(nonatomic, strong) NSTextField *asrTestResultLabel;
 // Doubao auth mode + new console API key
@@ -992,6 +995,8 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   [self.asrProviderPopup lastItem].representedObject = @"doubao";
   [self.asrProviderPopup addItemWithTitle:@"Qwen (Alibaba Cloud)"];
   [self.asrProviderPopup lastItem].representedObject = @"qwen";
+  [self.asrProviderPopup addItemWithTitle:@"GLM (Zhipu)"];
+  [self.asrProviderPopup lastItem].representedObject = @"glm";
   NSArray<NSString *> *supportedLocalProviders =
       [self.rustBridge supportedLocalProviders];
   // Add Apple Speech (macOS 26+, no model download required; also requires the
@@ -1226,6 +1231,31 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   qwenKeyLabel.tag = 1003;
   qwenKeyLabel.hidden = YES;
   [pane addSubview:qwenKeyLabel];
+
+  // GLM API Key — fixed at row 1 (same position as Qwen, toggled by provider)
+  CGFloat glmY = formStartY - rowH - rowH;
+  self.asrGlmApiKeySecureField = [[NSSecureTextField alloc]
+      initWithFrame:NSMakeRect(fieldX, glmY, secFieldW, 22)];
+  self.asrGlmApiKeySecureField.placeholderString =
+      @"API Key from bigmodel.cn";
+  self.asrGlmApiKeySecureField.font = [NSFont systemFontOfSize:13];
+  self.asrGlmApiKeySecureField.hidden = YES;
+  [pane addSubview:self.asrGlmApiKeySecureField];
+  self.asrGlmApiKeyField =
+      [self formTextField:NSMakeRect(fieldX, glmY, secFieldW, 22)
+              placeholder:@"API Key from bigmodel.cn"];
+  self.asrGlmApiKeyField.hidden = YES;
+  [pane addSubview:self.asrGlmApiKeyField];
+  self.asrGlmApiKeyToggle = [self
+      eyeButtonWithFrame:NSMakeRect(fieldX + secFieldW + 4, glmY - 1, eyeW, 24)
+                  action:@selector(toggleGlmApiKeyVisibility:)];
+  self.asrGlmApiKeyToggle.hidden = YES;
+  [pane addSubview:self.asrGlmApiKeyToggle];
+  NSTextField *glmKeyLabel =
+      [self formLabel:@"API Key" frame:NSMakeRect(16, glmY, labelW, 22)];
+  glmKeyLabel.tag = 1010;
+  glmKeyLabel.hidden = YES;
+  [pane addSubview:glmKeyLabel];
 
   // Test result label — positioned right after credential rows, before
   // language.
@@ -3769,6 +3799,28 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   }
 }
 
+- (void)toggleGlmApiKeyVisibility:(NSButton *)sender {
+  if (sender.tag == 0) {
+    // Show plain text
+    self.asrGlmApiKeyField.stringValue =
+        self.asrGlmApiKeySecureField.stringValue;
+    self.asrGlmApiKeySecureField.hidden = YES;
+    self.asrGlmApiKeyField.hidden = NO;
+    sender.image = [NSImage imageWithSystemSymbolName:@"eye"
+                             accessibilityDescription:@"Hide"];
+    sender.tag = 1;
+  } else {
+    // Show secure
+    self.asrGlmApiKeySecureField.stringValue =
+        self.asrGlmApiKeyField.stringValue;
+    self.asrGlmApiKeyField.hidden = YES;
+    self.asrGlmApiKeySecureField.hidden = NO;
+    sender.image = [NSImage imageWithSystemSymbolName:@"eye.slash"
+                             accessibilityDescription:@"Show"];
+    sender.tag = 0;
+  }
+}
+
 - (void)toggleAsrApiKeyVisibility:(NSButton *)sender {
   if (sender.tag == 0) {
     self.asrApiKeyField.stringValue = self.asrApiKeySecureField.stringValue;
@@ -3827,6 +3879,9 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   if ([provider isEqualToString:@"qwen"]) {
     return 340.0;
   }
+  if ([provider isEqualToString:@"glm"]) {
+    return 340.0;
+  }
   if ([provider isEqualToString:@"apple-speech"]) {
     return 280.0;
   }
@@ -3869,9 +3924,10 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   BOOL isDoubaoIme = [selectedProvider isEqualToString:@"doubaoime"];
   BOOL isDoubao = [selectedProvider isEqualToString:@"doubao"];
   BOOL isQwen = [selectedProvider isEqualToString:@"qwen"];
+  BOOL isGlm = [selectedProvider isEqualToString:@"glm"];
   BOOL isAppleSpeech = [selectedProvider isEqualToString:@"apple-speech"];
   BOOL isModelBasedLocal =
-      !isDoubaoIme && !isDoubao && !isQwen && !isAppleSpeech;
+      !isDoubaoIme && !isDoubao && !isQwen && !isGlm && !isAppleSpeech;
 
   // Show/hide Doubao auth mode control and credential fields
   [self setHidden:!isDoubao
@@ -3939,6 +3995,14 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   self.asrQwenApiKeySecureField.hidden = !isQwen;
   self.asrQwenApiKeyToggle.hidden = !isQwen;
 
+  // Show/hide GLM fields
+  [self setHidden:!isGlm
+      forViewsMatchingTags:[NSIndexSet indexSetWithIndex:1010]
+                    inView:self.currentPaneView];
+  self.asrGlmApiKeyField.hidden = YES; // Always start hidden (secure mode)
+  self.asrGlmApiKeySecureField.hidden = !isGlm;
+  self.asrGlmApiKeyToggle.hidden = !isGlm;
+
   // Show/hide Apple Speech locale popup and asset status
   self.appleSpeechLocalePopup.hidden = !isAppleSpeech;
   [self setHidden:!isAppleSpeech
@@ -3978,7 +4042,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   }
 
   // Hide test button for local providers (no remote connection to test)
-  BOOL isLocal = !isDoubaoIme && !isDoubao && !isQwen;
+  BOOL isLocal = !isDoubaoIme && !isDoubao && !isQwen && !isGlm;
   self.asrTestButton.hidden = isLocal;
   self.asrTestResultLabel.hidden = isLocal;
 
@@ -4840,6 +4904,10 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType,
     NSString *qwenApiKey = configGet(@"asr.qwen.api_key");
     self.asrQwenApiKeySecureField.stringValue = qwenApiKey;
     self.asrQwenApiKeyField.stringValue = qwenApiKey;
+    // Load GLM fields
+    NSString *glmApiKey = configGet(@"asr.glm.api_key");
+    self.asrGlmApiKeySecureField.stringValue = glmApiKey;
+    self.asrGlmApiKeyField.stringValue = glmApiKey;
     // Reset visibility based on selected provider
     [self asrProviderChanged:self.asrProviderPopup];
     // Select saved Apple Speech locale (always, so switching to apple-speech
@@ -5037,6 +5105,7 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType,
     BOOL isModelBasedLocal = ![provider isEqualToString:@"doubaoime"] &&
                              ![provider isEqualToString:@"doubao"] &&
                              ![provider isEqualToString:@"qwen"] &&
+                             ![provider isEqualToString:@"glm"] &&
                              ![provider isEqualToString:@"apple-speech"];
     if (isModelBasedLocal) {
       NSString *modelPath = self.localModelPopup.selectedItem.representedObject;
@@ -5156,6 +5225,11 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType,
                                ? self.asrQwenApiKeyField.stringValue
                                : self.asrQwenApiKeySecureField.stringValue;
     saveOk &= configSet(@"asr.qwen.api_key", qwenApiKey);
+    // Save GLM fields
+    NSString *glmApiKey = self.asrGlmApiKeyToggle.tag == 1
+                              ? self.asrGlmApiKeyField.stringValue
+                              : self.asrGlmApiKeySecureField.stringValue;
+    saveOk &= configSet(@"asr.glm.api_key", glmApiKey);
     // Save Apple Speech locale
     if ([selectedProvider isEqualToString:@"apple-speech"]) {
       NSString *locale =
@@ -5867,6 +5941,8 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType,
     [self testDoubaoConnection];
   } else if ([provider isEqualToString:@"qwen"]) {
     [self testQwenConnection];
+  } else if ([provider isEqualToString:@"glm"]) {
+    [self testGlmConnection];
   }
 }
 
@@ -6209,6 +6285,126 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType,
         } else if ([errorMsg containsString:@"bad response"] ||
                    [errorMsg containsString:@"Bad response"]) {
           // HTTP error during WebSocket handshake
+          strongSelf.asrTestResultLabel.stringValue =
+              @"Auth failed: please check your API Key";
+        } else if ([errorMsg containsString:@"unable"] ||
+                   [errorMsg containsString:@"Unable"] ||
+                   [errorMsg containsString:@"Cannot connect"]) {
+          strongSelf.asrTestResultLabel.stringValue =
+              @"Network error: please check your network settings";
+        } else {
+          strongSelf.asrTestResultLabel.stringValue =
+              @"Connection failed: please check your configuration";
+        }
+        strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
+        return;
+      }
+
+      if (message) {
+        strongSelf.asrTestResultLabel.stringValue = @"Connected";
+        strongSelf.asrTestResultLabel.textColor = [NSColor systemGreenColor];
+      } else {
+        strongSelf.asrTestResultLabel.stringValue =
+            @"Connection failed: no response from server";
+        strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
+      }
+    });
+  }];
+
+  [wsTask resume];
+
+  // Timeout handler
+  dispatch_after(
+      dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)),
+      dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf || strongSelf.asrTestButton.enabled)
+          return;
+
+        [wsTask cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure
+                             reason:nil];
+        strongSelf.asrTestButton.enabled = YES;
+        strongSelf.asrTestResultLabel.stringValue =
+            @"Connection timed out: please check your network";
+        strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
+      });
+}
+
+- (void)testGlmConnection {
+  // Get current key value (account for plain/secure toggle state)
+  NSString *apiKey = self.asrGlmApiKeyToggle.tag == 1
+                         ? self.asrGlmApiKeyField.stringValue
+                         : self.asrGlmApiKeySecureField.stringValue;
+
+  if (apiKey.length == 0) {
+    self.asrTestResultLabel.stringValue = @"Please fill in API Key first";
+    self.asrTestResultLabel.textColor = [NSColor systemOrangeColor];
+    return;
+  }
+
+  self.asrTestButton.enabled = NO;
+  self.asrTestResultLabel.stringValue = @"Testing...";
+  self.asrTestResultLabel.textColor = [NSColor secondaryLabelColor];
+
+  // GLM Realtime uses WebSocket, test by connecting to the WS endpoint
+  NSString *glmUrl = configGet(@"asr.glm.url");
+  if (glmUrl.length == 0)
+    glmUrl = @"wss://open.bigmodel.cn/api/paas/v4/realtime";
+  NSString *glmModel = configGet(@"asr.glm.model");
+  if (glmModel.length == 0)
+    glmModel = @"glm-realtime";
+
+  NSURL *url = [NSURL URLWithString:glmUrl];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+  request.timeoutInterval = 10;
+  [request setValue:[NSString stringWithFormat:@"Bearer %@", apiKey]
+      forHTTPHeaderField:@"Authorization"];
+
+  NSURLSessionConfiguration *config2 =
+      [NSURLSessionConfiguration defaultSessionConfiguration];
+  config2.timeoutIntervalForRequest = 10;
+  NSURLSession *session = [NSURLSession sessionWithConfiguration:config2];
+  NSURLSessionWebSocketTask *wsTask =
+      [session webSocketTaskWithRequest:request];
+
+  __weak typeof(self) weakSelf = self;
+  __weak NSURLSessionWebSocketTask *weakWsTask = wsTask;
+
+  // GLM Realtime returns a session.created message on connect
+  [wsTask receiveMessageWithCompletionHandler:^(
+              NSURLSessionWebSocketMessage *_Nullable message,
+              NSError *_Nullable error) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      if (!strongSelf)
+        return;
+
+      [weakWsTask
+          cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure
+                       reason:nil];
+
+      strongSelf.asrTestButton.enabled = YES;
+
+      if (error) {
+        NSString *errorMsg = error.localizedDescription;
+        NSInteger statusCode = 0;
+
+        if (error.userInfo[@"_kCFStreamErrorDomainKey"]) {
+          NSNumber *code = error.userInfo[@"_kCFStreamErrorDomainKey"];
+          if (code)
+            statusCode = code.integerValue;
+        }
+
+        if ([errorMsg containsString:@"401"] ||
+            [errorMsg containsString:@"403"] || statusCode == 401) {
+          strongSelf.asrTestResultLabel.stringValue =
+              @"Auth failed: please check your API Key";
+        } else if ([errorMsg containsString:@"time"] ||
+                   error.code == NSURLErrorTimedOut) {
+          strongSelf.asrTestResultLabel.stringValue =
+              @"Connection timed out: please check your network";
+        } else if ([errorMsg containsString:@"bad response"] ||
+                   [errorMsg containsString:@"Bad response"]) {
           strongSelf.asrTestResultLabel.stringValue =
               @"Auth failed: please check your API Key";
         } else if ([errorMsg containsString:@"unable"] ||

--- a/koe-asr/Cargo.toml
+++ b/koe-asr/Cargo.toml
@@ -18,10 +18,11 @@ flate2.workspace = true
 futures-util.workspace = true
 log.workspace = true
 md-5.workspace = true
-reqwest = { workspace = true, default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true, default-features = false, features = ["json", "multipart", "rustls-tls", "stream"] }
 rustls = { workspace = true, default-features = false, features = ["ring"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+bytes = "1"
 sherpa-onnx = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
 tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }

--- a/koe-asr/src/glm.rs
+++ b/koe-asr/src/glm.rs
@@ -1,0 +1,379 @@
+use crate::config::AsrConfig;
+use crate::error::{AsrError, Result};
+use crate::event::AsrEvent;
+use crate::provider::AsrProvider;
+use futures_util::StreamExt;
+use reqwest::Client;
+use std::collections::VecDeque;
+
+const DEFAULT_URL: &str = "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions";
+const DEFAULT_MODEL: &str = "glm-asr-1";
+
+/// GLM (Zhipu) ASR Provider.
+///
+/// Uses HTTP POST + SSE streaming (same approach as Voxt):
+/// 1. Buffer audio during `send_audio()`
+/// 2. Upload complete WAV file on `finish_input()`
+/// 3. Parse SSE streaming response for intermediate/final results
+pub struct GlmAsrProvider {
+    client: Option<Client>,
+    url: String,
+    api_key: String,
+    model: String,
+    prompt: Option<String>,
+    audio_buffer: Vec<u8>,
+    pending_events: VecDeque<AsrEvent>,
+    response_stream: Option<Pin<Box<dyn Stream<Item = std::result::Result<Bytes, reqwest::Error>> + Send>>>,
+    finished: bool,
+    connected: bool,
+}
+
+use bytes::Bytes;
+use futures_util::Stream;
+use std::pin::Pin;
+
+impl GlmAsrProvider {
+    pub fn new() -> Self {
+        Self {
+            client: None,
+            url: String::new(),
+            api_key: String::new(),
+            model: String::new(),
+            prompt: None,
+            audio_buffer: Vec::new(),
+            pending_events: VecDeque::new(),
+            response_stream: None,
+            finished: false,
+            connected: false,
+        }
+    }
+}
+
+impl Default for GlmAsrProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wrap raw PCM data (16-bit mono 16kHz) in a WAV container.
+fn wrap_wav(pcm: &[u8]) -> Vec<u8> {
+    let data_len = pcm.len() as u32;
+    let sample_rate: u32 = 16000;
+    let num_channels: u16 = 1;
+    let bits_per_sample: u16 = 16;
+    let byte_rate = sample_rate * num_channels as u32 * bits_per_sample as u32 / 8;
+    let block_align = num_channels * bits_per_sample / 8;
+    let total_size = 36 + data_len;
+
+    let mut wav = Vec::with_capacity(44 + pcm.len());
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&total_size.to_le_bytes());
+    wav.extend_from_slice(b"WAVE");
+    wav.extend_from_slice(b"fmt ");
+    wav.extend_from_slice(&16u32.to_le_bytes());
+    wav.extend_from_slice(&1u16.to_le_bytes());
+    wav.extend_from_slice(&num_channels.to_le_bytes());
+    wav.extend_from_slice(&sample_rate.to_le_bytes());
+    wav.extend_from_slice(&byte_rate.to_le_bytes());
+    wav.extend_from_slice(&block_align.to_le_bytes());
+    wav.extend_from_slice(&bits_per_sample.to_le_bytes());
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&data_len.to_le_bytes());
+    wav.extend_from_slice(pcm);
+    wav
+}
+
+/// Extract text from a JSON value, searching common fields.
+fn extract_text_from_json(json: &serde_json::Value) -> Option<String> {
+    // Try preferred keys
+    for key in &["text", "delta", "transcript", "result_text", "content", "utterance"] {
+        if let Some(val) = json.get(key).and_then(|v| v.as_str()) {
+            if !val.is_empty() {
+                return Some(val.to_string());
+            }
+        }
+    }
+    // Try nested in "results" array
+    if let Some(results) = json.get("results").and_then(|r| r.as_array()) {
+        if let Some(first) = results.first() {
+            if let Some(text) = first.get("text").and_then(|v| v.as_str()) {
+                if !text.is_empty() {
+                    return Some(text.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Parse a single SSE line and return an AsrEvent if applicable.
+fn parse_sse_line(line: &str) -> Option<AsrEvent> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Extract data after "data:" prefix
+    let data = if let Some(rest) = trimmed.strip_prefix("data:") {
+        rest.trim()
+    } else {
+        trimmed
+    };
+
+    // Stream end marker
+    if data == "[DONE]" {
+        return None; // Will be handled by caller
+    }
+
+    // Try JSON parse
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+        if let Some(text) = extract_text_from_json(&json) {
+            return Some(AsrEvent::Interim(text));
+        }
+        // Check for error
+        if let Some(error) = json.get("error") {
+            let msg = error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error");
+            return Some(AsrEvent::Error(msg.to_string()));
+        }
+    }
+
+    None
+}
+
+#[async_trait::async_trait]
+impl AsrProvider for GlmAsrProvider {
+    async fn connect(&mut self, config: &AsrConfig) -> Result<()> {
+        if config.access_key.is_empty() && config.api_key.is_empty() {
+            return Err(AsrError::Connection("API key is required".into()));
+        }
+
+        self.api_key = if !config.api_key.is_empty() {
+            config.api_key.clone()
+        } else {
+            config.access_key.clone()
+        };
+
+        self.url = if config.url.is_empty() {
+            DEFAULT_URL.to_string()
+        } else {
+            config.url.clone()
+        };
+
+        self.model = if config.app_key.is_empty() {
+            DEFAULT_MODEL.to_string()
+        } else {
+            config.app_key.clone()
+        };
+
+        self.prompt = config.language.clone(); // Reuse language field for prompt
+
+        self.client = Some(
+            Client::builder()
+                .timeout(std::time::Duration::from_secs(120))
+                .build()
+                .map_err(|e| AsrError::Connection(format!("failed to create HTTP client: {e}")))?,
+        );
+
+        self.connected = true;
+        log::info!("[GLM ASR] Configured: url={}, model={}", self.url, self.model);
+
+        // HTTP approach has no persistent connection, emit Connected immediately
+        self.pending_events.push_back(AsrEvent::Connected);
+
+        Ok(())
+    }
+
+    async fn send_audio(&mut self, frame: &[u8]) -> Result<()> {
+        if !self.connected {
+            return Err(AsrError::Connection("not connected".into()));
+        }
+        self.audio_buffer.extend_from_slice(frame);
+        log::debug!("[GLM ASR] Buffered audio: {} bytes (total: {})", frame.len(), self.audio_buffer.len());
+        Ok(())
+    }
+
+    async fn finish_input(&mut self) -> Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+        self.finished = true;
+
+        if self.audio_buffer.is_empty() {
+            log::warn!("[GLM ASR] No audio data to send");
+            self.pending_events.push_back(AsrEvent::Final(String::new()));
+            return Ok(());
+        }
+
+        let client = self
+            .client
+            .as_ref()
+            .ok_or_else(|| AsrError::Connection("not connected".into()))?;
+
+        // Build WAV from buffered PCM
+        let wav_data = wrap_wav(&self.audio_buffer);
+        log::info!("[GLM ASR] Uploading audio: {} bytes PCM → {} bytes WAV", self.audio_buffer.len(), wav_data.len());
+
+        // Build multipart form
+        let model_part = reqwest::multipart::Part::text(self.model.clone())
+            .mime_str("text/plain")
+            .map_err(|e| AsrError::Protocol(format!("model part: {e}")))?;
+
+        let file_part = reqwest::multipart::Part::bytes(wav_data)
+            .file_name("audio.wav")
+            .mime_str("audio/wav")
+            .map_err(|e| AsrError::Protocol(format!("file part: {e}")))?;
+
+        let stream_part = reqwest::multipart::Part::text("true".to_string())
+            .mime_str("text/plain")
+            .map_err(|e| AsrError::Protocol(format!("stream part: {e}")))?;
+
+        let mut form = reqwest::multipart::Form::new()
+            .part("model", model_part)
+            .part("file", file_part)
+            .part("stream", stream_part);
+
+        log::info!("[GLM ASR] Request: url={}, model={}", self.url, self.model);
+
+        if let Some(ref prompt) = self.prompt {
+            if !prompt.is_empty() {
+                let prompt_part = reqwest::multipart::Part::text(prompt.clone())
+                    .mime_str("text/plain")
+                    .map_err(|e| AsrError::Protocol(format!("prompt part: {e}")))?;
+                form = form.part("prompt", prompt_part);
+            }
+        }
+
+        let response = client
+            .post(&self.url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Accept", "text/event-stream, application/json, text/plain")
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| AsrError::Connection(format!("HTTP request failed: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "failed to read response body".into());
+            return Err(AsrError::Protocol(format!("HTTP {status}: {body}")));
+        }
+
+        log::info!("[GLM ASR] HTTP response: {}, streaming SSE...", status);
+
+        // Store response stream for next_event()
+        self.response_stream = Some(Box::pin(response.bytes_stream()));
+        self.pending_events.push_back(AsrEvent::Connected);
+
+        Ok(())
+    }
+
+    async fn next_event(&mut self) -> Result<AsrEvent> {
+        if let Some(event) = self.pending_events.pop_front() {
+            return Ok(event);
+        }
+
+        // If not finished yet, wait for audio to complete
+        // The native code may call next_event() while audio is still being captured
+        if !self.finished {
+            // Block until finish_input() is called and stream is ready
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                if self.finished {
+                    break;
+                }
+                if self.pending_events.front().is_some() {
+                    return Ok(self.pending_events.pop_front().unwrap());
+                }
+            }
+        }
+
+        let stream = match self.response_stream.as_mut() {
+            Some(s) => s,
+            None => {
+                return Ok(AsrEvent::Closed(None));
+            }
+        };
+
+        let mut line_buffer = String::new();
+        let mut last_text = String::new();
+
+        loop {
+            match stream.next().await {
+                Some(Ok(chunk)) => {
+                    let text = String::from_utf8_lossy(&chunk);
+                    line_buffer.push_str(&text);
+
+                    // Process complete lines
+                    while let Some(newline_pos) = line_buffer.find('\n') {
+                        let line = line_buffer[..newline_pos].to_string();
+                        line_buffer = line_buffer[newline_pos + 1..].to_string();
+
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+
+                        // Extract data portion
+                        let data = if let Some(rest) = trimmed.strip_prefix("data:") {
+                            rest.trim()
+                        } else {
+                            trimmed
+                        };
+
+                        // Stream end marker
+                        if data == "[DONE]" {
+                            if !last_text.is_empty() {
+                                log::info!("[GLM ASR] Final: {}", last_text);
+                                return Ok(AsrEvent::Final(last_text));
+                            }
+                            return Ok(AsrEvent::Closed(None));
+                        }
+
+                        // Parse JSON for text delta
+                        if let Some(event) = parse_sse_line(&line) {
+                            match &event {
+                                AsrEvent::Interim(text) => {
+                                    if text != &last_text {
+                                        log::debug!("[GLM ASR] Interim: {}", text);
+                                        last_text = text.clone();
+                                        return Ok(event);
+                                    }
+                                }
+                                AsrEvent::Error(_) => {
+                                    return Ok(event);
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                Some(Err(e)) => {
+                    return Err(AsrError::Protocol(format!("stream error: {e}")));
+                }
+                None => {
+                    // Stream ended
+                    if !last_text.is_empty() {
+                        log::info!("[GLM ASR] Final: {}", last_text);
+                        return Ok(AsrEvent::Final(last_text));
+                    }
+                    return Ok(AsrEvent::Closed(None));
+                }
+            }
+        }
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.client = None;
+        self.response_stream = None;
+        self.audio_buffer.clear();
+        self.pending_events.clear();
+        self.connected = false;
+        Ok(())
+    }
+}

--- a/koe-asr/src/lib.rs
+++ b/koe-asr/src/lib.rs
@@ -45,6 +45,7 @@ pub mod doubao;
 pub mod doubaoime;
 pub mod error;
 pub mod event;
+pub mod glm;
 #[cfg(feature = "mlx")]
 pub mod mlx;
 pub mod provider;
@@ -60,6 +61,7 @@ pub use doubao::DoubaoWsProvider;
 pub use doubaoime::DoubaoImeProvider;
 pub use error::AsrError;
 pub use event::AsrEvent;
+pub use glm::GlmAsrProvider;
 #[cfg(feature = "mlx")]
 pub use mlx::{MlxConfig, MlxProvider};
 pub use provider::AsrProvider;

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -44,7 +44,7 @@ pub struct PromptTemplate {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct AsrSection {
-    /// Which ASR provider to use: "doubaoime" (default), "doubao", "qwen", "mlx", "sherpa-onnx", "apple-speech"
+    /// Which ASR provider to use: "doubaoime" (default), "doubao", "qwen", "glm", "mlx", "sherpa-onnx", "apple-speech"
     #[serde(default = "default_asr_provider")]
     pub provider: String,
 
@@ -71,6 +71,10 @@ pub struct AsrSection {
     /// Apple Speech local ASR configuration (macOS 26+)
     #[serde(rename = "apple-speech", default)]
     pub apple_speech: AppleSpeechAsrConfig,
+
+    /// GLM (Zhipu) ASR configuration
+    #[serde(default)]
+    pub glm: GlmAsrConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -245,6 +249,36 @@ impl Default for AppleSpeechAsrConfig {
 
 fn default_apple_speech_locale() -> String {
     "zh_CN".to_string()
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct GlmAsrConfig {
+    #[serde(default = "default_glm_url")]
+    pub url: String,
+    #[serde(default)]
+    pub api_key: String,
+    #[serde(default = "default_glm_model")]
+    pub model: String,
+    /// ASR hint / prompt for guiding recognition
+    #[serde(default)]
+    pub prompt: Option<String>,
+    #[serde(default = "default_connect_timeout")]
+    pub connect_timeout_ms: u64,
+    #[serde(default = "default_final_wait_timeout")]
+    pub final_wait_timeout_ms: u64,
+}
+
+impl Default for GlmAsrConfig {
+    fn default() -> Self {
+        Self {
+            url: default_glm_url(),
+            api_key: String::new(),
+            model: default_glm_model(),
+            prompt: None,
+            connect_timeout_ms: default_connect_timeout(),
+            final_wait_timeout_ms: default_final_wait_timeout(),
+        }
+    }
 }
 
 // ─── Other Sections (unchanged) ─────────────────────────────────────
@@ -739,6 +773,12 @@ fn default_sherpa_onnx_hotwords_score() -> f32 {
 }
 fn default_sherpa_onnx_endpoint_silence() -> f32 {
     1.2
+}
+fn default_glm_url() -> String {
+    "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions".into()
+}
+fn default_glm_model() -> String {
+    "glm-asr-2512".into()
 }
 fn deserialize_option_u32_lenient<'de, D>(deserializer: D) -> std::result::Result<Option<u32>, D::Error>
 where
@@ -1560,7 +1600,7 @@ const DEFAULT_CONFIG_YAML: &str = r#"# Koe - Voice Input Tool Configuration
 # ~/.koe/config.yaml
 
 asr:
-  # ASR provider: "doubaoime" (default, free), "doubao", "qwen", "apple-speech", "mlx", "sherpa-onnx"
+  # ASR provider: "doubaoime" (default, free), "doubao", "qwen", "glm", "apple-speech", "mlx", "sherpa-onnx"
   provider: "doubaoime"
 
   # DoubaoIME (豆包输入法) free ASR — no API key required, auto device registration
@@ -1602,6 +1642,12 @@ asr:
     final_wait_timeout_ms: 5000
     # headers:           # custom HTTP headers for WebSocket connection
     #   X-Custom-Header: "value"
+
+  # GLM (Zhipu/智谱) ASR — HTTP POST + SSE streaming
+  glm:
+    url: "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions"
+    api_key: ""          # 从 https://bigmodel.cn/usercenter/proj-mgmt/apikeys 获取
+    model: "glm-asr-2512"  # glm-asr-2512 | glm-asr-1
 
   # Apple Speech local ASR (macOS 26+, zero-config, no model download)
   apple-speech:

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -27,8 +27,8 @@ use crate::session::{Session, SessionState};
 #[cfg(feature = "apple-speech")]
 use koe_asr::{AppleSpeechConfig, AppleSpeechProvider};
 use koe_asr::{
-    AsrConfig, AsrEvent, AsrProvider, DoubaoImeProvider, DoubaoWsProvider, QwenAsrProvider,
-    TranscriptAggregator,
+    AsrConfig, AsrEvent, AsrProvider, DoubaoImeProvider, DoubaoWsProvider, GlmAsrProvider,
+    QwenAsrProvider, TranscriptAggregator,
 };
 #[cfg(feature = "mlx")]
 use koe_asr::{MlxConfig, MlxProvider};
@@ -408,6 +408,34 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
                 context_messages: Vec::new(),
             };
             (config, Box::new(QwenAsrProvider::new()))
+        }
+        "glm" => {
+            let glm = &cfg.asr.glm;
+            let config = AsrConfig {
+                url: glm.url.clone(),
+                app_key: glm.model.clone(),
+                access_key: glm.api_key.clone(),
+                api_key: glm.api_key.clone(),
+                resource_id: String::new(),
+                sample_rate_hz: 16000,
+                connect_timeout_ms: glm.connect_timeout_ms,
+                final_wait_timeout_ms: glm.final_wait_timeout_ms,
+                enable_ddc: false,
+                enable_itn: false,
+                enable_punc: false,
+                enable_nonstream: false,
+                hotwords: Vec::new(),
+                language: glm.prompt.clone(),
+                custom_headers: std::collections::HashMap::new(),
+                end_window_size: None,
+                force_to_speech_time: None,
+                vad_segment_duration: None,
+                output_zh_variant: None,
+                enable_accelerate_text: false,
+                accelerate_score: None,
+                context_messages: Vec::new(),
+            };
+            (config, Box::new(GlmAsrProvider::new()))
         }
         #[cfg(feature = "mlx")]
         "mlx" => {


### PR DESCRIPTION
Add support for Zhipu GLM ASR as a new cloud ASR provider.

- Implement GlmAsrProvider using HTTP POST + SSE streaming
- Default model: glm-asr-2512
- Endpoint: https://open.bigmodel.cn/api/paas/v4/audio/transcriptions
- Support real-time text display via SSE delta events
- Add GLM to setup wizard with API Key field and Test button
- Update DEFAULT_CONFIG_YAML with GLM configuration

Based on Voxt's GLM ASR implementation pattern.