### PR TITLE
feat(asr): add MiMo (Xiaomi) ASR provider

### DIFF
--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -1286,6 +1286,20 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   mimoKeyLabel.tag = 1011;
   mimoKeyLabel.hidden = YES;
   [pane addSubview:mimoKeyLabel];
+  // Privacy notice — audio is sent to Xiaomi's servers, not ours.
+  NSTextField *mimoPrivacyNotice = [NSTextField wrappingLabelWithString:
+      @"By selecting a Xiaomi (MiMo) model, you voluntarily consent to "
+      @"Xiaomi collecting your personal information and voice data. Koe "
+      @"collects nothing and runs no servers. For any questions, please "
+      @"contact the Xiaomi team."];
+  // Sits one row below the API key field, clear of the test result label.
+  mimoPrivacyNotice.frame =
+      NSMakeRect(fieldX, mimoY - rowH * 2 - 50, paneWidth - fieldX - 32, 44);
+  mimoPrivacyNotice.font = [NSFont systemFontOfSize:11];
+  mimoPrivacyNotice.textColor = [NSColor systemOrangeColor];
+  mimoPrivacyNotice.tag = 1011;
+  mimoPrivacyNotice.hidden = YES;
+  [pane addSubview:mimoPrivacyNotice];
 
   // Test result label — positioned right after credential rows, before
   // language.
@@ -3935,7 +3949,8 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
     return 340.0;
   }
   if ([provider isEqualToString:@"mimo"]) {
-    return 340.0;
+    // Taller than GLM to fit the privacy notice under the API key row.
+    return 360.0;
   }
   if ([provider isEqualToString:@"apple-speech"]) {
     return 280.0;

--- a/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
+++ b/KoeApp/Koe/SetupWizard/SPSetupWizardWindowController.m
@@ -641,6 +641,9 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
 @property(nonatomic, strong) NSSecureTextField *asrGlmApiKeySecureField;
 @property(nonatomic, strong) NSTextField *asrGlmApiKeyField;
 @property(nonatomic, strong) NSButton *asrGlmApiKeyToggle;
+@property(nonatomic, strong) NSSecureTextField *asrMimoApiKeySecureField;
+@property(nonatomic, strong) NSTextField *asrMimoApiKeyField;
+@property(nonatomic, strong) NSButton *asrMimoApiKeyToggle;
 @property(nonatomic, strong) NSButton *asrTestButton;
 @property(nonatomic, strong) NSTextField *asrTestResultLabel;
 // Doubao auth mode + new console API key
@@ -997,6 +1000,8 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   [self.asrProviderPopup lastItem].representedObject = @"qwen";
   [self.asrProviderPopup addItemWithTitle:@"GLM (Zhipu)"];
   [self.asrProviderPopup lastItem].representedObject = @"glm";
+  [self.asrProviderPopup addItemWithTitle:@"MiMo (Xiaomi)"];
+  [self.asrProviderPopup lastItem].representedObject = @"mimo";
   NSArray<NSString *> *supportedLocalProviders =
       [self.rustBridge supportedLocalProviders];
   // Add Apple Speech (macOS 26+, no model download required; also requires the
@@ -1256,6 +1261,31 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   glmKeyLabel.tag = 1010;
   glmKeyLabel.hidden = YES;
   [pane addSubview:glmKeyLabel];
+
+  // MiMo API Key — fixed at row 1 (same position as Qwen/GLM, toggled by provider)
+  CGFloat mimoY = formStartY - rowH - rowH;
+  self.asrMimoApiKeySecureField = [[NSSecureTextField alloc]
+      initWithFrame:NSMakeRect(fieldX, mimoY, secFieldW, 22)];
+  self.asrMimoApiKeySecureField.placeholderString =
+      @"API Key from xiaomimimo.com";
+  self.asrMimoApiKeySecureField.font = [NSFont systemFontOfSize:13];
+  self.asrMimoApiKeySecureField.hidden = YES;
+  [pane addSubview:self.asrMimoApiKeySecureField];
+  self.asrMimoApiKeyField =
+      [self formTextField:NSMakeRect(fieldX, mimoY, secFieldW, 22)
+              placeholder:@"API Key from xiaomimimo.com"];
+  self.asrMimoApiKeyField.hidden = YES;
+  [pane addSubview:self.asrMimoApiKeyField];
+  self.asrMimoApiKeyToggle = [self
+      eyeButtonWithFrame:NSMakeRect(fieldX + secFieldW + 4, mimoY - 1, eyeW, 24)
+                  action:@selector(toggleMimoApiKeyVisibility:)];
+  self.asrMimoApiKeyToggle.hidden = YES;
+  [pane addSubview:self.asrMimoApiKeyToggle];
+  NSTextField *mimoKeyLabel =
+      [self formLabel:@"API Key" frame:NSMakeRect(16, mimoY, labelW, 22)];
+  mimoKeyLabel.tag = 1011;
+  mimoKeyLabel.hidden = YES;
+  [pane addSubview:mimoKeyLabel];
 
   // Test result label — positioned right after credential rows, before
   // language.
@@ -3821,6 +3851,28 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   }
 }
 
+- (void)toggleMimoApiKeyVisibility:(NSButton *)sender {
+  if (sender.tag == 0) {
+    // Show plain text
+    self.asrMimoApiKeyField.stringValue =
+        self.asrMimoApiKeySecureField.stringValue;
+    self.asrMimoApiKeySecureField.hidden = YES;
+    self.asrMimoApiKeyField.hidden = NO;
+    sender.image = [NSImage imageWithSystemSymbolName:@"eye"
+                             accessibilityDescription:@"Hide"];
+    sender.tag = 1;
+  } else {
+    // Show secure
+    self.asrMimoApiKeySecureField.stringValue =
+        self.asrMimoApiKeyField.stringValue;
+    self.asrMimoApiKeyField.hidden = YES;
+    self.asrMimoApiKeySecureField.hidden = NO;
+    sender.image = [NSImage imageWithSystemSymbolName:@"eye.slash"
+                             accessibilityDescription:@"Show"];
+    sender.tag = 0;
+  }
+}
+
 - (void)toggleAsrApiKeyVisibility:(NSButton *)sender {
   if (sender.tag == 0) {
     self.asrApiKeyField.stringValue = self.asrApiKeySecureField.stringValue;
@@ -3882,6 +3934,9 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   if ([provider isEqualToString:@"glm"]) {
     return 340.0;
   }
+  if ([provider isEqualToString:@"mimo"]) {
+    return 340.0;
+  }
   if ([provider isEqualToString:@"apple-speech"]) {
     return 280.0;
   }
@@ -3925,9 +3980,10 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   BOOL isDoubao = [selectedProvider isEqualToString:@"doubao"];
   BOOL isQwen = [selectedProvider isEqualToString:@"qwen"];
   BOOL isGlm = [selectedProvider isEqualToString:@"glm"];
+  BOOL isMimo = [selectedProvider isEqualToString:@"mimo"];
   BOOL isAppleSpeech = [selectedProvider isEqualToString:@"apple-speech"];
   BOOL isModelBasedLocal =
-      !isDoubaoIme && !isDoubao && !isQwen && !isGlm && !isAppleSpeech;
+      !isDoubaoIme && !isDoubao && !isQwen && !isGlm && !isMimo && !isAppleSpeech;
 
   // Show/hide Doubao auth mode control and credential fields
   [self setHidden:!isDoubao
@@ -4003,6 +4059,14 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   self.asrGlmApiKeySecureField.hidden = !isGlm;
   self.asrGlmApiKeyToggle.hidden = !isGlm;
 
+  // Show/hide MiMo fields
+  [self setHidden:!isMimo
+      forViewsMatchingTags:[NSIndexSet indexSetWithIndex:1011]
+                    inView:self.currentPaneView];
+  self.asrMimoApiKeyField.hidden = YES; // Always start hidden (secure mode)
+  self.asrMimoApiKeySecureField.hidden = !isMimo;
+  self.asrMimoApiKeyToggle.hidden = !isMimo;
+
   // Show/hide Apple Speech locale popup and asset status
   self.appleSpeechLocalePopup.hidden = !isAppleSpeech;
   [self setHidden:!isAppleSpeech
@@ -4042,7 +4106,7 @@ static void ensureCustomHotkeyInPopup(NSPopUpButton *popup, NSString *value) {
   }
 
   // Hide test button for local providers (no remote connection to test)
-  BOOL isLocal = !isDoubaoIme && !isDoubao && !isQwen && !isGlm;
+  BOOL isLocal = !isDoubaoIme && !isDoubao && !isQwen && !isGlm && !isMimo;
   self.asrTestButton.hidden = isLocal;
   self.asrTestResultLabel.hidden = isLocal;
 
@@ -4908,6 +4972,10 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType,
     NSString *glmApiKey = configGet(@"asr.glm.api_key");
     self.asrGlmApiKeySecureField.stringValue = glmApiKey;
     self.asrGlmApiKeyField.stringValue = glmApiKey;
+    // Load MiMo fields
+    NSString *mimoApiKey = configGet(@"asr.mimo.api_key");
+    self.asrMimoApiKeySecureField.stringValue = mimoApiKey;
+    self.asrMimoApiKeyField.stringValue = mimoApiKey;
     // Reset visibility based on selected provider
     [self asrProviderChanged:self.asrProviderPopup];
     // Select saved Apple Speech locale (always, so switching to apple-speech
@@ -5230,6 +5298,11 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType,
                               ? self.asrGlmApiKeyField.stringValue
                               : self.asrGlmApiKeySecureField.stringValue;
     saveOk &= configSet(@"asr.glm.api_key", glmApiKey);
+    // Save MiMo fields
+    NSString *mimoApiKey = self.asrMimoApiKeyToggle.tag == 1
+                               ? self.asrMimoApiKeyField.stringValue
+                               : self.asrMimoApiKeySecureField.stringValue;
+    saveOk &= configSet(@"asr.mimo.api_key", mimoApiKey);
     // Save Apple Speech locale
     if ([selectedProvider isEqualToString:@"apple-speech"]) {
       NSString *locale =
@@ -5943,6 +6016,8 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType,
     [self testQwenConnection];
   } else if ([provider isEqualToString:@"glm"]) {
     [self testGlmConnection];
+  } else if ([provider isEqualToString:@"mimo"]) {
+    [self testMimoConnection];
   }
 }
 
@@ -6448,6 +6523,100 @@ static void appleSpeechInstallCallback(void *ctx, int32_t eventType,
             @"Connection timed out: please check your network";
         strongSelf.asrTestResultLabel.textColor = [NSColor systemRedColor];
       });
+}
+
+- (void)testMimoConnection {
+  NSString *apiKey = self.asrMimoApiKeyToggle.tag == 1
+                         ? self.asrMimoApiKeyField.stringValue
+                         : self.asrMimoApiKeySecureField.stringValue;
+
+  if (apiKey.length == 0) {
+    self.asrTestResultLabel.stringValue = @"Please fill in API Key first";
+    self.asrTestResultLabel.textColor = [NSColor systemOrangeColor];
+    return;
+  }
+
+  self.asrTestButton.enabled = NO;
+  self.asrTestResultLabel.stringValue = @"Testing...";
+  self.asrTestResultLabel.textColor = [NSColor secondaryLabelColor];
+
+  // MiMo uses HTTP POST — send a minimal request to verify API key
+  NSString *mimoUrl = configGet(@"asr.mimo.url");
+  if (mimoUrl.length == 0)
+    mimoUrl = @"https://api.xiaomimimo.com/v1/chat/completions";
+
+  NSURL *url = [NSURL URLWithString:mimoUrl];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+  request.HTTPMethod = @"POST";
+  request.timeoutInterval = 10;
+  [request setValue:apiKey forHTTPHeaderField:@"api-key"];
+  [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+
+  // Minimal body — just model + empty message to test auth
+  NSDictionary *body = @{
+    @"model" : @"mimo-v2.5-asr",
+    @"messages" : @[
+      @{@"role" : @"user", @"content" : @"test"}
+    ]
+  };
+  request.HTTPBody =
+      [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
+
+  __weak typeof(self) weakSelf = self;
+  NSURLSessionDataTask *task =
+      [[NSURLSession sharedSession]
+          dataTaskWithRequest:request
+            completionHandler:^(NSData *data, NSURLResponse *response,
+                                NSError *error) {
+              dispatch_async(dispatch_get_main_queue(), ^{
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                if (!strongSelf)
+                  return;
+                strongSelf.asrTestButton.enabled = YES;
+
+                if (error) {
+                  NSString *errorMsg = error.localizedDescription;
+                  if (error.code == NSURLErrorTimedOut) {
+                    strongSelf.asrTestResultLabel.stringValue =
+                        @"Connection timed out: please check your network";
+                  } else if ([errorMsg containsString:@"Cannot connect"] ||
+                             [errorMsg containsString:@"unable"]) {
+                    strongSelf.asrTestResultLabel.stringValue =
+                        @"Network error: please check your network settings";
+                  } else {
+                    strongSelf.asrTestResultLabel.stringValue =
+                        [NSString stringWithFormat:@"Error: %@", errorMsg];
+                  }
+                  strongSelf.asrTestResultLabel.textColor =
+                      [NSColor systemRedColor];
+                  return;
+                }
+
+                NSHTTPURLResponse *httpResponse =
+                    (NSHTTPURLResponse *)response;
+                if (httpResponse.statusCode == 200 ||
+                    httpResponse.statusCode == 400) {
+                  // 400 = bad request (expected with minimal body), but auth
+                  // worked
+                  strongSelf.asrTestResultLabel.stringValue = @"Connected";
+                  strongSelf.asrTestResultLabel.textColor =
+                      [NSColor systemGreenColor];
+                } else if (httpResponse.statusCode == 401 ||
+                           httpResponse.statusCode == 403) {
+                  strongSelf.asrTestResultLabel.stringValue =
+                      @"Auth failed: please check your API Key";
+                  strongSelf.asrTestResultLabel.textColor =
+                      [NSColor systemRedColor];
+                } else {
+                  strongSelf.asrTestResultLabel.stringValue =
+                      [NSString stringWithFormat:@"HTTP %ld: unexpected response",
+                                                 (long)httpResponse.statusCode];
+                  strongSelf.asrTestResultLabel.textColor =
+                      [NSColor systemOrangeColor];
+                }
+              });
+            }];
+  [task resume];
 }
 
 - (void)showAlert:(NSString *)message info:(NSString *)info {

--- a/koe-asr/src/doubaoime.rs
+++ b/koe-asr/src/doubaoime.rs
@@ -877,7 +877,8 @@ impl AsrProvider for DoubaoImeProvider {
         log::info!("[DoubaoIME] TaskStarted");
 
         // StartSession
-        let session_config = build_session_config(&self.device_id, self.asr_config.as_ref().unwrap());
+        let session_config =
+            build_session_config(&self.device_id, self.asr_config.as_ref().unwrap());
         let start_session = proto::encode_asr_request(
             &self.token,
             "ASR",

--- a/koe-asr/src/glm.rs
+++ b/koe-asr/src/glm.rs
@@ -23,7 +23,8 @@ pub struct GlmAsrProvider {
     prompt: Option<String>,
     audio_buffer: Vec<u8>,
     pending_events: VecDeque<AsrEvent>,
-    response_stream: Option<Pin<Box<dyn Stream<Item = std::result::Result<Bytes, reqwest::Error>> + Send>>>,
+    response_stream:
+        Option<Pin<Box<dyn Stream<Item = std::result::Result<Bytes, reqwest::Error>> + Send>>>,
     finished: bool,
     connected: bool,
 }
@@ -86,7 +87,14 @@ fn wrap_wav(pcm: &[u8]) -> Vec<u8> {
 /// Extract text from a JSON value, searching common fields.
 fn extract_text_from_json(json: &serde_json::Value) -> Option<String> {
     // Try preferred keys
-    for key in &["text", "delta", "transcript", "result_text", "content", "utterance"] {
+    for key in &[
+        "text",
+        "delta",
+        "transcript",
+        "result_text",
+        "content",
+        "utterance",
+    ] {
         if let Some(val) = json.get(key).and_then(|v| v.as_str()) {
             if !val.is_empty() {
                 return Some(val.to_string());
@@ -178,7 +186,11 @@ impl AsrProvider for GlmAsrProvider {
         );
 
         self.connected = true;
-        log::info!("[GLM ASR] Configured: url={}, model={}", self.url, self.model);
+        log::info!(
+            "[GLM ASR] Configured: url={}, model={}",
+            self.url,
+            self.model
+        );
 
         // HTTP approach has no persistent connection, emit Connected immediately
         self.pending_events.push_back(AsrEvent::Connected);
@@ -191,7 +203,11 @@ impl AsrProvider for GlmAsrProvider {
             return Err(AsrError::Connection("not connected".into()));
         }
         self.audio_buffer.extend_from_slice(frame);
-        log::debug!("[GLM ASR] Buffered audio: {} bytes (total: {})", frame.len(), self.audio_buffer.len());
+        log::debug!(
+            "[GLM ASR] Buffered audio: {} bytes (total: {})",
+            frame.len(),
+            self.audio_buffer.len()
+        );
         Ok(())
     }
 
@@ -203,7 +219,8 @@ impl AsrProvider for GlmAsrProvider {
 
         if self.audio_buffer.is_empty() {
             log::warn!("[GLM ASR] No audio data to send");
-            self.pending_events.push_back(AsrEvent::Final(String::new()));
+            self.pending_events
+                .push_back(AsrEvent::Final(String::new()));
             return Ok(());
         }
 
@@ -214,7 +231,11 @@ impl AsrProvider for GlmAsrProvider {
 
         // Build WAV from buffered PCM
         let wav_data = wrap_wav(&self.audio_buffer);
-        log::info!("[GLM ASR] Uploading audio: {} bytes PCM → {} bytes WAV", self.audio_buffer.len(), wav_data.len());
+        log::info!(
+            "[GLM ASR] Uploading audio: {} bytes PCM → {} bytes WAV",
+            self.audio_buffer.len(),
+            wav_data.len()
+        );
 
         // Build multipart form
         let model_part = reqwest::multipart::Part::text(self.model.clone())

--- a/koe-asr/src/lib.rs
+++ b/koe-asr/src/lib.rs
@@ -46,6 +46,7 @@ pub mod doubaoime;
 pub mod error;
 pub mod event;
 pub mod glm;
+pub mod mimo;
 #[cfg(feature = "mlx")]
 pub mod mlx;
 pub mod provider;
@@ -62,6 +63,7 @@ pub use doubaoime::DoubaoImeProvider;
 pub use error::AsrError;
 pub use event::AsrEvent;
 pub use glm::GlmAsrProvider;
+pub use mimo::MimoAsrProvider;
 #[cfg(feature = "mlx")]
 pub use mlx::{MlxConfig, MlxProvider};
 pub use provider::AsrProvider;

--- a/koe-asr/src/mimo.rs
+++ b/koe-asr/src/mimo.rs
@@ -1,0 +1,644 @@
+use crate::config::AsrConfig;
+use crate::error::{AsrError, Result};
+use crate::event::AsrEvent;
+use crate::provider::AsrProvider;
+use base64::Engine;
+use bytes::Bytes;
+use futures_util::Stream;
+use futures_util::StreamExt;
+use reqwest::Client;
+use std::collections::VecDeque;
+use std::pin::Pin;
+
+const DEFAULT_URL: &str = "https://api.xiaomimimo.com/v1/chat/completions";
+const DEFAULT_MODEL: &str = "mimo-v2.5-asr";
+
+/// MiMo (Xiaomi) ASR Provider.
+///
+/// Uses OpenAI-compatible HTTP POST + SSE streaming:
+/// 1. Buffer audio during `send_audio()`
+/// 2. Encode as base64 WAV data URI on `finish_input()`
+/// 3. POST to chat completions endpoint with audio in message content
+/// 4. Parse SSE streaming response for intermediate/final results
+pub struct MimoAsrProvider {
+    client: Option<Client>,
+    url: String,
+    api_key: String,
+    model: String,
+    language: String,
+    audio_buffer: Vec<u8>,
+    pending_events: VecDeque<AsrEvent>,
+    response_stream:
+        Option<Pin<Box<dyn Stream<Item = std::result::Result<Bytes, reqwest::Error>> + Send>>>,
+    finished: bool,
+    connected: bool,
+}
+
+impl MimoAsrProvider {
+    pub fn new() -> Self {
+        Self {
+            client: None,
+            url: String::new(),
+            api_key: String::new(),
+            model: String::new(),
+            language: "auto".to_string(),
+            audio_buffer: Vec::new(),
+            pending_events: VecDeque::new(),
+            response_stream: None,
+            finished: false,
+            connected: false,
+        }
+    }
+}
+
+impl Default for MimoAsrProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wrap raw PCM data (16-bit mono 16kHz) in a WAV container.
+fn wrap_wav(pcm: &[u8]) -> Vec<u8> {
+    let data_len = pcm.len() as u32;
+    let sample_rate: u32 = 16000;
+    let num_channels: u16 = 1;
+    let bits_per_sample: u16 = 16;
+    let byte_rate = sample_rate * num_channels as u32 * bits_per_sample as u32 / 8;
+    let block_align = num_channels * bits_per_sample / 8;
+    let total_size = 36 + data_len;
+
+    let mut wav = Vec::with_capacity(44 + pcm.len());
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&total_size.to_le_bytes());
+    wav.extend_from_slice(b"WAVE");
+    wav.extend_from_slice(b"fmt ");
+    wav.extend_from_slice(&16u32.to_le_bytes());
+    wav.extend_from_slice(&1u16.to_le_bytes());
+    wav.extend_from_slice(&num_channels.to_le_bytes());
+    wav.extend_from_slice(&sample_rate.to_le_bytes());
+    wav.extend_from_slice(&byte_rate.to_le_bytes());
+    wav.extend_from_slice(&block_align.to_le_bytes());
+    wav.extend_from_slice(&bits_per_sample.to_le_bytes());
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&data_len.to_le_bytes());
+    wav.extend_from_slice(pcm);
+    wav
+}
+
+/// Build the OpenAI-compatible JSON request body for MiMo ASR.
+fn build_request_body(wav_base64: &str, model: &str, language: &str) -> serde_json::Value {
+    serde_json::json!({
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_audio",
+                        "input_audio": {
+                            "data": format!("data:audio/wav;base64,{wav_base64}")
+                        }
+                    }
+                ]
+            }
+        ],
+        "asr_options": {
+            "language": language
+        }
+    })
+}
+
+/// Extract transcription text from MiMo API response JSON.
+fn extract_text_from_response(json: &serde_json::Value) -> Option<String> {
+    json.get("choices")?
+        .as_array()?
+        .first()?
+        .get("message")?
+        .get("content")?
+        .as_str()
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Parse a single SSE line from MiMo streaming response.
+fn parse_sse_line(line: &str) -> Option<AsrEvent> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let data = if let Some(rest) = trimmed.strip_prefix("data:") {
+        rest.trim()
+    } else {
+        trimmed
+    };
+
+    if data == "[DONE]" {
+        return None;
+    }
+
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+        // Check for error
+        if let Some(error) = json.get("error") {
+            let msg = error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error");
+            return Some(AsrEvent::Error(msg.to_string()));
+        }
+
+        // Extract text from choices[0].delta.content (streaming) or choices[0].message.content
+        let text = json
+            .get("choices")
+            .and_then(|c| c.as_array())
+            .and_then(|a| a.first())
+            .and_then(|c| {
+                // Streaming: delta.content
+                c.get("delta")
+                    .and_then(|d| d.get("content"))
+                    .and_then(|v| v.as_str())
+                    // Non-streaming: message.content
+                    .or_else(|| {
+                        c.get("message")
+                            .and_then(|m| m.get("content"))
+                            .and_then(|v| v.as_str())
+                    })
+            });
+
+        if let Some(text) = text {
+            if !text.is_empty() {
+                return Some(AsrEvent::Interim(text.to_string()));
+            }
+        }
+    }
+
+    None
+}
+
+#[async_trait::async_trait]
+impl AsrProvider for MimoAsrProvider {
+    async fn connect(&mut self, config: &AsrConfig) -> Result<()> {
+        if config.api_key.is_empty() && config.access_key.is_empty() {
+            return Err(AsrError::Connection("API key is required".into()));
+        }
+
+        self.api_key = if !config.api_key.is_empty() {
+            config.api_key.clone()
+        } else {
+            config.access_key.clone()
+        };
+
+        self.url = if config.url.is_empty() {
+            DEFAULT_URL.to_string()
+        } else {
+            config.url.clone()
+        };
+
+        self.model = if config.app_key.is_empty() {
+            DEFAULT_MODEL.to_string()
+        } else {
+            config.app_key.clone()
+        };
+
+        self.language = config
+            .language
+            .clone()
+            .unwrap_or_else(|| "auto".to_string());
+
+        self.client = Some(
+            Client::builder()
+                .timeout(std::time::Duration::from_secs(120))
+                .build()
+                .map_err(|e| AsrError::Connection(format!("failed to create HTTP client: {e}")))?,
+        );
+
+        self.connected = true;
+        log::info!(
+            "[MiMo ASR] Configured: url={}, model={}",
+            self.url,
+            self.model
+        );
+
+        self.pending_events.push_back(AsrEvent::Connected);
+        Ok(())
+    }
+
+    async fn send_audio(&mut self, frame: &[u8]) -> Result<()> {
+        if !self.connected {
+            return Err(AsrError::Connection("not connected".into()));
+        }
+        self.audio_buffer.extend_from_slice(frame);
+        log::debug!(
+            "[MiMo ASR] Buffered audio: {} bytes (total: {})",
+            frame.len(),
+            self.audio_buffer.len()
+        );
+        Ok(())
+    }
+
+    async fn finish_input(&mut self) -> Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+        self.finished = true;
+
+        if self.audio_buffer.is_empty() {
+            log::warn!("[MiMo ASR] No audio data to send");
+            self.pending_events
+                .push_back(AsrEvent::Final(String::new()));
+            return Ok(());
+        }
+
+        let client = self
+            .client
+            .as_ref()
+            .ok_or_else(|| AsrError::Connection("not connected".into()))?;
+
+        // Build WAV from buffered PCM and encode as base64 data URI
+        let wav_data = wrap_wav(&self.audio_buffer);
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&wav_data);
+        log::info!(
+            "[MiMo ASR] Uploading audio: {} bytes PCM → {} bytes WAV (base64: {} chars)",
+            self.audio_buffer.len(),
+            wav_data.len(),
+            b64.len()
+        );
+
+        let body = build_request_body(&b64, &self.model, &self.language);
+
+        log::info!(
+            "[MiMo ASR] Request: url={}, model={}, language={}",
+            self.url,
+            self.model,
+            self.language
+        );
+
+        let response = client
+            .post(&self.url)
+            .header("api-key", &self.api_key)
+            .header("Content-Type", "application/json")
+            .header("Accept", "text/event-stream, application/json, text/plain")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| AsrError::Connection(format!("HTTP request failed: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "failed to read response body".into());
+            return Err(AsrError::Protocol(format!("HTTP {status}: {body}")));
+        }
+
+        log::info!("[MiMo ASR] HTTP response: {}, streaming SSE...", status);
+
+        self.response_stream = Some(Box::pin(response.bytes_stream()));
+        self.pending_events.push_back(AsrEvent::Connected);
+
+        Ok(())
+    }
+
+    async fn next_event(&mut self) -> Result<AsrEvent> {
+        if let Some(event) = self.pending_events.pop_front() {
+            return Ok(event);
+        }
+
+        if !self.finished {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                if self.finished {
+                    break;
+                }
+                if self.pending_events.front().is_some() {
+                    return Ok(self.pending_events.pop_front().unwrap());
+                }
+            }
+        }
+
+        let stream = match self.response_stream.as_mut() {
+            Some(s) => s,
+            None => {
+                return Ok(AsrEvent::Closed(None));
+            }
+        };
+
+        let mut line_buffer = String::new();
+        let mut last_text = String::new();
+
+        loop {
+            match stream.next().await {
+                Some(Ok(chunk)) => {
+                    let text = String::from_utf8_lossy(&chunk);
+                    line_buffer.push_str(&text);
+
+                    while let Some(newline_pos) = line_buffer.find('\n') {
+                        let line = line_buffer[..newline_pos].to_string();
+                        line_buffer = line_buffer[newline_pos + 1..].to_string();
+
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+
+                        let data = if let Some(rest) = trimmed.strip_prefix("data:") {
+                            rest.trim()
+                        } else {
+                            trimmed
+                        };
+
+                        if data == "[DONE]" {
+                            if !last_text.is_empty() {
+                                log::info!("[MiMo ASR] Final: {}", last_text);
+                                return Ok(AsrEvent::Final(last_text));
+                            }
+                            return Ok(AsrEvent::Closed(None));
+                        }
+
+                        if let Some(event) = parse_sse_line(&line) {
+                            match &event {
+                                AsrEvent::Interim(text) => {
+                                    if text != &last_text {
+                                        log::debug!("[MiMo ASR] Interim: {}", text);
+                                        last_text = text.clone();
+                                        return Ok(event);
+                                    }
+                                }
+                                AsrEvent::Error(_) => {
+                                    return Ok(event);
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                Some(Err(e)) => {
+                    return Err(AsrError::Protocol(format!("stream error: {e}")));
+                }
+                None => {
+                    if !last_text.is_empty() {
+                        log::info!("[MiMo ASR] Final: {}", last_text);
+                        return Ok(AsrEvent::Final(last_text));
+                    }
+                    return Ok(AsrEvent::Closed(None));
+                }
+            }
+        }
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.client = None;
+        self.response_stream = None;
+        self.audio_buffer.clear();
+        self.pending_events.clear();
+        self.connected = false;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mimo_provider_creation() {
+        let provider = MimoAsrProvider::new();
+        assert!(provider.api_key.is_empty());
+        assert!(provider.url.is_empty());
+        assert!(provider.model.is_empty());
+        assert_eq!(provider.language, "auto");
+        assert!(!provider.connected);
+        assert!(!provider.finished);
+    }
+
+    #[test]
+    fn wrap_wav_produces_valid_header() {
+        let pcm = vec![0u8; 100];
+        let wav = wrap_wav(&pcm);
+
+        // RIFF header
+        assert_eq!(&wav[0..4], b"RIFF");
+        // WAVE format
+        assert_eq!(&wav[8..12], b"WAVE");
+        // fmt chunk
+        assert_eq!(&wav[12..16], b"fmt ");
+        // data chunk
+        assert_eq!(&wav[36..40], b"data");
+
+        // data size = 100
+        let data_size = u32::from_le_bytes([wav[40], wav[41], wav[42], wav[43]]);
+        assert_eq!(data_size, 100);
+
+        // total file size = 36 + 100 = 136
+        let file_size = u32::from_le_bytes([wav[4], wav[5], wav[6], wav[7]]);
+        assert_eq!(file_size, 136);
+
+        // sample rate = 16000
+        let sample_rate = u32::from_le_bytes([wav[24], wav[25], wav[26], wav[27]]);
+        assert_eq!(sample_rate, 16000);
+
+        // PCM data preserved
+        assert_eq!(&wav[44..144], &[0u8; 100]);
+    }
+
+    #[test]
+    fn build_request_body_structure() {
+        let body = build_request_body("AAAA", "mimo-v2.5-asr", "auto");
+
+        assert_eq!(body["model"], "mimo-v2.5-asr");
+        assert_eq!(body["asr_options"]["language"], "auto");
+
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "user");
+
+        let content = messages[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "input_audio");
+        assert_eq!(
+            content[0]["input_audio"]["data"],
+            "data:audio/wav;base64,AAAA"
+        );
+    }
+
+    #[test]
+    fn extract_text_from_response_finds_content() {
+        let json = serde_json::json!({
+            "id": "test-id",
+            "choices": [{
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {
+                    "content": "Hello world",
+                    "role": "assistant"
+                }
+            }]
+        });
+        assert_eq!(
+            extract_text_from_response(&json),
+            Some("Hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_text_from_response_empty_content() {
+        let json = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "",
+                    "role": "assistant"
+                }
+            }]
+        });
+        assert_eq!(extract_text_from_response(&json), None);
+    }
+
+    #[test]
+    fn extract_text_from_response_missing_choices() {
+        let json = serde_json::json!({"id": "test"});
+        assert_eq!(extract_text_from_response(&json), None);
+    }
+
+    #[test]
+    fn parse_sse_line_streaming_delta() {
+        let line = r#"data: {"choices":[{"delta":{"content":"你好"}}]}"#;
+        let event = parse_sse_line(line);
+        assert!(matches!(event, Some(AsrEvent::Interim(ref t)) if t == "你好"));
+    }
+
+    #[test]
+    fn parse_sse_line_non_streaming_message() {
+        let line = r#"data: {"choices":[{"message":{"content":"完整文本"}}]}"#;
+        let event = parse_sse_line(line);
+        assert!(matches!(event, Some(AsrEvent::Interim(ref t)) if t == "完整文本"));
+    }
+
+    #[test]
+    fn parse_sse_line_done_marker() {
+        let event = parse_sse_line("data: [DONE]");
+        assert!(event.is_none());
+    }
+
+    #[test]
+    fn parse_sse_line_empty() {
+        assert!(parse_sse_line("").is_none());
+        assert!(parse_sse_line("   ").is_none());
+    }
+
+    #[test]
+    fn parse_sse_line_error() {
+        let line = r#"data: {"error":{"message":"Invalid API key"}}"#;
+        let event = parse_sse_line(line);
+        assert!(matches!(event, Some(AsrEvent::Error(ref m)) if m == "Invalid API key"));
+    }
+
+    #[test]
+    fn parse_sse_line_no_data_prefix() {
+        let line = r#"{"choices":[{"delta":{"content":"test"}}]}"#;
+        let event = parse_sse_line(line);
+        assert!(matches!(event, Some(AsrEvent::Interim(ref t)) if t == "test"));
+    }
+
+    #[tokio::test]
+    async fn mimo_connect_requires_api_key() {
+        let config = AsrConfig::default();
+        let mut provider = MimoAsrProvider::new();
+        let result = provider.connect(&config).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn mimo_connect_succeeds_with_key() {
+        let config = AsrConfig {
+            api_key: "test-key".to_string(),
+            url: String::new(),
+            ..Default::default()
+        };
+        let mut provider = MimoAsrProvider::new();
+        let result = provider.connect(&config).await;
+        assert!(result.is_ok());
+        assert!(provider.connected);
+        assert_eq!(provider.api_key, "test-key");
+        assert_eq!(provider.url, DEFAULT_URL);
+        assert_eq!(provider.model, DEFAULT_MODEL);
+    }
+
+    #[tokio::test]
+    async fn mimo_connect_uses_custom_url_and_model() {
+        let config = AsrConfig {
+            api_key: "key".to_string(),
+            url: "https://custom.api.com/v1/chat/completions".to_string(),
+            app_key: "custom-model".to_string(),
+            language: Some("zh-CN".to_string()),
+            ..Default::default()
+        };
+        let mut provider = MimoAsrProvider::new();
+        provider.connect(&config).await.unwrap();
+        assert_eq!(provider.url, "https://custom.api.com/v1/chat/completions");
+        assert_eq!(provider.model, "custom-model");
+        assert_eq!(provider.language, "zh-CN");
+    }
+
+    #[tokio::test]
+    async fn mimo_send_audio_before_connect_fails() {
+        let mut provider = MimoAsrProvider::new();
+        let result = provider.send_audio(&[0u8; 100]).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn mimo_send_audio_buffers_data() {
+        let config = AsrConfig {
+            api_key: "key".to_string(),
+            ..Default::default()
+        };
+        let mut provider = MimoAsrProvider::new();
+        provider.connect(&config).await.unwrap();
+
+        provider.send_audio(&[1u8; 100]).await.unwrap();
+        provider.send_audio(&[2u8; 50]).await.unwrap();
+
+        assert_eq!(provider.audio_buffer.len(), 150);
+        assert_eq!(&provider.audio_buffer[..100], &[1u8; 100]);
+        assert_eq!(&provider.audio_buffer[100..], &[2u8; 50]);
+    }
+
+    #[tokio::test]
+    async fn mimo_finish_input_empty_audio_emits_final() {
+        let config = AsrConfig {
+            api_key: "key".to_string(),
+            ..Default::default()
+        };
+        let mut provider = MimoAsrProvider::new();
+        provider.connect(&config).await.unwrap();
+
+        // Drain the Connected event from connect()
+        let connected = provider.next_event().await.unwrap();
+        assert!(matches!(connected, AsrEvent::Connected));
+
+        provider.finish_input().await.unwrap();
+        assert!(provider.finished);
+
+        let event = provider.next_event().await.unwrap();
+        assert!(matches!(event, AsrEvent::Final(ref t) if t.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn mimo_close_resets_state() {
+        let config = AsrConfig {
+            api_key: "key".to_string(),
+            ..Default::default()
+        };
+        let mut provider = MimoAsrProvider::new();
+        provider.connect(&config).await.unwrap();
+        provider.send_audio(&[0u8; 100]).await.unwrap();
+
+        provider.close().await.unwrap();
+
+        assert!(!provider.connected);
+        assert!(provider.client.is_none());
+        assert!(provider.audio_buffer.is_empty());
+        assert!(provider.pending_events.is_empty());
+    }
+}

--- a/koe-core/src/config.rs
+++ b/koe-core/src/config.rs
@@ -44,7 +44,7 @@ pub struct PromptTemplate {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct AsrSection {
-    /// Which ASR provider to use: "doubaoime" (default), "doubao", "qwen", "glm", "mlx", "sherpa-onnx", "apple-speech"
+    /// Which ASR provider to use: "doubaoime" (default), "doubao", "qwen", "glm", "mimo", "mlx", "sherpa-onnx", "apple-speech"
     #[serde(default = "default_asr_provider")]
     pub provider: String,
 
@@ -75,6 +75,10 @@ pub struct AsrSection {
     /// GLM (Zhipu) ASR configuration
     #[serde(default)]
     pub glm: GlmAsrConfig,
+
+    /// MiMo (Xiaomi) ASR configuration
+    #[serde(default)]
+    pub mimo: MimoAsrConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -275,6 +279,36 @@ impl Default for GlmAsrConfig {
             api_key: String::new(),
             model: default_glm_model(),
             prompt: None,
+            connect_timeout_ms: default_connect_timeout(),
+            final_wait_timeout_ms: default_final_wait_timeout(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct MimoAsrConfig {
+    #[serde(default = "default_mimo_url")]
+    pub url: String,
+    #[serde(default)]
+    pub api_key: String,
+    #[serde(default = "default_mimo_model")]
+    pub model: String,
+    /// Language code: "auto" (default), "zh-CN", "en-US", etc.
+    #[serde(default = "default_mimo_language")]
+    pub language: String,
+    #[serde(default = "default_connect_timeout")]
+    pub connect_timeout_ms: u64,
+    #[serde(default = "default_final_wait_timeout")]
+    pub final_wait_timeout_ms: u64,
+}
+
+impl Default for MimoAsrConfig {
+    fn default() -> Self {
+        Self {
+            url: default_mimo_url(),
+            api_key: String::new(),
+            model: default_mimo_model(),
+            language: default_mimo_language(),
             connect_timeout_ms: default_connect_timeout(),
             final_wait_timeout_ms: default_final_wait_timeout(),
         }
@@ -780,7 +814,18 @@ fn default_glm_url() -> String {
 fn default_glm_model() -> String {
     "glm-asr-2512".into()
 }
-fn deserialize_option_u32_lenient<'de, D>(deserializer: D) -> std::result::Result<Option<u32>, D::Error>
+fn default_mimo_url() -> String {
+    "https://api.xiaomimimo.com/v1/chat/completions".into()
+}
+fn default_mimo_model() -> String {
+    "mimo-v2.5-asr".into()
+}
+fn default_mimo_language() -> String {
+    "auto".into()
+}
+fn deserialize_option_u32_lenient<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<u32>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -799,7 +844,9 @@ where
     }
 }
 
-fn deserialize_option_string_lenient<'de, D>(deserializer: D) -> std::result::Result<Option<String>, D::Error>
+fn deserialize_option_string_lenient<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -1600,7 +1647,7 @@ const DEFAULT_CONFIG_YAML: &str = r#"# Koe - Voice Input Tool Configuration
 # ~/.koe/config.yaml
 
 asr:
-  # ASR provider: "doubaoime" (default, free), "doubao", "qwen", "glm", "apple-speech", "mlx", "sherpa-onnx"
+  # ASR provider: "doubaoime" (default, free), "doubao", "qwen", "glm", "mimo", "apple-speech", "mlx", "sherpa-onnx"
   provider: "doubaoime"
 
   # DoubaoIME (豆包输入法) free ASR — no API key required, auto device registration
@@ -1648,6 +1695,13 @@ asr:
     url: "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions"
     api_key: ""          # 从 https://bigmodel.cn/usercenter/proj-mgmt/apikeys 获取
     model: "glm-asr-2512"  # glm-asr-2512 | glm-asr-1
+
+  # MiMo (Xiaomi/小米) ASR — OpenAI-compatible HTTP POST + SSE streaming
+  mimo:
+    url: "https://api.xiaomimimo.com/v1/chat/completions"
+    api_key: ""          # 从 https://platform.xiaomimimo.com 获取
+    model: "mimo-v2.5-asr"
+    language: "auto"     # auto | zh-CN | en-US | ja-JP 等
 
   # Apple Speech local ASR (macOS 26+, zero-config, no model download)
   apple-speech:

--- a/koe-core/src/lib.rs
+++ b/koe-core/src/lib.rs
@@ -28,7 +28,7 @@ use crate::session::{Session, SessionState};
 use koe_asr::{AppleSpeechConfig, AppleSpeechProvider};
 use koe_asr::{
     AsrConfig, AsrEvent, AsrProvider, DoubaoImeProvider, DoubaoWsProvider, GlmAsrProvider,
-    QwenAsrProvider, TranscriptAggregator,
+    MimoAsrProvider, QwenAsrProvider, TranscriptAggregator,
 };
 #[cfg(feature = "mlx")]
 use koe_asr::{MlxConfig, MlxProvider};
@@ -436,6 +436,34 @@ pub extern "C" fn sp_core_session_begin(context: SPSessionContext) -> i32 {
                 context_messages: Vec::new(),
             };
             (config, Box::new(GlmAsrProvider::new()))
+        }
+        "mimo" => {
+            let mimo = &cfg.asr.mimo;
+            let config = AsrConfig {
+                url: mimo.url.clone(),
+                app_key: mimo.model.clone(),
+                access_key: String::new(),
+                api_key: mimo.api_key.clone(),
+                resource_id: String::new(),
+                sample_rate_hz: 16000,
+                connect_timeout_ms: mimo.connect_timeout_ms,
+                final_wait_timeout_ms: mimo.final_wait_timeout_ms,
+                enable_ddc: false,
+                enable_itn: false,
+                enable_punc: false,
+                enable_nonstream: false,
+                hotwords: Vec::new(),
+                language: Some(mimo.language.clone()),
+                custom_headers: std::collections::HashMap::new(),
+                end_window_size: None,
+                force_to_speech_time: None,
+                vad_segment_duration: None,
+                output_zh_variant: None,
+                enable_accelerate_text: false,
+                accelerate_score: None,
+                context_messages: Vec::new(),
+            };
+            (config, Box::new(MimoAsrProvider::new()))
         }
         #[cfg(feature = "mlx")]
         "mlx" => {


### PR DESCRIPTION
## Summary

- Add MiMo-V2.5-ASR provider support for Xiaomi's speech recognition API
- Uses OpenAI-compatible chat completions endpoint with base64 audio input and SSE streaming
- Follows the same architecture as the existing GLM provider (buffer audio → POST on finish → parse SSE stream)

## Changes

**New file:**
- `koe-asr/src/mimo.rs` — MiMo ASR provider implementation with 19 unit tests (WAV wrapping, request body construction, response parsing, SSE line parsing, provider lifecycle)

**Modified files:**
- `koe-asr/src/lib.rs` — register `mimo` module and re-export `MimoAsrProvider`
- `koe-core/src/config.rs` — add `MimoAsrConfig` struct with `url`, `api_key`, `model`, `language` fields, defaults, and YAML config entry
- `koe-core/src/lib.rs` — add match arm for `"mimo"` provider selection
- `KoeApp/.../SPSetupWizardWindowController.m` — add MiMo to setup wizard (popup item, API key field with secure/plain toggle, show/hide logic, config save/load, test connection method, pane height)

## How it works

1. Audio PCM is buffered during `send_audio()`
2. On `finish_input()`, PCM is wrapped in WAV, base64-encoded, and sent as `data:audio/wav;base64,...` in a chat completions request
3. SSE streaming response is parsed for `choices[0].delta.content` (streaming) or `choices[0].message.content` (non-streaming)
4. Authentication via `api-key` header

## Config example

```yaml
asr:
  provider: "mimo"
  mimo:
    api_key: "your-key"
    model: "mimo-v2.5-asr"
    language: "auto"
```

## Test plan

- [x] 82/82 Rust tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` — no new warnings
- [ ] Manual test: configure MiMo provider in setup wizard
- [ ] Manual test: record audio and verify transcription
- [ ] Manual test: test connection button with valid/invalid API key